### PR TITLE
Add mDNS device discovery and synced-device E2E helpers

### DIFF
--- a/.agents/skills/fini-dev/SKILL.md
+++ b/.agents/skills/fini-dev/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: fini-dev
+description: "Always use this at the start of development work in the Fini repo. Orchestrates which repo-local or gstack skill to load, which Makefile command to prefer, what context to read, and what evidence is required before claiming implementation, debugging, QA, Android, design-to-code, release, or documentation work is complete."
+---
+
+# Fini Development Orchestrator
+
+Use this skill as the first step for development work in this repository. It is a routing and evidence checklist, not a replacement for specialized skills.
+
+## Outcome
+
+Keep every development session consistent:
+
+- Pick the right specialized skill before doing domain work.
+- Use the repo's documented context path instead of guessing.
+- Prefer Makefile targets over raw commands.
+- Make the smallest correct change.
+- Verify with concrete evidence before reporting success.
+
+## Start Of Work
+
+Before implementation, debugging, QA, Android, design-to-code, release, or documentation changes:
+
+1. State the target outcome, in-scope work, out-of-scope work, and success checks in the user's terms.
+2. Read only the context needed for the task: `AGENTS.md`, the relevant folder `README.md`, companion `.md` specs, and targeted source files.
+3. If the task needs product, business, terminology, strategic, or historical context, follow the wiki retrieval protocol in `AGENTS.md`.
+4. Choose any specialized skill from the routing table below before doing the domain-specific work.
+5. Pick the smallest useful verification command before editing so the success standard is clear.
+
+If the user explicitly asks to think, plan, brainstorm, or review without implementation, do that mode first and do not edit files until execution is requested.
+
+## Skill Routing
+
+Load the specialized skill when its condition applies:
+
+| Condition | Skill |
+|---|---|
+| Create, update, list, or manage quests/spaces through the Fini CLI | `fini` |
+| Validate Android behavior, prove Android navigation/state, or debug Android-only behavior | `android-testing` |
+| Design or refine native Figma components, variants, screens, or visual systems | `ui-ux-design` |
+| Save plans, decisions, research, or conversation context to wiki raw material | `save-to-wiki` |
+| Debug errors, regressions, stack traces, crashes, or unexpected behavior | `investigate` |
+| QA a web/app flow and fix bugs found | `qa` |
+| QA report only, without fixes | `qa-only` |
+| Browser dogfooding, screenshots, forms, responsive checks, or live site interaction | `browse` or `gstack` |
+| Frontend UI construction or visual polish in code | `frontend-design`, then preserve existing Fini patterns |
+| Code review or pre-landing diff review | `review` |
+| Ship, push, create PR, or prepare code for landing | `ship` |
+| Merge, deploy, or production verification | `land-and-deploy` or `canary` |
+| Performance, page speed, bundle size, or regression checks | `benchmark` |
+| Security audit, threat model, OWASP, secrets, or supply-chain concerns | `cso` |
+| Create or improve skills | `skill-creator` |
+| Create, start, or draft tickets | `create-ticket`, `start-ticket`, or `ticket-markdown` |
+
+When no specialized skill fits, continue with this skill's project workflow.
+
+## Project Context Rules
+
+Use the repo structure as the default map:
+
+- Frontend: `src/`, Vue 3, TypeScript, Vite, Tailwind CSS, DaisyUI, Pinia.
+- Backend: `src-tauri/`, Rust, Tauri 2, Diesel, SQLite.
+- Domain specs and companion specs: `spec/`, folder `README.md` files, and sidecar `.md` files next to source files.
+
+Before changing a significant source file, read its companion `.md` spec when present. Write code to match the spec, or update docs/specs deliberately when the behavior changes.
+
+For product semantics, read wiki context using this order:
+
+1. `~/projects/fini-wiki/_hot.md`
+2. `~/projects/fini-wiki/_index.md` if needed
+3. One or two targeted wiki pages
+4. Targeted search only if the right page is not obvious
+
+Stay within the five-page wiki limit unless the user asks for deeper research.
+
+## Command Selection
+
+Prefer these Makefile targets over raw `npm`, `tauri`, or container commands:
+
+| Need | Command |
+|---|---|
+| Desktop dev app | `make dev` |
+| Release desktop build | `make build` |
+| Run debug MCP server | `make mcp` |
+| Visible local two-app E2E | `make e2e` or `make e2e-headed` |
+| Containerized CI-style E2E | `make e2e-ci` |
+| Build/update E2E images | `make e2e-image` or `make e2e-actors-image` |
+| Full containerized actor E2E | `make e2e-actors` |
+| Runtime container image | `make runtime-image` |
+| Runtime CLI smoke | `make runtime-smoke` |
+| Android device list | `make android-devices` |
+| Android Wi-Fi connect | `make android-connect` |
+| Android hot reload | `make android-dev` |
+| Android build | `make android-build` |
+| Android debug deploy | `make android-debug-deploy` |
+| Android local release deploy | `make android-release-deploy-local` |
+| Signed release tag | `make release-tag VERSION=x.y.z` |
+
+Use package scripts directly only when no Makefile target exists or when a narrower check is clearly better, such as `npm run build` for frontend type/build validation.
+
+Do not invent generic targets such as `make test`, `make lint`, or `make check` unless they exist in the current `Makefile`. If a desired target is missing, name the closest existing target from the table or state that no Makefile target exists for that check.
+
+## Development Loop
+
+Use this loop for implementation and fixes:
+
+1. Establish evidence for the current behavior: code path, spec, failing output, test result, log, or reproducible step.
+2. Trace write path, persisted data, and read path when data behavior is involved.
+3. Make the smallest scoped change that addresses the root cause or requested behavior.
+4. Avoid broad refactors, compatibility layers, or new abstractions unless they prevent a concrete defect.
+5. Preserve user or other-agent changes in the worktree.
+6. Update companion docs/specs when behavior or structure changes.
+7. Verify with the smallest useful check, then escalate only as needed.
+8. Report the exact evidence collected and any remaining risk.
+
+## Verification Defaults
+
+Choose verification based on touched area:
+
+- Frontend-only logic or UI: run the narrowest available unit/type/build check; use browser/QA skill when visual behavior matters.
+- Backend Rust or Tauri command changes: run the narrowest Rust or app build check available; include command output evidence.
+- Cross-process, sync, or persistence changes: verify write path, storage/outbox/database effects, and read path.
+- E2E-sensitive flows: use `make e2e-headed` for local visible debugging or `make e2e-ci` for CI parity.
+- Android behavior: load `android-testing`; use `make android-devices`, `make android-connect`, and `make android-dev` for dev-runtime verification, or `make android-debug-deploy` when an installed APK check is needed.
+- Runtime/container behavior: use `make runtime-smoke` or the relevant image target.
+- Release work: follow release tag rules in `AGENTS.md`; do not create or push tags unless explicitly requested.
+
+If a command cannot be run, say why, what evidence is missing, and the exact command the user can run.
+
+## Reporting Pattern
+
+Final responses for development work should include:
+
+- What changed, with file references.
+- Verification evidence, with commands and outcomes.
+- Any limits, skipped checks, or residual risks.
+
+Keep this concise. Lead with evidence when the user explicitly asks for proof.

--- a/.agents/skills/save-to-wiki/SKILL.md
+++ b/.agents/skills/save-to-wiki/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: save-to-wiki
+description: "Use this when the user asks to save discussed information, plans, decisions, research, summaries, or context to the project wiki raw folder for future ingestion. Trigger on phrases like 'save this to wiki', 'write this plan to raw', 'save this discussion for later ingestion', 'put this in the wiki raw folder', or when the user wants durable wiki source material without immediate ingestion."
+---
+
+# Save To Wiki Raw
+
+Save the current discussion, plan, decision, research summary, or other user-approved context as a new raw source document in the sibling project wiki.
+
+This skill is for durable capture only. It creates raw source material for future postponed ingestion; it does not synthesize wiki pages under `pages/`.
+
+## Target Location
+
+Resolve the wiki path from the current repository name:
+
+```text
+current repo: <repo-name>
+wiki root: ../<repo-name>-wiki/
+raw folder: ../<repo-name>-wiki/raw/
+```
+
+Examples:
+
+```text
+repo: fini
+wiki raw: ../fini-wiki/raw/
+```
+
+If the sibling wiki or `raw/` folder does not exist, stop and report the expected path. Do not create a new wiki structure unless the user explicitly asks.
+
+## Preflight
+
+Before writing:
+
+1. Identify the current workspace basename as the repo name.
+2. Resolve `../<repo-name>-wiki/AGENTS.md` and read it if present.
+3. Resolve `../<repo-name>-wiki/raw/`.
+4. Choose a dated, kebab-case filename.
+5. Check that the filename does not already exist.
+6. If it exists, append `-2`, `-3`, etc.
+
+## Filename Convention
+
+Use:
+
+```text
+YYYY-MM-DD-<short-kebab-title>.md
+```
+
+Good examples:
+
+```text
+2026-04-26-mdns-sd-device-discovery-architecture.md
+2026-04-26-reusable-synced-devices-e2e-precondition.md
+2026-04-26-release-dry-run-notes.md
+```
+
+Prefer a concise descriptive title over a generic one like `notes.md`.
+
+## Raw Document Structure
+
+Use this structure by default, trimming sections that clearly do not apply:
+
+```markdown
+# <Title>
+
+Date: YYYY-MM-DD
+
+## Context
+
+Why this was discussed or captured.
+
+## Summary
+
+The short version.
+
+## Decisions
+
+Locked decisions or agreed direction.
+
+## Plan
+
+Implementation or follow-up plan, if any.
+
+## Evidence
+
+Concrete evidence, commands, links, outputs, code references, or sources that support the claims.
+
+## Open Questions
+
+Unresolved decisions, risks, or follow-ups.
+```
+
+For transcript-like saves, preserve the user's intent and important corrections. Do not invent decisions that were not made.
+
+## Rules
+
+- Create a new file under `raw/` only.
+- Treat existing `raw/` files as immutable; do not edit them.
+- Do not update `_hot.md`, `_index.md`, `log.md`, or `pages/**` unless the user explicitly asks for ingestion.
+- Preserve exact commands, paths, issue numbers, and decision wording when they matter.
+- Mark uncertainty explicitly in `Open Questions` instead of asserting guesses.
+- Keep secrets and credentials out of the raw doc.
+- If the discussion references sensitive local files such as `.env`, summarize without copying sensitive content.
+
+## Reporting
+
+After writing, report:
+
+- created path
+- one-line summary
+- whether ingestion was intentionally deferred
+
+Example:
+
+```text
+Saved to `../fini-wiki/raw/2026-04-26-mdns-sd-device-discovery-architecture.md`.
+Summary: locks mdns-sd as the discovery provider and WebSocket as the pairing/sync path.
+Ingestion deferred; no wiki pages were updated.
+```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,12 +59,37 @@ jobs:
   e2e-ci:
     name: E2E Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     env:
       CONTAINER: docker
       FINI_E2E_CI_RUN_ID: ci-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+
+      - name: Resolve E2E image cache settings
+        shell: bash
+        env:
+          CAN_PUSH_CACHE: "${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}"
+        run: |
+          set -euo pipefail
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          echo "FINI_E2E_CACHE_IMAGE_PREFIX=ghcr.io/${owner}/fini" >> "$GITHUB_ENV"
+          if [ "$CAN_PUSH_CACHE" = "true" ]; then
+            echo "FINI_E2E_CACHE_PUSH=1" >> "$GITHUB_ENV"
+          else
+            echo "FINI_E2E_CACHE_PUSH=0" >> "$GITHUB_ENV"
+          fi
+
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - name: Build E2E actor image
         run: make pr-gate-e2e-build-actor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,35 @@ jobs:
   e2e-ci:
     name: E2E Tests
     runs-on: ubuntu-latest
+    env:
+      CONTAINER: docker
+      FINI_E2E_CI_RUN_ID: ci-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Run E2E tests
-        run: CONTAINER=docker make pr-gate-e2e
+      - name: Build E2E actor image
+        run: make pr-gate-e2e-build-actor
+
+      - name: Build E2E runner image
+        run: make pr-gate-e2e-build-runner
+
+      - name: Create E2E network
+        run: make pr-gate-e2e-network
+
+      - name: Start E2E actors
+        run: make pr-gate-e2e-start-actors
+
+      - name: Wait for E2E actors
+        run: make pr-gate-e2e-wait-actors
+
+      - name: Run Playwright E2E suite
+        run: make pr-gate-e2e-run
+
+      - name: Print actor logs on failure
+        if: failure()
+        run: make pr-gate-e2e-logs
+
+      - name: Cleanup E2E containers
+        if: always()
+        run: make pr-gate-e2e-cleanup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           args: --file=package.json --severity-threshold=high
 
   fe-unit-tests:
-    name: fe unit tests
+    name: FE Unit Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -47,7 +47,7 @@ jobs:
         run: CONTAINER=docker make pr-gate-fe-unit
 
   be-unit-tests:
-    name: be unit tests
+    name: BE Unit Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -57,7 +57,7 @@ jobs:
         run: CONTAINER=docker make pr-gate-be-unit
 
   e2e-ci:
-    name: npm run test:e2e:ci
+    name: E2E Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: PR Gate
+name: CI
 
 on:
   pull_request:
@@ -10,10 +10,32 @@ permissions:
   contents: read
 
 concurrency:
-  group: pr-gate-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  snyk:
+    name: Snyk Vulnerability Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Snyk checks
+        uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --file=package.json --severity-threshold=high
+
   fe-unit-tests:
     name: fe unit tests
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,0 +1,45 @@
+name: PR Gate
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-gate-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fe-unit-tests:
+    name: fe unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Run frontend unit tests
+        run: CONTAINER=docker make pr-gate-fe-unit
+
+  be-unit-tests:
+    name: be unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Run backend unit tests
+        run: CONTAINER=docker make pr-gate-be-unit
+
+  e2e-ci:
+    name: npm run test:e2e:ci
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Run E2E tests
+        run: CONTAINER=docker make pr-gate-e2e

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
   id-token: write
 
 concurrency:
@@ -103,6 +104,26 @@ jobs:
             src-tauri -> target
           shared-key: release-rust
 
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Resolve E2E image cache settings
+        shell: bash
+        run: |
+          set -euo pipefail
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          echo "FINI_E2E_CACHE_IMAGE_PREFIX=ghcr.io/${owner}/fini" >> "$GITHUB_ENV"
+          echo "FINI_E2E_CACHE_PUSH=1" >> "$GITHUB_ENV"
+          echo "CONTAINER=docker" >> "$GITHUB_ENV"
+          echo "FINI_E2E_CI_RUN_ID=release-prep-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_ENV"
+
       - name: Install npm dependencies
         run: npm ci
 
@@ -116,16 +137,43 @@ jobs:
         run: npm run build
 
       - name: Build runtime container
-        run: docker build --target runtime -t fini-runtime-ci .
+        run: |
+          docker buildx build \
+            --target runtime \
+            --load \
+            --cache-from type=gha,scope=fini-runtime \
+            --cache-to type=gha,mode=max,scope=fini-runtime \
+            -t fini-runtime-ci \
+            .
 
       - name: Run runtime smoke check
         run: docker run --rm fini-runtime-ci --help
 
-      - name: Build desktop e2e container
-        run: docker build --target test -t fini-e2e-ci .
+      - name: Build E2E actor image
+        run: make pr-gate-e2e-build-actor
+
+      - name: Build E2E runner image
+        run: make pr-gate-e2e-build-runner
+
+      - name: Create E2E network
+        run: make pr-gate-e2e-network
+
+      - name: Start E2E actors
+        run: make pr-gate-e2e-start-actors
+
+      - name: Wait for E2E actors
+        run: make pr-gate-e2e-wait-actors
 
       - name: Run desktop e2e flow
-        run: docker run --rm fini-e2e-ci
+        run: make pr-gate-e2e-run
+
+      - name: Print actor logs on failure
+        if: failure()
+        run: make pr-gate-e2e-logs
+
+      - name: Cleanup E2E containers
+        if: always()
+        run: make pr-gate-e2e-cleanup
 
   build-linux:
     name: Build Linux Artifact (${{ matrix.arch }})

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   actions: read
+  packages: write
   id-token: write
 
 concurrency:
@@ -193,6 +194,26 @@ jobs:
             src-tauri -> target
           shared-key: release-rust
 
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Resolve E2E image cache settings
+        shell: bash
+        run: |
+          set -euo pipefail
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          echo "FINI_E2E_CACHE_IMAGE_PREFIX=ghcr.io/${owner}/fini" >> "$GITHUB_ENV"
+          echo "FINI_E2E_CACHE_PUSH=1" >> "$GITHUB_ENV"
+          echo "CONTAINER=docker" >> "$GITHUB_ENV"
+          echo "FINI_E2E_CI_RUN_ID=release-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_ENV"
+
       - name: Install npm dependencies
         run: npm ci
 
@@ -206,16 +227,43 @@ jobs:
         run: npm run build
 
       - name: Build runtime container
-        run: docker build --target runtime -t fini-runtime-ci .
+        run: |
+          docker buildx build \
+            --target runtime \
+            --load \
+            --cache-from type=gha,scope=fini-runtime \
+            --cache-to type=gha,mode=max,scope=fini-runtime \
+            -t fini-runtime-ci \
+            .
 
       - name: Run runtime smoke check
         run: docker run --rm fini-runtime-ci --help
 
-      - name: Build desktop e2e container
-        run: docker build --target test -t fini-e2e-ci .
+      - name: Build E2E actor image
+        run: make pr-gate-e2e-build-actor
+
+      - name: Build E2E runner image
+        run: make pr-gate-e2e-build-runner
+
+      - name: Create E2E network
+        run: make pr-gate-e2e-network
+
+      - name: Start E2E actors
+        run: make pr-gate-e2e-start-actors
+
+      - name: Wait for E2E actors
+        run: make pr-gate-e2e-wait-actors
 
       - name: Run desktop e2e flow
-        run: docker run --rm fini-e2e-ci
+        run: make pr-gate-e2e-run
+
+      - name: Print actor logs on failure
+        if: failure()
+        run: make pr-gate-e2e-logs
+
+      - name: Cleanup E2E containers
+        if: always()
+        run: make pr-gate-e2e-cleanup
 
   build-linux:
     name: Build Linux Artifact (${{ matrix.arch }})

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,13 +1,6 @@
 name: Security Check
 
 on:
-  push:
-    branches:
-      - main
-      - master
-      - dev
-      - prod
-  pull_request:
   workflow_call:
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,9 @@ When working inside that directory, load its `AGENTS.md` as the authoritative sc
 
 ## Workflow
 
+- Always load the `fini-dev` skill at the start of development work in this repo.
+- Use `fini-dev` to choose which repo-local or gstack skill applies, which Makefile target to run, and what evidence is required before reporting success.
+- `fini-dev` orchestrates workflow only; use the specialized skill for the actual domain work when it applies.
 - Do not commit implementation changes until the user has verified they work.
 - Docs and spec changes can be committed freely.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,13 +54,14 @@ COPY index.html ./
 
 RUN node ./node_modules/@tauri-apps/cli/tauri.js build --debug --features e2e-testing --no-bundle
 
-FROM ubuntu:24.04 AS runtime
+FROM ubuntu:24.04 AS runtime-base
 
 RUN set -eux; \
     apt-get update -o Acquire::Retries=5; \
     apt-get install -y --no-install-recommends --fix-missing \
       ca-certificates \
       libasound2t64 \
+      libayatana-appindicator3-1 \
       libgtk-3-0 \
       libwebkit2gtk-4.1-0 \
       librsvg2-2; \
@@ -68,13 +69,80 @@ RUN set -eux; \
 
 WORKDIR /app
 
-COPY --from=app-build-release /workspace/src-tauri/target/release/fini /usr/local/bin/fini
-
 ENV XDG_DATA_HOME=/data
 
 VOLUME ["/data"]
 
+FROM runtime-base AS runtime
+
+COPY --from=app-build-release /workspace/src-tauri/target/release/fini /usr/local/bin/fini
+
 ENTRYPOINT ["/usr/local/bin/fini"]
+
+FROM runtime-base AS e2e-actor
+
+RUN set -eux; \
+    apt-get update -o Acquire::Retries=5; \
+    apt-get install -y --no-install-recommends --fix-missing \
+      xvfb \
+      xauth; \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=app-build-e2e /workspace/src-tauri/target/debug/fini /usr/local/bin/fini
+COPY specs/e2e/actors/start-actor.sh /usr/local/bin/fini-e2e-actor
+
+ENV FINI_E2E_SOCKET_DIR=/var/run/fini-e2e \
+    FINI_APP_DATA_DIR=/data \
+    TZ=UTC
+
+ENTRYPOINT ["/usr/local/bin/fini-e2e-actor"]
+
+FROM node-deps AS e2e-runner
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libasound2 \
+    libayatana-appindicator3-1 \
+    libglib2.0-0 \
+    libnss3 \
+    libnspr4 \
+    libdbus-1-3 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libx11-6 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxrandr2 \
+    libxkbcommon0 \
+    libpango-1.0-0 \
+    libcairo2 \
+    fonts-liberation \
+    libgtk-3-0 \
+    libwebkit2gtk-4.1-0 \
+    librsvg2-2 \
+    xvfb \
+    xauth \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+COPY --from=node-deps /app/node_modules ./node_modules
+COPY --from=playwright-browsers /root/.cache/ms-playwright /root/.cache/ms-playwright
+COPY --from=app-build-e2e /workspace/src-tauri/target/debug/fini /usr/local/bin/fini
+COPY tsconfig*.json ./
+COPY specs/e2e ./specs/e2e
+
+ENV FINI_E2E_SOCKET_DIR=/var/run/fini-e2e \
+    FINI_E2E_ACTORS=actor-a,actor-b \
+    FINI_BINARY=/usr/local/bin/fini \
+    TZ=UTC \
+    CI=1
+
+CMD ["npx", "playwright", "test", "--config", "specs/e2e/playwright.config.ts"]
 
 # ── E2E test stage ─────────────────────────────────────────────────────────────
 FROM node:24.15.0-trixie-slim AS test

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,16 @@ FROM node-deps AS playwright-browsers
 
 RUN npx playwright install chromium
 
+FROM node-deps AS fe-unit-test
+
+WORKDIR /app
+
+COPY tsconfig*.json ./
+COPY jest.config.cjs ./
+COPY src ./src
+
+RUN npm run test:unit
+
 FROM rust:1.88-bookworm AS rust-builder-base
 
 WORKDIR /workspace
@@ -34,6 +44,10 @@ COPY src-tauri/src ./src-tauri/src
 COPY src-tauri/capabilities ./src-tauri/capabilities
 COPY src-tauri/icons ./src-tauri/icons
 COPY src-tauri/tauri.conf.json ./src-tauri/tauri.conf.json
+
+FROM rust-builder-base AS be-unit-test
+
+RUN cargo test --manifest-path src-tauri/Cargo.toml
 
 FROM rust-builder-base AS app-build-release
 
@@ -139,6 +153,7 @@ COPY specs/e2e ./specs/e2e
 ENV FINI_E2E_SOCKET_DIR=/var/run/fini-e2e \
     FINI_E2E_ACTORS=actor-a,actor-b \
     FINI_BINARY=/usr/local/bin/fini \
+    FINI_E2E_CONTAINER_RUNNER=1 \
     TZ=UTC \
     CI=1
 
@@ -192,6 +207,7 @@ COPY index.html ./
 COPY specs/e2e ./specs/e2e
 
 ENV FINI_BINARY=/usr/local/bin/fini \
+    FINI_E2E_CONTAINER_RUNNER=1 \
     TZ=UTC \
     CI=1
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 -include .env
 export
 
-.PHONY: help dev build mcp e2e e2e-ci e2e-image e2e-build e2e-headed e2e-actors-image e2e-actors runtime-image runtime-smoke release-tag android-connect android-dev android-build android-sign-debug android-sign-release-local android-install-debug android-install-release-local android-launch android-devices android-debug-deploy android-release-deploy-local
+CONTAINER ?= podman
+
+.PHONY: help dev build mcp pr-gate-fe-unit pr-gate-be-unit pr-gate-e2e e2e e2e-ci e2e-image e2e-build e2e-headed e2e-actors-image e2e-actors runtime-image runtime-smoke release-tag android-connect android-dev android-build android-sign-debug android-sign-release-local android-install-debug android-install-release-local android-launch android-devices android-debug-deploy android-release-deploy-local
 
 help:
 	@echo ""
@@ -9,15 +11,18 @@ help:
 	@echo "  make dev              Hot-reload dev app (Vite HMR + Rust watch)"
 	@echo "  make build            Release build"
 	@echo "  make mcp              Run MCP server (debug binary)"
+	@echo "  make pr-gate-fe-unit  Run frontend unit tests in Dockerfile stage"
+	@echo "  make pr-gate-be-unit  Run backend unit tests in Dockerfile stage"
+	@echo "  make pr-gate-e2e      Run npm run test:e2e:ci with Dockerfile stages"
 	@echo "  make e2e              Run visible local two-app E2E"
 	@echo "  make e2e-ci           Run containerized headless E2E in CI mode"
-	@echo "  make e2e-image        Build/update the Podman e2e image"
-	@echo "  make e2e-build        Build Podman image and run e2e-ci inside it"
+	@echo "  make e2e-image        Build/update the container e2e image"
+	@echo "  make e2e-build        Build container image and run e2e-ci inside it"
 	@echo "  make e2e-headed       Run visible local two-app E2E"
 	@echo "  make e2e-actors-image Force rebuild actor and runner images"
 	@echo "  make e2e-actors       Run containerized full E2E suite, reusing fresh images"
 	@echo "  FINI_E2E_REBUILD=1 npm run test:e2e  Force E2E image rebuild before running"
-	@echo "  make runtime-image    Build/update the Podman runtime image"
+	@echo "  make runtime-image    Build/update the runtime container image"
 	@echo "  make runtime-smoke    Run a runtime container smoke check"
 	@echo "  make release-tag VERSION=x.y.z  Create signed annotated release tag vX.Y.Z"
 	@echo ""
@@ -46,6 +51,15 @@ build:
 mcp:
 	./src-tauri/target/debug/fini mcp
 
+pr-gate-fe-unit:
+	$(CONTAINER) build --target fe-unit-test -t fini-fe-unit-test .
+
+pr-gate-be-unit:
+	$(CONTAINER) build --target be-unit-test -t fini-be-unit-test .
+
+pr-gate-e2e:
+	FINI_E2E_ACTOR_IMAGE=fini-e2e-actor-ci FINI_E2E_RUNNER_IMAGE=fini-e2e-runner-ci $(MAKE) e2e-actors
+
 # Run the real-app e2e lane locally.
 e2e:
 	$(MAKE) e2e-headed
@@ -56,12 +70,12 @@ e2e-ci:
 
 # Build/update the container image used for CI-style local e2e runs.
 e2e-image:
-	podman build --target test -t fini-e2e .
+	$(CONTAINER) build --target test -t fini-e2e .
 
 # Run the headless e2e tier inside the cached Podman image.
 e2e-build:
-	podman image exists fini-e2e || podman build --target test -t fini-e2e .
-	podman run --rm fini-e2e
+	$(CONTAINER) image inspect fini-e2e >/dev/null 2>&1 || $(CONTAINER) build --target test -t fini-e2e .
+	$(CONTAINER) run --rm fini-e2e
 
 # Run the visible local two-app E2E suite against the host desktop display.
 e2e-headed:
@@ -178,8 +192,8 @@ e2e-actors-image:
 	  } | sort -zu; \
 	}; \
 	cache_key="$$(cache_inputs | xargs -0 sha256sum | sha256sum | cut -d ' ' -f 1)"; \
-	podman build --target e2e-actor --label "fini.e2e.cache-key=$$cache_key" -t fini-e2e-actor .; \
-	podman build --target e2e-runner --label "fini.e2e.cache-key=$$cache_key" -t fini-e2e-runner .
+	$(CONTAINER) build --target e2e-actor --label "fini.e2e.cache-key=$$cache_key" -t fini-e2e-actor .; \
+	$(CONTAINER) build --target e2e-runner --label "fini.e2e.cache-key=$$cache_key" -t fini-e2e-runner .
 
 # Run the multi-actor desktop e2e smoke lane.
 e2e-actors:
@@ -236,7 +250,7 @@ e2e-actors:
 	  } | sort -zu; \
 	}; \
 	image_cache_key() { \
-	  podman image inspect "$$1" --format '{{ index .Config.Labels "fini.e2e.cache-key" }}' 2>/dev/null || true; \
+	  $(CONTAINER) image inspect "$$1" --format '{{ index .Config.Labels "fini.e2e.cache-key" }}' 2>/dev/null || true; \
 	}; \
 	cache_key="$$(cache_inputs | xargs -0 sha256sum | sha256sum | cut -d ' ' -f 1)"; \
 	actor_current_key="$$(image_cache_key "$$actor_image")"; \
@@ -251,35 +265,35 @@ e2e-actors:
 	cleanup() { \
 	  status="$$?"; \
 	  if [ "$$status" -ne 0 ]; then \
-	    for actor in "$$@"; do podman logs "fini-$$run_id-$$actor" 2>/dev/null || true; done; \
+	    for actor in "$$@"; do $(CONTAINER) logs "fini-$$run_id-$$actor" 2>/dev/null || true; done; \
 	  fi; \
 	  if [ "$$keep" = "1" ]; then \
 	    printf 'Keeping containers and network for debugging: %s\n' "$$run_id"; \
 	    exit "$$status"; \
 	  fi; \
-	  podman rm -f "fini-$$run_id-runner" >/dev/null 2>&1 || true; \
-	  for actor in "$$@"; do podman rm -f "fini-$$run_id-$$actor" >/dev/null 2>&1 || true; done; \
-	  podman network rm "$$network_name" >/dev/null 2>&1 || true; \
+	  $(CONTAINER) rm -f "fini-$$run_id-runner" >/dev/null 2>&1 || true; \
+	  for actor in "$$@"; do $(CONTAINER) rm -f "fini-$$run_id-$$actor" >/dev/null 2>&1 || true; done; \
+	  $(CONTAINER) network rm "$$network_name" >/dev/null 2>&1 || true; \
 	  exit "$$status"; \
 	}; \
 	trap 'cleanup "$$@"' EXIT INT TERM; \
 	if [ "$$force_rebuild" = "1" ] || [ "$$actor_current_key" != "$$cache_key" ]; then \
 	  printf 'Building actor image: %s\n' "$$actor_image"; \
-	  podman build --target e2e-actor --label "fini.e2e.cache-key=$$cache_key" -t "$$actor_image" .; \
+	  $(CONTAINER) build --target e2e-actor --label "fini.e2e.cache-key=$$cache_key" -t "$$actor_image" .; \
 	else \
 	  printf 'Using cached actor image: %s\n' "$$actor_image"; \
 	fi; \
 	if [ "$$force_rebuild" = "1" ] || [ "$$runner_current_key" != "$$cache_key" ]; then \
 	  printf 'Building runner image: %s\n' "$$runner_image"; \
-	  podman build --target e2e-runner --label "fini.e2e.cache-key=$$cache_key" -t "$$runner_image" .; \
+	  $(CONTAINER) build --target e2e-runner --label "fini.e2e.cache-key=$$cache_key" -t "$$runner_image" .; \
 	else \
 	  printf 'Using cached runner image: %s\n' "$$runner_image"; \
 	fi; \
-	podman network create "$$network_name" >/dev/null; \
+	$(CONTAINER) network create "$$network_name" >/dev/null; \
 	for actor in "$$@"; do \
 	  actor_data_dir="$$run_dir/$$actor-data"; \
 	  mkdir -p "$$actor_data_dir"; \
-	  podman run -d --rm \
+	  $(CONTAINER) run -d --rm \
 	    --name "fini-$$run_id-$$actor" \
 	    --hostname "$$actor" \
 	    --network "$$network_name" \
@@ -301,7 +315,7 @@ e2e-actors:
 	    sleep 1; \
 	  done; \
 	done; \
-	podman run --rm \
+	$(CONTAINER) run --rm \
 	  --name "fini-$$run_id-runner" \
 	  --network "$$network_name" \
 	  -e FINI_E2E_ACTORS="$$actor_list" \
@@ -312,12 +326,12 @@ e2e-actors:
 
 # Build/update the published headless runtime image locally.
 runtime-image:
-	podman build --target runtime -t fini-runtime .
+	$(CONTAINER) build --target runtime -t fini-runtime .
 
 # Verify the runtime container executes the CLI surface.
 runtime-smoke:
-	podman image exists fini-runtime || podman build --target runtime -t fini-runtime .
-	podman run --rm fini-runtime --help
+	$(CONTAINER) image inspect fini-runtime >/dev/null 2>&1 || $(CONTAINER) build --target runtime -t fini-runtime .
+	$(CONTAINER) run --rm fini-runtime --help
 
 release-tag:
 	@test -n "$(VERSION)" || (echo "VERSION is required. Use: make release-tag VERSION=x.y.z" && exit 1)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 -include .env
 export
 
-.PHONY: help dev build mcp e2e e2e-ci e2e-image e2e-build runtime-image runtime-smoke release-tag android-connect android-dev android-build android-sign-debug android-sign-release-local android-install-debug android-install-release-local android-launch android-devices android-debug-deploy android-release-deploy-local
+.PHONY: help dev build mcp e2e e2e-ci e2e-image e2e-build e2e-headed e2e-actors-image e2e-actors runtime-image runtime-smoke release-tag android-connect android-dev android-build android-sign-debug android-sign-release-local android-install-debug android-install-release-local android-launch android-devices android-debug-deploy android-release-deploy-local
 
 help:
 	@echo ""
@@ -9,10 +9,14 @@ help:
 	@echo "  make dev              Hot-reload dev app (Vite HMR + Rust watch)"
 	@echo "  make build            Release build"
 	@echo "  make mcp              Run MCP server (debug binary)"
-	@echo "  make e2e              Run real-app e2e tests locally"
-	@echo "  make e2e-ci           Run real-app e2e tests in CI mode"
+	@echo "  make e2e              Run visible local two-app E2E"
+	@echo "  make e2e-ci           Run containerized headless E2E in CI mode"
 	@echo "  make e2e-image        Build/update the Podman e2e image"
 	@echo "  make e2e-build        Build Podman image and run e2e-ci inside it"
+	@echo "  make e2e-headed       Run visible local two-app E2E"
+	@echo "  make e2e-actors-image Force rebuild actor and runner images"
+	@echo "  make e2e-actors       Run containerized full E2E suite, reusing fresh images"
+	@echo "  FINI_E2E_REBUILD=1 npm run test:e2e  Force E2E image rebuild before running"
 	@echo "  make runtime-image    Build/update the Podman runtime image"
 	@echo "  make runtime-smoke    Run a runtime container smoke check"
 	@echo "  make release-tag VERSION=x.y.z  Create signed annotated release tag vX.Y.Z"
@@ -44,11 +48,11 @@ mcp:
 
 # Run the real-app e2e lane locally.
 e2e:
-	npm run test:e2e
+	$(MAKE) e2e-headed
 
 # Run the same lane under CI settings.
 e2e-ci:
-	npm run test:e2e:ci
+	CI=1 $(MAKE) e2e-actors
 
 # Build/update the container image used for CI-style local e2e runs.
 e2e-image:
@@ -58,6 +62,253 @@ e2e-image:
 e2e-build:
 	podman image exists fini-e2e || podman build --target test -t fini-e2e .
 	podman run --rm fini-e2e
+
+# Run the visible local two-app E2E suite against the host desktop display.
+e2e-headed:
+	@set -eu; \
+	actor_list="$${FINI_E2E_ACTORS:-actor-a,actor-b}"; \
+	keep="$${FINI_E2E_KEEP:-0}"; \
+	run_root="$${FINI_E2E_ROOT:-/var/tmp/fini-e2e-headed}"; \
+	run_id="$$(date +%Y%m%d-%H%M%S)-$$$$"; \
+	run_dir="$$run_root/$$run_id"; \
+	socket_dir="$$run_dir/sockets"; \
+	test_results_dir="$$run_dir/test-results"; \
+	bin_path="./src-tauri/target/debug/fini"; \
+	printf 'FINI_E2E_RUN_DIR=%s\n' "$$run_dir"; \
+	mkdir -p "$$socket_dir" "$$test_results_dir"; \
+	IFS=','; set -- $$actor_list; \
+	if [ "$$#" -lt 2 ]; then \
+	  printf 'Need at least two actors, got: %s\n' "$$actor_list" >&2; \
+	  exit 1; \
+	fi; \
+	peer_ports=""; \
+	idx=0; \
+	for actor in "$$@"; do \
+	  port=$$((45454 + idx * 2)); \
+	  if [ -z "$$peer_ports" ]; then peer_ports="$$port"; else peer_ports="$$peer_ports,$$port"; fi; \
+	  idx=$$((idx + 1)); \
+	done; \
+	cleanup() { \
+	  status="$$?"; \
+	  if [ "$$keep" = "1" ]; then \
+	    printf 'Keeping local app processes for debugging: %s\n' "$$run_id"; \
+	    printf 'Stop them manually if needed. Run dir: %s\n' "$$run_dir"; \
+	    exit "$$status"; \
+	  fi; \
+	  for pid_file in "$$run_dir"/*.pid; do \
+	    [ -f "$$pid_file" ] || continue; \
+	    pid="$$(cat "$$pid_file")"; \
+	    kill "$$pid" >/dev/null 2>&1 || true; \
+	  done; \
+	  wait >/dev/null 2>&1 || true; \
+	  exit "$$status"; \
+	}; \
+	trap cleanup EXIT INT TERM; \
+	node ./node_modules/@tauri-apps/cli/tauri.js build --debug --features e2e-testing --no-bundle; \
+	idx=0; \
+	for actor in "$$@"; do \
+	  actor_data_dir="$$run_dir/$$actor-data"; \
+	  actor_socket="$$socket_dir/$$actor.sock"; \
+	  actor_log="$$run_dir/$$actor.log"; \
+	  discovery_port=$$((45454 + idx * 2)); \
+	  ws_port=$$((45455 + idx * 2)); \
+	  mkdir -p "$$actor_data_dir"; \
+	  rm -f "$$actor_socket"; \
+	  printf 'Launching visible app window: %s (discovery=%s ws=%s)\n' "$$actor" "$$discovery_port" "$$ws_port"; \
+	  HOSTNAME="$$actor" FINI_APP_DATA_DIR="$$actor_data_dir" TAURI_PLAYWRIGHT_SOCKET="$$actor_socket" FINI_DISCOVERY_PORT="$$discovery_port" FINI_DISCOVERY_PEER_PORTS="$$peer_ports" FINI_SPACE_SYNC_WS_PORT="$$ws_port" TZ=UTC "$$bin_path" app >"$$actor_log" 2>&1 & \
+	  printf '%s' "$$!" > "$$run_dir/$$actor.pid"; \
+	  idx=$$((idx + 1)); \
+	done; \
+	for actor in "$$@"; do \
+	  socket_path="$$socket_dir/$$actor.sock"; \
+	  deadline=$$(($$(date +%s) + 60)); \
+	  while [ ! -S "$$socket_path" ]; do \
+	    if [ "$$(date +%s)" -ge "$$deadline" ]; then \
+	      printf 'Actor socket did not appear: %s\n' "$$socket_path" >&2; \
+	      log_path="$$run_dir/$$actor.log"; \
+	      [ -f "$$log_path" ] && printf 'Actor log: %s\n' "$$log_path" >&2; \
+	      exit 1; \
+	    fi; \
+	    sleep 1; \
+	  done; \
+	done; \
+	FINI_E2E_ACTORS="$$actor_list" FINI_E2E_SOCKET_DIR="$$socket_dir" FINI_E2E_HEADFUL=1 TZ=UTC npx playwright test --config specs/e2e/playwright.config.ts --project actors --output "$$test_results_dir"
+
+# Build/update the actor and runner images for multi-actor desktop e2e.
+e2e-actors-image:
+	@set -eu; \
+	cache_inputs() { \
+	  { \
+	    git ls-files -z -- \
+	      Dockerfile \
+	      package.json \
+	      package-lock.json \
+	      tsconfig\*.json \
+	      index.html \
+	      vite.config.ts \
+	      src \
+	      src-tauri/Cargo.toml \
+	      src-tauri/Cargo.lock \
+	      src-tauri/build.rs \
+	      src-tauri/src \
+	      src-tauri/migrations \
+	      src-tauri/patches \
+	      src-tauri/capabilities \
+	      src-tauri/icons \
+	      src-tauri/tauri.conf.json \
+	      specs/e2e; \
+	    git ls-files --others --exclude-standard -z -- \
+	      Dockerfile \
+	      package.json \
+	      package-lock.json \
+	      tsconfig\*.json \
+	      index.html \
+	      vite.config.ts \
+	      src \
+	      src-tauri/Cargo.toml \
+	      src-tauri/Cargo.lock \
+	      src-tauri/build.rs \
+	      src-tauri/src \
+	      src-tauri/migrations \
+	      src-tauri/patches \
+	      src-tauri/capabilities \
+	      src-tauri/icons \
+	      src-tauri/tauri.conf.json \
+	      specs/e2e; \
+	  } | sort -zu; \
+	}; \
+	cache_key="$$(cache_inputs | xargs -0 sha256sum | sha256sum | cut -d ' ' -f 1)"; \
+	podman build --target e2e-actor --label "fini.e2e.cache-key=$$cache_key" -t fini-e2e-actor .; \
+	podman build --target e2e-runner --label "fini.e2e.cache-key=$$cache_key" -t fini-e2e-runner .
+
+# Run the multi-actor desktop e2e smoke lane.
+e2e-actors:
+	@set -eu; \
+	actor_image="$${FINI_E2E_ACTOR_IMAGE:-fini-e2e-actor}"; \
+	runner_image="$${FINI_E2E_RUNNER_IMAGE:-fini-e2e-runner}"; \
+	force_rebuild="$${FINI_E2E_REBUILD:-0}"; \
+	actor_list="$${FINI_E2E_ACTORS:-actor-a,actor-b}"; \
+	keep="$${FINI_E2E_KEEP:-0}"; \
+	run_root="$${FINI_E2E_ROOT:-/var/tmp/fini-e2e-actors}"; \
+	run_id="$$(date +%Y%m%d-%H%M%S)-$$$$"; \
+	run_dir="$$run_root/$$run_id"; \
+	socket_dir="$$run_dir/sockets"; \
+	test_results_dir="$$run_dir/test-results"; \
+	network_name="fini-e2e-$$run_id"; \
+	cache_inputs() { \
+	  { \
+	    git ls-files -z -- \
+	      Dockerfile \
+	      package.json \
+	      package-lock.json \
+	      tsconfig\*.json \
+	      index.html \
+	      vite.config.ts \
+	      src \
+	      src-tauri/Cargo.toml \
+	      src-tauri/Cargo.lock \
+	      src-tauri/build.rs \
+	      src-tauri/src \
+	      src-tauri/migrations \
+	      src-tauri/patches \
+	      src-tauri/capabilities \
+	      src-tauri/icons \
+	      src-tauri/tauri.conf.json \
+	      specs/e2e; \
+	    git ls-files --others --exclude-standard -z -- \
+	      Dockerfile \
+	      package.json \
+	      package-lock.json \
+	      tsconfig\*.json \
+	      index.html \
+	      vite.config.ts \
+	      src \
+	      src-tauri/Cargo.toml \
+	      src-tauri/Cargo.lock \
+	      src-tauri/build.rs \
+	      src-tauri/src \
+	      src-tauri/migrations \
+	      src-tauri/patches \
+	      src-tauri/capabilities \
+	      src-tauri/icons \
+	      src-tauri/tauri.conf.json \
+	      specs/e2e; \
+	  } | sort -zu; \
+	}; \
+	image_cache_key() { \
+	  podman image inspect "$$1" --format '{{ index .Config.Labels "fini.e2e.cache-key" }}' 2>/dev/null || true; \
+	}; \
+	cache_key="$$(cache_inputs | xargs -0 sha256sum | sha256sum | cut -d ' ' -f 1)"; \
+	actor_current_key="$$(image_cache_key "$$actor_image")"; \
+	runner_current_key="$$(image_cache_key "$$runner_image")"; \
+	printf 'FINI_E2E_RUN_DIR=%s\n' "$$run_dir"; \
+	mkdir -p "$$socket_dir" "$$test_results_dir"; \
+	IFS=','; set -- $$actor_list; \
+	if [ "$$#" -lt 2 ]; then \
+	  printf 'Need at least two actors, got: %s\n' "$$actor_list" >&2; \
+	  exit 1; \
+	fi; \
+	cleanup() { \
+	  status="$$?"; \
+	  if [ "$$status" -ne 0 ]; then \
+	    for actor in "$$@"; do podman logs "fini-$$run_id-$$actor" 2>/dev/null || true; done; \
+	  fi; \
+	  if [ "$$keep" = "1" ]; then \
+	    printf 'Keeping containers and network for debugging: %s\n' "$$run_id"; \
+	    exit "$$status"; \
+	  fi; \
+	  podman rm -f "fini-$$run_id-runner" >/dev/null 2>&1 || true; \
+	  for actor in "$$@"; do podman rm -f "fini-$$run_id-$$actor" >/dev/null 2>&1 || true; done; \
+	  podman network rm "$$network_name" >/dev/null 2>&1 || true; \
+	  exit "$$status"; \
+	}; \
+	trap 'cleanup "$$@"' EXIT INT TERM; \
+	if [ "$$force_rebuild" = "1" ] || [ "$$actor_current_key" != "$$cache_key" ]; then \
+	  printf 'Building actor image: %s\n' "$$actor_image"; \
+	  podman build --target e2e-actor --label "fini.e2e.cache-key=$$cache_key" -t "$$actor_image" .; \
+	else \
+	  printf 'Using cached actor image: %s\n' "$$actor_image"; \
+	fi; \
+	if [ "$$force_rebuild" = "1" ] || [ "$$runner_current_key" != "$$cache_key" ]; then \
+	  printf 'Building runner image: %s\n' "$$runner_image"; \
+	  podman build --target e2e-runner --label "fini.e2e.cache-key=$$cache_key" -t "$$runner_image" .; \
+	else \
+	  printf 'Using cached runner image: %s\n' "$$runner_image"; \
+	fi; \
+	podman network create "$$network_name" >/dev/null; \
+	for actor in "$$@"; do \
+	  actor_data_dir="$$run_dir/$$actor-data"; \
+	  mkdir -p "$$actor_data_dir"; \
+	  podman run -d --rm \
+	    --name "fini-$$run_id-$$actor" \
+	    --hostname "$$actor" \
+	    --network "$$network_name" \
+	    -e FINI_ACTOR_SLUG="$$actor" \
+	    -e FINI_E2E_SOCKET_DIR=/var/run/fini-e2e \
+	    -e FINI_APP_DATA_DIR=/data \
+	    -v "$$socket_dir:/var/run/fini-e2e:z" \
+	    -v "$$actor_data_dir:/data:Z" \
+	    "$$actor_image" >/dev/null; \
+	done; \
+	for actor in "$$@"; do \
+	  socket_path="$$socket_dir/$$actor.sock"; \
+	  deadline=$$(($$(date +%s) + 60)); \
+	  while [ ! -S "$$socket_path" ]; do \
+	    if [ "$$(date +%s)" -ge "$$deadline" ]; then \
+	      printf 'Actor socket did not appear: %s\n' "$$socket_path" >&2; \
+	      exit 1; \
+	    fi; \
+	    sleep 1; \
+	  done; \
+	done; \
+	podman run --rm \
+	  --name "fini-$$run_id-runner" \
+	  --network "$$network_name" \
+	  -e FINI_E2E_ACTORS="$$actor_list" \
+	  -e FINI_E2E_SOCKET_DIR=/var/run/fini-e2e \
+	  -v "$$socket_dir:/var/run/fini-e2e:z" \
+	  -v "$$test_results_dir:/app/test-results:Z" \
+	  "$$runner_image"
 
 # Build/update the published headless runtime image locally.
 runtime-image:

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,16 @@
 export
 
 CONTAINER ?= podman
+FINI_E2E_CI_RUN_ID ?= pr-gate
+FINI_E2E_CI_RUN_DIR ?= /var/tmp/fini-e2e-$(FINI_E2E_CI_RUN_ID)
+FINI_E2E_CI_SOCKET_DIR ?= $(FINI_E2E_CI_RUN_DIR)/sockets
+FINI_E2E_CI_RESULTS_DIR ?= $(FINI_E2E_CI_RUN_DIR)/test-results
+FINI_E2E_CI_NETWORK ?= fini-e2e-$(FINI_E2E_CI_RUN_ID)
+FINI_E2E_CI_ACTORS ?= actor-a,actor-b
+FINI_E2E_ACTOR_IMAGE ?= fini-e2e-actor-ci
+FINI_E2E_RUNNER_IMAGE ?= fini-e2e-runner-ci
 
-.PHONY: help dev build mcp pr-gate-fe-unit pr-gate-be-unit pr-gate-e2e e2e e2e-ci e2e-image e2e-build e2e-headed e2e-actors-image e2e-actors runtime-image runtime-smoke release-tag android-connect android-dev android-build android-sign-debug android-sign-release-local android-install-debug android-install-release-local android-launch android-devices android-debug-deploy android-release-deploy-local
+.PHONY: help dev build mcp pr-gate-fe-unit pr-gate-be-unit pr-gate-e2e pr-gate-e2e-build-actor pr-gate-e2e-build-runner pr-gate-e2e-network pr-gate-e2e-start-actors pr-gate-e2e-wait-actors pr-gate-e2e-run pr-gate-e2e-logs pr-gate-e2e-cleanup e2e e2e-ci e2e-image e2e-build e2e-headed e2e-actors-image e2e-actors runtime-image runtime-smoke release-tag android-connect android-dev android-build android-sign-debug android-sign-release-local android-install-debug android-install-release-local android-launch android-devices android-debug-deploy android-release-deploy-local
 
 help:
 	@echo ""
@@ -14,6 +22,7 @@ help:
 	@echo "  make pr-gate-fe-unit  Run frontend unit tests in Dockerfile stage"
 	@echo "  make pr-gate-be-unit  Run backend unit tests in Dockerfile stage"
 	@echo "  make pr-gate-e2e      Run npm run test:e2e:ci with Dockerfile stages"
+	@echo "  make pr-gate-e2e-*    Run one named CI E2E phase for easier failure diagnosis"
 	@echo "  make e2e              Run visible local two-app E2E"
 	@echo "  make e2e-ci           Run containerized headless E2E in CI mode"
 	@echo "  make e2e-image        Build/update the container e2e image"
@@ -58,7 +67,98 @@ pr-gate-be-unit:
 	$(CONTAINER) build --target be-unit-test -t fini-be-unit-test .
 
 pr-gate-e2e:
-	FINI_E2E_ACTOR_IMAGE=fini-e2e-actor-ci FINI_E2E_RUNNER_IMAGE=fini-e2e-runner-ci $(MAKE) e2e-actors
+	@set -eu; \
+	cleanup() { $(MAKE) pr-gate-e2e-cleanup >/dev/null 2>&1 || true; }; \
+	trap cleanup EXIT INT TERM; \
+	$(MAKE) pr-gate-e2e-build-actor; \
+	$(MAKE) pr-gate-e2e-build-runner; \
+	$(MAKE) pr-gate-e2e-network; \
+	$(MAKE) pr-gate-e2e-start-actors; \
+	$(MAKE) pr-gate-e2e-wait-actors; \
+	$(MAKE) pr-gate-e2e-run
+
+pr-gate-e2e-build-actor:
+	$(CONTAINER) build --target e2e-actor -t $(FINI_E2E_ACTOR_IMAGE) .
+
+pr-gate-e2e-build-runner:
+	$(CONTAINER) build --target e2e-runner -t $(FINI_E2E_RUNNER_IMAGE) .
+
+pr-gate-e2e-network:
+	@set -eu; \
+	mkdir -p "$(FINI_E2E_CI_SOCKET_DIR)" "$(FINI_E2E_CI_RESULTS_DIR)"; \
+	$(CONTAINER) network rm "$(FINI_E2E_CI_NETWORK)" >/dev/null 2>&1 || true; \
+	$(CONTAINER) network create "$(FINI_E2E_CI_NETWORK)" >/dev/null
+
+pr-gate-e2e-start-actors:
+	@set -eu; \
+	actor_list="$(FINI_E2E_CI_ACTORS)"; \
+	IFS=','; set -- $$actor_list; \
+	if [ "$$#" -lt 2 ]; then \
+	  printf 'Need at least two actors, got: %s\n' "$(FINI_E2E_CI_ACTORS)" >&2; \
+	  exit 1; \
+	fi; \
+	for actor in "$$@"; do \
+	  actor_data_dir="$(FINI_E2E_CI_RUN_DIR)/$$actor-data"; \
+	  mkdir -p "$$actor_data_dir"; \
+	  $(CONTAINER) rm -f "fini-$(FINI_E2E_CI_RUN_ID)-$$actor" >/dev/null 2>&1 || true; \
+	  $(CONTAINER) run -d --rm \
+	    --name "fini-$(FINI_E2E_CI_RUN_ID)-$$actor" \
+	    --hostname "$$actor" \
+	    --network "$(FINI_E2E_CI_NETWORK)" \
+	    -e FINI_ACTOR_SLUG="$$actor" \
+	    -e FINI_E2E_SOCKET_DIR=/var/run/fini-e2e \
+	    -e FINI_APP_DATA_DIR=/data \
+	    -v "$(FINI_E2E_CI_SOCKET_DIR):/var/run/fini-e2e:z" \
+	    -v "$$actor_data_dir:/data:Z" \
+	    "$(FINI_E2E_ACTOR_IMAGE)" >/dev/null; \
+	done
+
+pr-gate-e2e-wait-actors:
+	@set -eu; \
+	actor_list="$(FINI_E2E_CI_ACTORS)"; \
+	IFS=','; set -- $$actor_list; \
+	for actor in "$$@"; do \
+	  socket_path="$(FINI_E2E_CI_SOCKET_DIR)/$$actor.sock"; \
+	  deadline=$$(($$(date +%s) + 60)); \
+	  while [ ! -S "$$socket_path" ]; do \
+	    if [ "$$(date +%s)" -ge "$$deadline" ]; then \
+	      printf 'Actor socket did not appear: %s\n' "$$socket_path" >&2; \
+	      $(CONTAINER) logs "fini-$(FINI_E2E_CI_RUN_ID)-$$actor" 2>/dev/null || true; \
+	      exit 1; \
+	    fi; \
+	    sleep 1; \
+	  done; \
+	done
+
+pr-gate-e2e-run:
+	$(CONTAINER) rm -f "fini-$(FINI_E2E_CI_RUN_ID)-runner" >/dev/null 2>&1 || true
+	$(CONTAINER) run --rm \
+	  --name "fini-$(FINI_E2E_CI_RUN_ID)-runner" \
+	  --network "$(FINI_E2E_CI_NETWORK)" \
+	  -e FINI_E2E_ACTORS="$(FINI_E2E_CI_ACTORS)" \
+	  -e FINI_E2E_SOCKET_DIR=/var/run/fini-e2e \
+	  -v "$(FINI_E2E_CI_SOCKET_DIR):/var/run/fini-e2e:z" \
+	  -v "$(FINI_E2E_CI_RESULTS_DIR):/app/test-results:Z" \
+	  "$(FINI_E2E_RUNNER_IMAGE)"
+
+pr-gate-e2e-logs:
+	@set -eu; \
+	actor_list="$(FINI_E2E_CI_ACTORS)"; \
+	IFS=','; set -- $$actor_list; \
+	for actor in "$$@"; do \
+	  printf '\n===== logs: %s =====\n' "$$actor"; \
+	  $(CONTAINER) logs "fini-$(FINI_E2E_CI_RUN_ID)-$$actor" 2>/dev/null || true; \
+	done
+
+pr-gate-e2e-cleanup:
+	@set -eu; \
+	$(CONTAINER) rm -f "fini-$(FINI_E2E_CI_RUN_ID)-runner" >/dev/null 2>&1 || true; \
+	actor_list="$(FINI_E2E_CI_ACTORS)"; \
+	IFS=','; set -- $$actor_list; \
+	for actor in "$$@"; do \
+	  $(CONTAINER) rm -f "fini-$(FINI_E2E_CI_RUN_ID)-$$actor" >/dev/null 2>&1 || true; \
+	done; \
+	$(CONTAINER) network rm "$(FINI_E2E_CI_NETWORK)" >/dev/null 2>&1 || true
 
 # Run the real-app e2e lane locally.
 e2e:

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,10 @@ FINI_E2E_CI_NETWORK ?= fini-e2e-$(FINI_E2E_CI_RUN_ID)
 FINI_E2E_CI_ACTORS ?= actor-a,actor-b
 FINI_E2E_ACTOR_IMAGE ?= fini-e2e-actor-ci
 FINI_E2E_RUNNER_IMAGE ?= fini-e2e-runner-ci
+FINI_E2E_CACHE_IMAGE_PREFIX ?=
+FINI_E2E_CACHE_PUSH ?= 0
 
-.PHONY: help dev build mcp pr-gate-fe-unit pr-gate-be-unit pr-gate-e2e pr-gate-e2e-build-actor pr-gate-e2e-build-runner pr-gate-e2e-network pr-gate-e2e-start-actors pr-gate-e2e-wait-actors pr-gate-e2e-run pr-gate-e2e-logs pr-gate-e2e-cleanup e2e e2e-ci e2e-image e2e-build e2e-headed e2e-actors-image e2e-actors runtime-image runtime-smoke release-tag android-connect android-dev android-build android-sign-debug android-sign-release-local android-install-debug android-install-release-local android-launch android-devices android-debug-deploy android-release-deploy-local
+.PHONY: help dev build mcp pr-gate-fe-unit pr-gate-be-unit pr-gate-e2e pr-gate-e2e-cache-key pr-gate-e2e-build-actor pr-gate-e2e-build-runner pr-gate-e2e-network pr-gate-e2e-start-actors pr-gate-e2e-wait-actors pr-gate-e2e-run pr-gate-e2e-logs pr-gate-e2e-cleanup e2e e2e-ci e2e-image e2e-build e2e-headed e2e-actors-image e2e-actors runtime-image runtime-smoke release-tag android-connect android-dev android-build android-sign-debug android-sign-release-local android-install-debug android-install-release-local android-launch android-devices android-debug-deploy android-release-deploy-local
 
 help:
 	@echo ""
@@ -22,6 +24,7 @@ help:
 	@echo "  make pr-gate-fe-unit  Run frontend unit tests in Dockerfile stage"
 	@echo "  make pr-gate-be-unit  Run backend unit tests in Dockerfile stage"
 	@echo "  make pr-gate-e2e      Run npm run test:e2e:ci with Dockerfile stages"
+	@echo "  make pr-gate-e2e-cache-key  Print the E2E image input cache key"
 	@echo "  make pr-gate-e2e-*    Run one named CI E2E phase for easier failure diagnosis"
 	@echo "  make e2e              Run visible local two-app E2E"
 	@echo "  make e2e-ci           Run containerized headless E2E in CI mode"
@@ -77,11 +80,91 @@ pr-gate-e2e:
 	$(MAKE) pr-gate-e2e-wait-actors; \
 	$(MAKE) pr-gate-e2e-run
 
+pr-gate-e2e-cache-key:
+	@set -eu; \
+	cache_inputs() { \
+	  { \
+	    git ls-files -z -- \
+	      Dockerfile \
+	      package.json \
+	      package-lock.json \
+	      tsconfig\*.json \
+	      index.html \
+	      vite.config.ts \
+	      src \
+	      src-tauri/Cargo.toml \
+	      src-tauri/Cargo.lock \
+	      src-tauri/build.rs \
+	      src-tauri/src \
+	      src-tauri/migrations \
+	      src-tauri/patches \
+	      src-tauri/capabilities \
+	      src-tauri/icons \
+	      src-tauri/tauri.conf.json \
+	      specs/e2e; \
+	    git ls-files --others --exclude-standard -z -- \
+	      Dockerfile \
+	      package.json \
+	      package-lock.json \
+	      tsconfig\*.json \
+	      index.html \
+	      vite.config.ts \
+	      src \
+	      src-tauri/Cargo.toml \
+	      src-tauri/Cargo.lock \
+	      src-tauri/build.rs \
+	      src-tauri/src \
+	      src-tauri/migrations \
+	      src-tauri/patches \
+	      src-tauri/capabilities \
+	      src-tauri/icons \
+	      src-tauri/tauri.conf.json \
+	      specs/e2e; \
+	  } | sort -zu; \
+	}; \
+	cache_inputs | xargs -0 sha256sum | sha256sum | cut -d ' ' -f 1
+
 pr-gate-e2e-build-actor:
-	$(CONTAINER) build --target e2e-actor -t $(FINI_E2E_ACTOR_IMAGE) .
+	@set -eu; \
+	cache_key="$$(make --no-print-directory pr-gate-e2e-cache-key)"; \
+	cache_prefix="$(FINI_E2E_CACHE_IMAGE_PREFIX)"; \
+	cache_image=""; \
+	if [ -n "$$cache_prefix" ]; then cache_image="$$cache_prefix-e2e-actor-cache:$$cache_key"; fi; \
+	if [ -n "$$cache_image" ] && $(CONTAINER) pull "$$cache_image"; then \
+	  printf 'Using cached actor image: %s\n' "$$cache_image"; \
+	  $(CONTAINER) tag "$$cache_image" "$(FINI_E2E_ACTOR_IMAGE)"; \
+	  exit 0; \
+	fi; \
+	printf 'Building actor image for E2E cache key: %s\n' "$$cache_key"; \
+	if [ -n "$$cache_image" ]; then \
+	  $(CONTAINER) build --target e2e-actor --label "fini.e2e.cache-key=$$cache_key" -t "$(FINI_E2E_ACTOR_IMAGE)" -t "$$cache_image" .; \
+	else \
+	  $(CONTAINER) build --target e2e-actor --label "fini.e2e.cache-key=$$cache_key" -t "$(FINI_E2E_ACTOR_IMAGE)" .; \
+	fi; \
+	if [ -n "$$cache_image" ] && [ "$(FINI_E2E_CACHE_PUSH)" = "1" ]; then \
+	  $(CONTAINER) push "$$cache_image"; \
+	fi
 
 pr-gate-e2e-build-runner:
-	$(CONTAINER) build --target e2e-runner -t $(FINI_E2E_RUNNER_IMAGE) .
+	@set -eu; \
+	cache_key="$$(make --no-print-directory pr-gate-e2e-cache-key)"; \
+	cache_prefix="$(FINI_E2E_CACHE_IMAGE_PREFIX)"; \
+	cache_image=""; \
+	if [ -n "$$cache_prefix" ]; then cache_image="$$cache_prefix-e2e-runner-cache:$$cache_key"; fi; \
+	if [ -n "$$cache_image" ] && $(CONTAINER) pull "$$cache_image"; then \
+	  printf 'Using cached runner image: %s\n' "$$cache_image"; \
+	  $(CONTAINER) tag "$$cache_image" "$(FINI_E2E_RUNNER_IMAGE)"; \
+	  exit 0; \
+	fi; \
+	printf 'Building runner image for E2E cache key: %s\n' "$$cache_key"; \
+	if [ -n "$$cache_image" ]; then \
+	  $(CONTAINER) build --target e2e-runner --label "fini.e2e.cache-key=$$cache_key" -t "$(FINI_E2E_RUNNER_IMAGE)" -t "$$cache_image" .; \
+	else \
+	  $(CONTAINER) build --target e2e-runner --label "fini.e2e.cache-key=$$cache_key" -t "$(FINI_E2E_RUNNER_IMAGE)" .; \
+	fi; \
+	if [ -n "$$cache_image" ] && [ "$(FINI_E2E_CACHE_PUSH)" = "1" ]; then \
+	  $(CONTAINER) push "$$cache_image"; \
+	fi
 
 pr-gate-e2e-network:
 	@set -eu; \

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build",
     "test:unit": "jest --runInBand",
-    "test:e2e": "playwright test --config specs/e2e/playwright.config.ts",
-    "test:e2e:ci": "CI=1 Xvfb :99 -screen 0 1280x720x24 >/var/tmp/fini-e2e-xvfb.log 2>&1 & XVFB_PID=$!; trap 'kill $XVFB_PID' EXIT; DISPLAY=:99 playwright test --config specs/e2e/playwright.config.ts",
+    "test:e2e": "make e2e-headed",
+    "test:e2e:ci": "CI=1 make e2e-actors",
+    "test:e2e:containers": "make e2e-actors",
     "preview": "vite preview",
     "tauri": "tauri"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vue-tsc --noEmit && vite build",
     "test:unit": "jest --runInBand",
     "test:e2e": "make e2e-headed",
-    "test:e2e:ci": "CI=1 make e2e-actors",
+    "test:e2e:ci": "if [ \"$FINI_E2E_CONTAINER_RUNNER\" = \"1\" ]; then npx playwright test --config specs/e2e/playwright.config.ts; else CI=1 make e2e-actors; fi",
     "test:e2e:containers": "make e2e-actors",
     "preview": "vite preview",
     "tauri": "tauri"

--- a/specs/e2e/actors/fixtures.ts
+++ b/specs/e2e/actors/fixtures.ts
@@ -1,0 +1,111 @@
+import { expect, test as base } from '@playwright/test';
+import { PluginClient, TauriPage } from '@srsholmes/tauri-playwright';
+import { existsSync } from 'fs';
+import path from 'path';
+
+export interface E2EActor {
+  slug: string;
+  page: TauriPage;
+  invoke<T>(command: string, args?: Record<string, unknown>): Promise<T>;
+}
+
+interface ActorFixtures {
+  actors: Record<string, E2EActor>;
+  actorA: E2EActor;
+  actorB: E2EActor;
+}
+
+function actorSlugs(): string[] {
+  return (process.env.FINI_E2E_ACTORS ?? 'actor-a,actor-b')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function actorSocketPath(slug: string): string {
+  const socketDir = process.env.FINI_E2E_SOCKET_DIR ?? '/var/run/fini-e2e';
+  return path.join(socketDir, `${slug}.sock`);
+}
+
+async function waitForSocket(socketPath: string, timeoutMs = 30_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (existsSync(socketPath)) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+
+  throw new Error(`Socket ${socketPath} did not appear within ${timeoutMs}ms`);
+}
+
+async function invokeTauri<T>(page: TauriPage, command: string, args?: Record<string, unknown>): Promise<T> {
+  return page.evaluate<T>(`(async () => {
+    const invoke = window.__TAURI_INTERNALS__?.invoke;
+    if (!invoke) throw new Error('Tauri invoke is unavailable');
+    return await invoke(${JSON.stringify(command)}, ${JSON.stringify(args ?? {})});
+  })()`);
+}
+
+export const test = base.extend<ActorFixtures>({
+  actors: async ({}, use) => {
+    const slugs = actorSlugs();
+    const clients: PluginClient[] = [];
+    const actorEntries: Array<[string, E2EActor]> = [];
+
+    try {
+      for (const slug of slugs) {
+        const socketPath = actorSocketPath(slug);
+        await waitForSocket(socketPath);
+
+        const client = new PluginClient(socketPath);
+        clients.push(client);
+        await client.connect();
+
+        const ping = await client.send({ type: 'ping' });
+        if (!ping.ok) {
+          throw new Error(`Plugin ping failed for ${slug}`);
+        }
+
+        const page = new TauriPage(client);
+        page.setDefaultTimeout(15_000);
+
+        actorEntries.push([
+          slug,
+          {
+            slug,
+            page,
+            invoke<T>(command: string, args?: Record<string, unknown>): Promise<T> {
+              return invokeTauri<T>(page, command, args);
+            },
+          },
+        ]);
+      }
+
+      await use(Object.fromEntries(actorEntries));
+    } finally {
+      for (const client of clients.reverse()) {
+        client.disconnect();
+      }
+    }
+  },
+
+  actorA: async ({ actors }, use) => {
+    const actor = actors['actor-a'] ?? Object.values(actors)[0];
+    if (!actor) {
+      throw new Error('actor-a is not available');
+    }
+    await use(actor);
+  },
+
+  actorB: async ({ actors }, use) => {
+    const actor = actors['actor-b'] ?? Object.values(actors)[1];
+    if (!actor) {
+      throw new Error('actor-b is not available');
+    }
+    await use(actor);
+  },
+});
+
+export { expect };

--- a/specs/e2e/actors/helpers/device-sync.ts
+++ b/specs/e2e/actors/helpers/device-sync.ts
@@ -1,0 +1,216 @@
+import { expect } from '../fixtures.js';
+import type { E2EActor } from '../fixtures.js';
+import { allTextContents, pollUntil, waitForText } from './dom.js';
+
+interface DeviceIdentity {
+  device_id: string;
+  hostname: string;
+}
+
+interface PairedDevice {
+  peer_device_id: string;
+  display_name: string;
+}
+
+interface DiscoveredDevice {
+  device_id: string;
+  hostname: string;
+}
+
+interface SyncTickResult {
+  sent_events: number;
+  applied_events: number;
+  received_acks: number;
+}
+
+export interface SyncedActor {
+  actor: E2EActor;
+  identity: DeviceIdentity;
+}
+
+export interface EnsureSyncedActorsOptions {
+  pairViaUi?: boolean;
+  timeoutMs?: number;
+  syncTicks?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+export async function ensureSyncedActors(
+  actors: E2EActor[],
+  options: EnsureSyncedActorsOptions = {},
+): Promise<SyncedActor[]> {
+  if (actors.length < 2) {
+    throw new Error(`ensureSyncedActors requires at least two actors, got ${actors.length}`);
+  }
+
+  const pairViaUi = options.pairViaUi ?? true;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const syncTicks = options.syncTicks ?? 3;
+  const syncedActors = await waitForActorsReady(actors, timeoutMs);
+
+  if (pairViaUi) {
+    for (let i = 0; i < syncedActors.length; i += 1) {
+      for (let j = i + 1; j < syncedActors.length; j += 1) {
+        const left = syncedActors[i];
+        const right = syncedActors[j];
+        if (!(await areActorsPaired(left.actor, right.identity.device_id))) {
+          await pairActorsViaUi(left, right, timeoutMs);
+        }
+      }
+    }
+  }
+
+  await waitForPairedDevices(syncedActors, timeoutMs);
+  await waitForPresence(syncedActors, timeoutMs);
+  await driveSyncReadiness(syncedActors, syncTicks);
+  await waitForPairedDeviceNames(syncedActors, timeoutMs);
+
+  return syncedActors;
+}
+
+export async function waitForActorsReady(
+  actors: E2EActor[],
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<SyncedActor[]> {
+  const syncedActors: SyncedActor[] = [];
+
+  for (const actor of actors) {
+    await actor.page.waitForSelector('nav.nav', timeoutMs);
+    const identity = await actor.invoke<DeviceIdentity>('device_connection_get_identity');
+    expect(identity.device_id, `${actor.slug} should have a device id`).toBeTruthy();
+    expect(identity.hostname, `${actor.slug} should have a hostname`).toBeTruthy();
+    syncedActors.push({ actor, identity });
+  }
+
+  const ids = new Set(syncedActors.map((item) => item.identity.device_id));
+  expect(ids.size, 'actor device ids should be unique').toBe(syncedActors.length);
+
+  return syncedActors;
+}
+
+export async function pairActorsViaUi(
+  requester: SyncedActor,
+  accepter: SyncedActor,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<void> {
+  await openAddDevice(requester.actor, timeoutMs);
+  await openAddDevice(accepter.actor, timeoutMs);
+
+  const requesterPage = requester.actor.page;
+  const accepterPage = accepter.actor.page;
+  const targetSelector = nearbyDeviceRequestSelector(accepter.identity.hostname);
+  await requesterPage.waitForSelector(targetSelector, timeoutMs);
+  await requesterPage.click(targetSelector);
+
+  const incomingSelector = incomingRequestAcceptSelector(requester.identity.hostname);
+  await accepterPage.waitForSelector(incomingSelector, timeoutMs);
+  await accepterPage.click(incomingSelector);
+
+  await requesterPage.waitForSelector('[data-testid="pair-code"]', timeoutMs);
+  const code = (await requesterPage.textContent('[data-testid="pair-code"]'))?.trim() ?? '';
+  expect(code, `pair code for ${requester.actor.slug} -> ${accepter.actor.slug}`).toMatch(/^\d{6}$/);
+
+  await accepterPage.fill('[data-testid="pair-code-input"]', code);
+  await accepterPage.click('[data-testid="pair-code-submit"]');
+
+  await requesterPage.waitForSelector('[data-testid="settings-devices"]', timeoutMs);
+  await accepterPage.waitForSelector('[data-testid="settings-devices"]', timeoutMs);
+}
+
+async function openAddDevice(actor: E2EActor, timeoutMs: number): Promise<void> {
+  await actor.page.waitForSelector('nav.nav a[href="#/settings"]', timeoutMs);
+  await actor.page.click('nav.nav a[href="#/settings"]');
+  await actor.page.waitForSelector('[data-testid="settings-devices"]', timeoutMs);
+  await actor.page.click('[data-testid="add-device-link"]');
+  await actor.page.waitForSelector('[data-testid="nearby-devices"]', timeoutMs);
+}
+
+async function areActorsPaired(actor: E2EActor, peerDeviceId: string): Promise<boolean> {
+  const paired = await actor.invoke<PairedDevice[]>('device_connection_get_paired_devices');
+  return paired.some((device) => device.peer_device_id === peerDeviceId);
+}
+
+async function waitForPairedDevices(
+  syncedActors: SyncedActor[],
+  timeoutMs: number,
+): Promise<void> {
+  for (const current of syncedActors) {
+    const peerIds = syncedActors
+      .filter((candidate) => candidate.identity.device_id !== current.identity.device_id)
+      .map((candidate) => candidate.identity.device_id);
+
+    await pollUntil(`${current.actor.slug} paired devices`, async () => {
+      const paired = await current.actor.invoke<PairedDevice[]>('device_connection_get_paired_devices');
+      const pairedIds = new Set(paired.map((device) => device.peer_device_id));
+      return peerIds.every((peerId) => pairedIds.has(peerId));
+    }, timeoutMs);
+  }
+}
+
+async function waitForPresence(
+  syncedActors: SyncedActor[],
+  timeoutMs: number,
+): Promise<void> {
+  for (const current of syncedActors) {
+    const peerIds = syncedActors
+      .filter((candidate) => candidate.identity.device_id !== current.identity.device_id)
+      .map((candidate) => candidate.identity.device_id);
+
+    await pollUntil(`${current.actor.slug} presence`, async () => {
+      const present = await current.actor.invoke<DiscoveredDevice[]>('device_connection_presence_snapshot');
+      const presentIds = new Set(present.map((device) => device.device_id));
+      return peerIds.every((peerId) => presentIds.has(peerId));
+    }, timeoutMs);
+  }
+}
+
+async function driveSyncReadiness(syncedActors: SyncedActor[], syncTicks: number): Promise<void> {
+  for (let tick = 0; tick < syncTicks; tick += 1) {
+    for (const synced of syncedActors) {
+      await synced.actor.invoke<SyncTickResult>('space_sync_tick');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+}
+
+async function waitForPairedDeviceNames(
+  syncedActors: SyncedActor[],
+  timeoutMs: number,
+): Promise<void> {
+  for (const current of syncedActors) {
+    await current.actor.page.click('nav.nav a[href="#/settings"]');
+    await current.actor.page.waitForSelector('[data-testid="settings-devices"]', timeoutMs);
+
+    for (const peer of syncedActors) {
+      if (peer.identity.device_id === current.identity.device_id) {
+        continue;
+      }
+      await waitForText(
+        current.actor.page,
+        '[data-testid="paired-device-name"]',
+        peer.identity.hostname,
+        timeoutMs,
+      );
+    }
+
+    const names = await allTextContents(current.actor.page, '[data-testid="paired-device-name"]');
+    for (const peer of syncedActors) {
+      if (peer.identity.device_id !== current.identity.device_id) {
+        expect(names, `${current.actor.slug} paired device names`).toContain(peer.identity.hostname);
+      }
+    }
+  }
+}
+
+function nearbyDeviceRequestSelector(hostname: string): string {
+  return `[data-testid="nearby-device-row"][data-device-hostname="${cssString(hostname)}"] [data-testid="request-pair"]`;
+}
+
+function incomingRequestAcceptSelector(hostname: string): string {
+  return `[data-testid="incoming-request-row"][data-from-hostname="${cssString(hostname)}"] [data-testid="accept-incoming-request"]`;
+}
+
+function cssString(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}

--- a/specs/e2e/actors/helpers/dom.ts
+++ b/specs/e2e/actors/helpers/dom.ts
@@ -1,0 +1,47 @@
+export async function waitForText(
+  page: { waitForFunction: (script: string, timeout?: number) => Promise<unknown> },
+  selector: string,
+  text: string,
+  timeout = 30_000,
+) {
+  await page.waitForFunction(`(() => {
+    return Array.from(document.querySelectorAll(${JSON.stringify(selector)}))
+      .some((node) => node.textContent?.includes(${JSON.stringify(text)}));
+  })()`, timeout);
+}
+
+export async function allTextContents(
+  page: { evaluate: <T>(script: string) => Promise<T> },
+  selector: string,
+): Promise<string[]> {
+  return page.evaluate<string[]>(`(() => {
+    return Array.from(document.querySelectorAll(${JSON.stringify(selector)}))
+      .map((node) => node.textContent?.trim() ?? '');
+  })()`);
+}
+
+export async function pollUntil<T>(
+  description: string,
+  probe: () => Promise<T | null | undefined | false>,
+  timeoutMs = 30_000,
+  intervalMs = 500,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      const result = await probe();
+      if (result) {
+        return result;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  const suffix = lastError instanceof Error ? ` Last error: ${lastError.message}` : '';
+  throw new Error(`Timed out waiting for ${description}.${suffix}`);
+}

--- a/specs/e2e/actors/playwright.config.ts
+++ b/specs/e2e/actors/playwright.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 120_000,
+  reporter: 'list',
+  fullyParallel: false,
+  workers: 1,
+  use: {
+    mode: 'tauri' as any,
+  },
+});

--- a/specs/e2e/actors/start-actor.sh
+++ b/specs/e2e/actors/start-actor.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+actor_slug="${FINI_ACTOR_SLUG:-actor-a}"
+socket_dir="${FINI_E2E_SOCKET_DIR:-/var/run/fini-e2e}"
+app_data_dir="${FINI_APP_DATA_DIR:-/data}"
+socket_path="${TAURI_PLAYWRIGHT_SOCKET:-${socket_dir}/${actor_slug}.sock}"
+display="${DISPLAY:-:99}"
+
+mkdir -p "$socket_dir" "$app_data_dir"
+rm -f "$socket_path"
+
+export FINI_APP_DATA_DIR="$app_data_dir"
+export TAURI_PLAYWRIGHT_SOCKET="$socket_path"
+export XDG_DATA_HOME="${XDG_DATA_HOME:-/data}"
+export TZ="${TZ:-UTC}"
+export DISPLAY="$display"
+
+Xvfb "$display" -screen 0 1280x720x24 -nolisten tcp &
+xvfb_pid="$!"
+
+cleanup() {
+  if kill -0 "$xvfb_pid" 2>/dev/null; then
+    kill "$xvfb_pid" 2>/dev/null || true
+    wait "$xvfb_pid" 2>/dev/null || true
+  fi
+}
+
+trap cleanup EXIT INT TERM
+
+for _ in $(seq 1 50); do
+  if [ -S "/tmp/.X11-unix/X${display#:}" ]; then
+    break
+  fi
+  sleep 0.1
+done
+
+exec /usr/local/bin/fini app

--- a/specs/e2e/actors/tests/multi-actor-smoke.spec.ts
+++ b/specs/e2e/actors/tests/multi-actor-smoke.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '../fixtures.js';
+
+interface DeviceIdentity {
+  device_id: string;
+  hostname: string;
+}
+
+test('runner controls two isolated actors with distinct identities', async ({ actorA, actorB }) => {
+  await actorA.page.waitForSelector('nav.nav', 30_000);
+  await actorB.page.waitForSelector('nav.nav', 30_000);
+
+  const identityA = await actorA.invoke<DeviceIdentity>('device_connection_get_identity');
+  const identityB = await actorB.invoke<DeviceIdentity>('device_connection_get_identity');
+
+  expect(identityA.device_id).toBeTruthy();
+  expect(identityB.device_id).toBeTruthy();
+  expect(identityA.device_id).not.toBe(identityB.device_id);
+  expect(identityA.hostname).toBe('actor-a');
+  expect(identityB.hostname).toBe('actor-b');
+});

--- a/specs/e2e/actors/tests/settings-device-discovery.spec.ts
+++ b/specs/e2e/actors/tests/settings-device-discovery.spec.ts
@@ -1,0 +1,6 @@
+import { test } from '../fixtures.js';
+import { ensureSyncedActors } from '../helpers/device-sync.js';
+
+test('two app instances pair through Settings and show each other device names', async ({ actorA, actorB }) => {
+  await ensureSyncedActors([actorA, actorB], { pairViaUi: true });
+});

--- a/specs/e2e/playwright.config.ts
+++ b/specs/e2e/playwright.config.ts
@@ -1,16 +1,24 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './ui/tests',
+  testDir: '.',
   timeout: 180_000,
   reporter: 'list',
   fullyParallel: false,
   workers: 1,
   projects: [
     {
-      name: 'tauri',
-      testMatch: '**/*.spec.ts',
+      name: 'cli',
+      testMatch: ['reminder-bridge.spec.ts'],
+    },
+    {
+      name: 'ui',
+      testMatch: ['ui/tests/**/*.spec.ts'],
       use: { mode: 'tauri' } as any,
+    },
+    {
+      name: 'actors',
+      testMatch: ['actors/tests/**/*.spec.ts'],
     },
   ],
 });

--- a/specs/e2e/ui/fixtures.ts
+++ b/specs/e2e/ui/fixtures.ts
@@ -8,7 +8,7 @@
 import { createTauriTest } from '@srsholmes/tauri-playwright';
 
 const tauriCommand = process.env.FINI_BINARY
-  ? `env FINI_APP_DATA_DIR=/var/tmp/fini-e2e-ui TZ=UTC ${process.env.FINI_BINARY} app`
+  ? `xvfb-run -a env FINI_APP_DATA_DIR=/var/tmp/fini-e2e-ui TZ=UTC ${process.env.FINI_BINARY} app`
   : 'env FINI_APP_DATA_DIR=/var/tmp/fini-e2e-ui TZ=UTC npx tauri dev --features e2e-testing -- -- app';
 
 export const { test, expect } = createTauriTest({

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1300,12 +1300,14 @@ dependencies = [
  "dirs 5.0.1",
  "futures-util",
  "libsqlite3-sys",
+ "mdns-sd",
  "reqwest 0.12.28",
  "rmcp",
  "serde",
  "serde_json",
  "sherpa-onnx",
  "sherpa-onnx-sys",
+ "socket2 0.6.3",
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
@@ -1327,6 +1329,17 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
 ]
 
 [[package]]
@@ -1965,7 +1978,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2117,6 +2130,16 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2500,6 +2523,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "mdns-sd"
+version = "0.13.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328f4e1041f7cfeb3affccb814ddbe2f004856a2ce769c8bf22080d74c5204c6"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "log",
+ "mio",
+ "socket2 0.5.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2564,6 +2601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -3565,7 +3603,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3602,7 +3640,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4396,6 +4434,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -4450,6 +4498,15 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -5101,7 +5158,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,6 +46,8 @@ tauri-plugin-notification = "2.3.3"
 tauri-plugin-autostart = "2.5.1"
 time = { version = "0.3.47", features = ["parsing", "formatting"] }
 tauri-plugin-playwright = { version = "0.2" }
+socket2 = "0.6"
+mdns-sd = "0.13"
 
 [features]
 # Enable the Playwright control-server plugin for UI e2e tests. Off by default;

--- a/src-tauri/src/services/device_connection/commands.rs
+++ b/src-tauri/src/services/device_connection/commands.rs
@@ -1,10 +1,12 @@
 use chrono::Utc;
 use diesel::prelude::*;
-use std::net::{IpAddr, SocketAddr, UdpSocket};
+use futures_util::SinkExt;
+use std::net::IpAddr;
 use std::time::Duration;
 use tauri::State;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
 
-use super::{DISCOVERY_PORT, DISCOVERY_PROTOCOL, DISCOVERY_TTL_SECS, PAIR_REQUEST_TTL_SECS};
+use super::{DISCOVERY_PROTOCOL, DISCOVERY_TTL_SECS, PAIR_REQUEST_TTL_SECS};
 use crate::models::{CreatePairedDeviceInput, PairedDevice};
 use crate::schema::paired_devices;
 use crate::services::db::DbState;
@@ -17,6 +19,30 @@ use crate::services::device_connection::types::{
     PairCodeUpdate, PairCompletePayload, PairCompletionUpdate, PairRequestPayload,
 };
 use crate::services::device_connection::DeviceConnectionState;
+use crate::services::space_sync::types::WsMessage;
+
+fn ws_url(addr: IpAddr, port: u16) -> String {
+    match addr {
+        IpAddr::V4(_) => format!("ws://{addr}:{port}"),
+        IpAddr::V6(_) => format!("ws://[{addr}]:{port}"),
+    }
+}
+
+fn send_pair_ws(addr: IpAddr, port: u16, msg: WsMessage) -> Result<(), String> {
+    tauri::async_runtime::block_on(async move {
+        let url = ws_url(addr, port);
+        let (mut ws, _) = connect_async(&url)
+            .await
+            .map_err(|err| format!("connect pair websocket {url} failed: {err}"))?;
+        let text = serde_json::to_string(&msg)
+            .map_err(|err| format!("serialize pair websocket message failed: {err}"))?;
+        ws.send(Message::Text(text.into()))
+            .await
+            .map_err(|err| format!("send pair websocket message failed: {err}"))?;
+        let _ = ws.close(None).await;
+        Ok(())
+    })
+}
 
 pub fn device_connection_get_identity_impl(
     state: &DeviceConnectionState,
@@ -92,29 +118,23 @@ pub fn device_connection_send_pair_request_impl(
         request_id: input.request_id,
         from_device_id: state.identity.device_id.clone(),
         from_hostname: state.identity.hostname.clone(),
+        from_discovery_port: Some(state.discovery_port),
+        from_ws_port: Some(state.space_sync_ws_port),
         to_device_id: input.to_device_id,
         created_at,
         expires_at,
     };
 
-    let bytes =
-        serde_json::to_vec(&payload).map_err(|err| format!("serialize pair request: {err}"))?;
-
-    let socket = UdpSocket::bind(("0.0.0.0", 0))
-        .map_err(|err| format!("bind ephemeral send socket failed: {err}"))?;
-
-    let target = SocketAddr::new(target_ip, DISCOVERY_PORT);
-    socket
-        .send_to(&bytes, target)
-        .map_err(|err| format!("send pair request failed: {err}"))?;
+    let target_port = input.to_ws_port.unwrap_or(state.space_sync_ws_port);
+    send_pair_ws(target_ip, target_port, WsMessage::PairRequest(payload.clone()))?;
 
     if let Ok(mut guard) = state.runtime.lock() {
         guard.tx_count += 1;
     }
 
     eprintln!(
-        "[device-sync] pair request {} sent to {} ({})",
-        payload.request_id, payload.to_device_id, target
+        "[device-sync] pair request {} sent to {} ({}:{})",
+        payload.request_id, payload.to_device_id, target_ip, target_port
     );
 
     Ok(())
@@ -214,7 +234,7 @@ pub fn device_connection_pair_accept_request_impl(
     state: &DeviceConnectionState,
     input: DevicePairRequestAckInput,
 ) -> Result<PairCodeUpdate, String> {
-    let (to_device_id, to_addr) = {
+    let (to_device_id, to_addr, to_ws_port) = {
         let mut guard = state
             .runtime
             .lock()
@@ -229,6 +249,7 @@ pub fn device_connection_pair_accept_request_impl(
         (
             stored.request.from_device_id.clone(),
             stored.from_addr.clone(),
+            stored.from_ws_port.unwrap_or(state.space_sync_ws_port),
         )
     };
 
@@ -252,37 +273,15 @@ pub fn device_connection_pair_accept_request_impl(
         accepted_at: update.accepted_at.clone(),
     };
 
-    let bytes =
-        serde_json::to_vec(&payload).map_err(|err| format!("serialize pair accept: {err}"))?;
-    let socket = UdpSocket::bind(("0.0.0.0", 0))
-        .map_err(|err| format!("bind pair accept socket failed: {err}"))?;
-    let target = SocketAddr::new(target_ip, DISCOVERY_PORT);
-    let mut sent_count: u64 = 0;
-    let mut last_send_error: Option<String> = None;
-
-    for _ in 0..3 {
-        match socket.send_to(&bytes, target) {
-            Ok(_) => {
-                sent_count += 1;
-            }
-            Err(err) => {
-                last_send_error = Some(err.to_string());
-            }
-        }
-    }
-
-    if sent_count == 0 {
-        let message = last_send_error.unwrap_or_else(|| "unknown send error".to_string());
-        return Err(format!("send pair accept failed: {message}"));
-    }
+    send_pair_ws(target_ip, to_ws_port, WsMessage::PairAccept(payload))?;
 
     if let Ok(mut guard) = state.runtime.lock() {
-        guard.tx_count += sent_count;
+        guard.tx_count += 1;
     }
 
     eprintln!(
-        "[device-sync] accepted request {} for {} with code {} (sent {}x)",
-        update.request_id, to_device_id, update.code, sent_count
+        "[device-sync] accepted request {} for {} with code {}",
+        update.request_id, to_device_id, update.code
     );
 
     Ok(update)
@@ -300,7 +299,7 @@ pub fn device_connection_pair_complete_request_impl(
     state: &DeviceConnectionState,
     input: DevicePairRequestAckInput,
 ) -> Result<(), String> {
-    let (to_device_id, to_addr) = {
+    let (to_device_id, to_addr, to_ws_port) = {
         let mut guard = state
             .runtime
             .lock()
@@ -315,6 +314,7 @@ pub fn device_connection_pair_complete_request_impl(
         (
             stored.request.from_device_id.clone(),
             stored.from_addr.clone(),
+            stored.from_ws_port.unwrap_or(state.space_sync_ws_port),
         )
     };
 
@@ -332,40 +332,18 @@ pub fn device_connection_pair_complete_request_impl(
         paired_at: utc_now(),
     };
 
-    let bytes =
-        serde_json::to_vec(&payload).map_err(|err| format!("serialize pair complete: {err}"))?;
-    let socket = UdpSocket::bind(("0.0.0.0", 0))
-        .map_err(|err| format!("bind pair complete socket failed: {err}"))?;
-    let target = SocketAddr::new(target_ip, DISCOVERY_PORT);
-
-    let mut sent_count: u64 = 0;
-    let mut last_send_error: Option<String> = None;
-    for _ in 0..3 {
-        match socket.send_to(&bytes, target) {
-            Ok(_) => {
-                sent_count += 1;
-            }
-            Err(err) => {
-                last_send_error = Some(err.to_string());
-            }
-        }
-    }
-
-    if sent_count == 0 {
-        let message = last_send_error.unwrap_or_else(|| "unknown send error".to_string());
-        return Err(format!("send pair complete failed: {message}"));
-    }
+    send_pair_ws(target_ip, to_ws_port, WsMessage::PairComplete(payload))?;
 
     let mut guard = state
         .runtime
         .lock()
         .map_err(|_| "device sync runtime lock poisoned".to_string())?;
-    guard.tx_count += sent_count;
+    guard.tx_count += 1;
     guard.incoming_requests.remove(&input.request_id);
 
     eprintln!(
-        "[device-sync] completed request {} for {} (sent {}x)",
-        input.request_id, to_device_id, sent_count
+        "[device-sync] completed request {} for {}",
+        input.request_id, to_device_id
     );
 
     Ok(())
@@ -420,6 +398,7 @@ pub fn device_connection_discovery_snapshot_impl(
             device_id: device_id.clone(),
             hostname: peer.hostname.clone(),
             addr: peer.addr.clone(),
+            discovery_port: peer.discovery_port,
             ws_port: peer.ws_port,
             last_seen_at: peer.last_seen_at.clone(),
         })
@@ -456,6 +435,7 @@ pub fn device_connection_presence_snapshot_impl(
             device_id: device_id.clone(),
             hostname: peer.hostname.clone(),
             addr: peer.addr.clone(),
+            discovery_port: peer.discovery_port,
             ws_port: peer.ws_port,
             last_seen_at: peer.last_seen_at.clone(),
         })
@@ -495,7 +475,8 @@ pub fn device_connection_debug_status_impl(
         outgoing_code_count: guard.outgoing_code_updates.len(),
         last_broadcast_at: guard.last_broadcast_at.clone(),
         last_error: guard.last_error.clone(),
-        discovery_port: DISCOVERY_PORT,
+        discovery_port: state.discovery_port,
+        discovery_provider: "mdns-sd".to_string(),
     })
 }
 

--- a/src-tauri/src/services/device_connection/mod.rs
+++ b/src-tauri/src/services/device_connection/mod.rs
@@ -1,6 +1,6 @@
 mod commands;
 mod runtime;
-mod types;
+pub(crate) mod types;
 
 use std::net::Ipv4Addr;
 use std::path::{Path, PathBuf};
@@ -24,6 +24,10 @@ use types::DiscoveryRuntime;
 pub use types::{
     CustomSpaceDescriptor, DeviceIdentity, IncomingSpaceMappingUpdate, IncomingSyncAck,
 };
+use types::{
+    PairAcceptPayload, PairCodeUpdate, PairCompletePayload, PairCompletionUpdate,
+    PairRequestPayload,
+};
 
 pub const DISCOVERY_INTERVAL_MS: u64 = 5_000;
 pub const HEARTBEAT_INTERVAL_MS: u64 = 60_000;
@@ -34,12 +38,42 @@ pub(super) const DISCOVERY_TTL_SECS: u64 = 15;
 pub(super) const PAIR_REQUEST_TTL_SECS: i64 = 60;
 pub(super) const MULTICAST_GROUP: Ipv4Addr = Ipv4Addr::new(239, 255, 42, 99);
 pub(crate) const SPACE_SYNC_WS_PORT: u16 = 45_455;
+pub(crate) const MDNS_SERVICE_TYPE: &str = "_fini-sync._tcp.local.";
 
 #[derive(Clone)]
 pub struct DeviceConnectionState {
     pub identity: DeviceIdentity,
     pub db_path: PathBuf,
+    pub discovery_port: u16,
+    pub space_sync_ws_port: u16,
     runtime: Arc<Mutex<DiscoveryRuntime>>,
+}
+
+fn env_port(name: &str, fallback: u16) -> u16 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<u16>().ok())
+        .unwrap_or(fallback)
+}
+
+fn env_port_list(name: &str, fallback: u16) -> Vec<u16> {
+    let mut ports: Vec<u16> = std::env::var(name)
+        .ok()
+        .map(|value| {
+            value
+                .split(',')
+                .filter_map(|item| item.trim().parse::<u16>().ok())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if !ports.contains(&fallback) {
+        ports.push(fallback);
+    }
+
+    ports.sort_unstable();
+    ports.dedup();
+    ports
 }
 
 impl DeviceConnectionState {
@@ -47,12 +81,23 @@ impl DeviceConnectionState {
         let identity = load_or_create_identity(app_data_dir);
         let runtime = Arc::new(Mutex::new(DiscoveryRuntime::default()));
         let db_path = app_data_dir.join("fini.db");
+        let discovery_port = env_port("FINI_DISCOVERY_PORT", DISCOVERY_PORT);
+        let space_sync_ws_port = env_port("FINI_SPACE_SYNC_WS_PORT", SPACE_SYNC_WS_PORT);
+        let discovery_broadcast_ports = env_port_list("FINI_DISCOVERY_PEER_PORTS", discovery_port);
 
-        spawn_discovery_worker(identity.clone(), runtime.clone());
+        spawn_discovery_worker(
+            identity.clone(),
+            runtime.clone(),
+            discovery_port,
+            discovery_broadcast_ports,
+            space_sync_ws_port,
+        );
 
         Self {
             identity,
             db_path,
+            discovery_port,
+            space_sync_ws_port,
             runtime,
         }
     }
@@ -167,15 +212,99 @@ impl DeviceConnectionState {
         }
     }
 
-    /// Returns (device_id, addr) for every presenced peer (seen within TTL).
-    pub fn list_presenced_peers(&self) -> Vec<(String, String)> {
+    pub fn receive_ws_pair_request(
+        &self,
+        payload: PairRequestPayload,
+        from_addr: String,
+    ) -> Result<(), String> {
+        if payload.to_device_id != self.identity.device_id {
+            return Ok(());
+        }
+
+        let mut guard = self
+            .runtime
+            .lock()
+            .map_err(|_| "device sync runtime lock poisoned".to_string())?;
+        guard.rx_count += 1;
+
+        if guard.add_mode_enabled {
+            let is_new = !guard
+                .incoming_requests
+                .contains_key(payload.request_id.as_str());
+            guard.incoming_requests.insert(
+                payload.request_id.clone(),
+                runtime::build_incoming_pair_request(&payload, from_addr),
+            );
+
+            if is_new {
+                eprintln!(
+                    "[device-sync] incoming ws pair request {} from {} ({})",
+                    payload.request_id, payload.from_hostname, payload.from_device_id
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn receive_ws_pair_accept(&self, payload: PairAcceptPayload) -> Result<(), String> {
+        if payload.to_device_id != self.identity.device_id {
+            return Ok(());
+        }
+
+        let mut guard = self
+            .runtime
+            .lock()
+            .map_err(|_| "device sync runtime lock poisoned".to_string())?;
+        guard.rx_count += 1;
+        guard.outgoing_code_updates.insert(
+            payload.request_id.clone(),
+            PairCodeUpdate {
+                request_id: payload.request_id,
+                code: payload.code,
+                accepted_at: payload.accepted_at,
+            },
+        );
+        Ok(())
+    }
+
+    pub fn receive_ws_pair_complete(&self, payload: PairCompletePayload) -> Result<(), String> {
+        if payload.to_device_id != self.identity.device_id {
+            return Ok(());
+        }
+
+        let mut guard = self
+            .runtime
+            .lock()
+            .map_err(|_| "device sync runtime lock poisoned".to_string())?;
+        guard.rx_count += 1;
+        guard.outgoing_pair_completions.insert(
+            payload.request_id.clone(),
+            PairCompletionUpdate {
+                request_id: payload.request_id,
+                from_device_id: payload.from_device_id,
+                from_hostname: payload.from_hostname,
+                paired_at: payload.paired_at,
+            },
+        );
+        Ok(())
+    }
+
+    /// Returns (device_id, addr, ws_port) for every presenced peer (seen within TTL).
+    pub fn list_presenced_peers(&self) -> Vec<(String, String, u16)> {
         let Ok(guard) = self.runtime.lock() else {
             return Vec::new();
         };
         guard
             .presence
             .iter()
-            .map(|(id, peer)| (id.clone(), peer.addr.clone()))
+            .map(|(id, peer)| {
+                (
+                    id.clone(),
+                    peer.addr.clone(),
+                    peer.ws_port.unwrap_or(self.space_sync_ws_port),
+                )
+            })
             .collect()
     }
 }

--- a/src-tauri/src/services/device_connection/runtime.rs
+++ b/src-tauri/src/services/device_connection/runtime.rs
@@ -1,4 +1,6 @@
 use chrono::Utc;
+use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo};
+use socket2::{Domain, Protocol, Socket, Type};
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket};
 use std::path::Path;
@@ -8,8 +10,8 @@ use std::time::{Duration, Instant};
 use uuid::Uuid;
 
 use super::{
-    DISCOVERY_INTERVAL_MS, DISCOVERY_PORT, DISCOVERY_PROTOCOL, DISCOVERY_TTL_SECS,
-    HEARTBEAT_INTERVAL_MS, MULTICAST_GROUP, PAIR_REQUEST_TTL_SECS, SPACE_SYNC_WS_PORT,
+    DISCOVERY_INTERVAL_MS, DISCOVERY_PROTOCOL, DISCOVERY_TTL_SECS, HEARTBEAT_INTERVAL_MS,
+    MDNS_SERVICE_TYPE, MULTICAST_GROUP, PAIR_REQUEST_TTL_SECS,
 };
 use crate::services::device_connection::types::{
     DeviceIdentity, DiscoveryBeacon, DiscoveryRuntime, IncomingPairRequest, PairAcceptPayload,
@@ -104,6 +106,7 @@ pub(super) fn build_incoming_pair_request(
             cooldown_until: None,
         },
         from_addr,
+        from_ws_port: payload.from_ws_port,
     }
 }
 
@@ -111,12 +114,14 @@ pub(super) fn upsert_seen_peer(
     peers: &mut HashMap<String, SeenPeer>,
     beacon: &DiscoveryBeacon,
     addr: IpAddr,
+    fallback_discovery_port: u16,
 ) {
     peers.insert(
         beacon.device_id.clone(),
         SeenPeer {
             hostname: beacon.hostname.clone(),
             addr: addr.to_string(),
+            discovery_port: beacon.discovery_port.unwrap_or(fallback_discovery_port),
             ws_port: beacon.ws_port,
             last_seen_at: utc_now(),
             last_seen_mono: Instant::now(),
@@ -124,11 +129,204 @@ pub(super) fn upsert_seen_peer(
     );
 }
 
+fn parse_bool_txt(value: Option<&str>) -> bool {
+    matches!(value, Some("1") | Some("true") | Some("yes"))
+}
+
+fn service_txt<'a>(info: &'a ServiceInfo, key: &str) -> Option<&'a str> {
+    info.get_property_val_str(key).filter(|value| !value.is_empty())
+}
+
+fn upsert_mdns_peer(
+    peers: &mut HashMap<String, SeenPeer>,
+    info: &ServiceInfo,
+    fallback_discovery_port: u16,
+) -> Option<(String, bool)> {
+    let txtvers = service_txt(info, "txtvers")?;
+    let proto = service_txt(info, "proto")?;
+    if txtvers != "1" || proto != "1" {
+        return None;
+    }
+
+    let device_id = service_txt(info, "devid")?.to_string();
+    let hostname = service_txt(info, "name")
+        .unwrap_or_else(|| info.get_fullname())
+        .to_string();
+    let addr = info.get_addresses().iter().next()?.to_string();
+    let add_mode = parse_bool_txt(service_txt(info, "add"));
+
+    peers.insert(
+        device_id.clone(),
+        SeenPeer {
+            hostname,
+            addr,
+            discovery_port: fallback_discovery_port,
+            ws_port: Some(info.get_port()),
+            last_seen_at: utc_now(),
+            last_seen_mono: Instant::now(),
+        },
+    );
+
+    Some((device_id, add_mode))
+}
+
+fn register_mdns_service(
+    daemon: &ServiceDaemon,
+    identity: &DeviceIdentity,
+    space_sync_ws_port: u16,
+    add_mode_enabled: bool,
+) -> Result<String, String> {
+    let instance_name = format!("{}-{}", identity.hostname, &identity.device_id[..8]);
+    let host_name = format!("fini-{}.local.", &identity.device_id[..8]);
+    let add_value = if add_mode_enabled { "1" } else { "0" };
+    let properties = [
+        ("txtvers", "1"),
+        ("devid", identity.device_id.as_str()),
+        ("name", identity.hostname.as_str()),
+        ("add", add_value),
+        ("proto", "1"),
+    ];
+    let service = ServiceInfo::new(
+        MDNS_SERVICE_TYPE,
+        &instance_name,
+        &host_name,
+        "",
+        space_sync_ws_port,
+        &properties[..],
+    )
+    .map_err(|err| format!("create mdns service failed: {err}"))?
+    .enable_addr_auto();
+    let fullname = service.get_fullname().to_string();
+    daemon
+        .register(service)
+        .map_err(|err| format!("register mdns service failed: {err}"))?;
+    Ok(fullname)
+}
+
+fn spawn_mdns_worker(
+    identity: DeviceIdentity,
+    runtime: Arc<Mutex<DiscoveryRuntime>>,
+    discovery_port: u16,
+    space_sync_ws_port: u16,
+) {
+    if std::env::var("FINI_MDNS_DISABLED").ok().as_deref() == Some("1") {
+        return;
+    }
+
+    let builder = thread::Builder::new().name("fini-mdns-discovery".to_string());
+    let runtime_worker = runtime.clone();
+    let spawn_result = builder.spawn(move || {
+        let daemon = match ServiceDaemon::new() {
+            Ok(daemon) => daemon,
+            Err(err) => {
+                set_last_error(&runtime_worker, format!("start mdns daemon failed: {err}"));
+                return;
+            }
+        };
+
+        let browser = match daemon.browse(MDNS_SERVICE_TYPE) {
+            Ok(browser) => browser,
+            Err(err) => {
+                set_last_error(&runtime_worker, format!("start mdns browse failed: {err}"));
+                return;
+            }
+        };
+
+        let mut last_add_mode = runtime_worker
+            .lock()
+            .map(|guard| guard.add_mode_enabled)
+            .unwrap_or(false);
+        let mut registered_fullname = match register_mdns_service(
+            &daemon,
+            &identity,
+            space_sync_ws_port,
+            last_add_mode,
+        ) {
+            Ok(fullname) => Some(fullname),
+            Err(err) => {
+                set_last_error(&runtime_worker, err);
+                None
+            }
+        };
+
+        if let Ok(mut guard) = runtime_worker.lock() {
+            guard.worker_started = true;
+        }
+
+        loop {
+            let add_mode = runtime_worker
+                .lock()
+                .map(|guard| guard.add_mode_enabled)
+                .unwrap_or(false);
+            if add_mode != last_add_mode {
+                if let Some(fullname) = registered_fullname.take() {
+                    let _ = daemon.unregister(&fullname);
+                }
+                registered_fullname = match register_mdns_service(
+                    &daemon,
+                    &identity,
+                    space_sync_ws_port,
+                    add_mode,
+                ) {
+                    Ok(fullname) => Some(fullname),
+                    Err(err) => {
+                        set_last_error(&runtime_worker, err);
+                        None
+                    }
+                };
+                last_add_mode = add_mode;
+            }
+
+            match browser.recv_timeout(Duration::from_millis(500)) {
+                Ok(ServiceEvent::ServiceResolved(info)) => {
+                    if service_txt(&info, "devid") == Some(identity.device_id.as_str()) {
+                        continue;
+                    }
+
+                    if let Ok(mut guard) = runtime_worker.lock() {
+                        guard.rx_count += 1;
+                        let presence = upsert_mdns_peer(&mut guard.presence, &info, discovery_port);
+                        if let Some((device_id, add_mode)) = presence {
+                            if add_mode {
+                                let is_new = !guard.discovered.contains_key(device_id.as_str());
+                                let _ = upsert_mdns_peer(&mut guard.discovered, &info, discovery_port);
+                                if is_new {
+                                    eprintln!(
+                                        "[device-sync] mdns discovered peer {} ({})",
+                                        info.get_fullname(), device_id
+                                    );
+                                }
+                            } else {
+                                guard.discovered.remove(&device_id);
+                            }
+                        }
+                    }
+                }
+                Ok(_) => {}
+                Err(err) => {
+                    if err.to_string().contains("timed out") {
+                        continue;
+                    }
+                    set_last_error(&runtime_worker, format!("mdns browse recv failed: {err}"));
+                    break;
+                }
+            }
+        }
+    });
+
+    if let Err(err) = spawn_result {
+        set_last_error(&runtime, format!("spawn mdns worker failed: {err}"));
+    }
+}
+
 fn broadcast_beacon(
     socket: &UdpSocket,
     runtime: &Arc<Mutex<DiscoveryRuntime>>,
     identity: &DeviceIdentity,
     mode: &str,
+    discovery_port: u16,
+    broadcast_ports: &[u16],
+    space_sync_ws_port: u16,
 ) {
     let beacon = DiscoveryBeacon {
         protocol: DISCOVERY_PROTOCOL.to_string(),
@@ -136,19 +334,30 @@ fn broadcast_beacon(
         device_id: identity.device_id.clone(),
         hostname: identity.hostname.clone(),
         sent_at: utc_now(),
-        ws_port: Some(SPACE_SYNC_WS_PORT),
+        discovery_port: Some(discovery_port),
+        ws_port: Some(space_sync_ws_port),
     };
 
     let payload = serde_json::to_vec(&beacon);
     match payload {
         Ok(body) => {
-            let multicast_target = SocketAddr::from((MULTICAST_GROUP, DISCOVERY_PORT));
-            let broadcast_target =
-                SocketAddr::from((Ipv4Addr::new(255, 255, 255, 255), DISCOVERY_PORT));
+            let mut sent = false;
+            let mut last_error: Option<String> = None;
 
-            let send_multicast = socket.send_to(&body, multicast_target);
-            let send_broadcast = socket.send_to(&body, broadcast_target);
-            let sent = send_multicast.is_ok() || send_broadcast.is_ok();
+            for port in broadcast_ports {
+                let multicast_target = SocketAddr::from((MULTICAST_GROUP, *port));
+                let broadcast_target = SocketAddr::from((Ipv4Addr::new(255, 255, 255, 255), *port));
+
+                match socket.send_to(&body, multicast_target) {
+                    Ok(_) => sent = true,
+                    Err(err) => last_error = Some(format!("multicast send error: {err}")),
+                }
+
+                match socket.send_to(&body, broadcast_target) {
+                    Ok(_) => sent = true,
+                    Err(err) => last_error = Some(format!("broadcast send error: {err}")),
+                }
+            }
 
             if let Ok(mut guard) = runtime.lock() {
                 guard.last_broadcast_at = Some(beacon.sent_at);
@@ -156,11 +365,8 @@ fn broadcast_beacon(
                     guard.tx_count += 1;
                 }
 
-                if let Err(err) = send_multicast {
-                    guard.last_error = Some(format!("multicast send error: {err}"));
-                }
-                if let Err(err) = send_broadcast {
-                    guard.last_error = Some(format!("broadcast send error: {err}"));
+                if let Some(err) = last_error {
+                    guard.last_error = Some(err);
                 }
             }
         }
@@ -171,16 +377,35 @@ fn broadcast_beacon(
     }
 }
 
+fn bind_discovery_socket(discovery_port: u16) -> std::io::Result<UdpSocket> {
+    let socket = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP))?;
+    socket.set_reuse_address(true)?;
+    #[cfg(any(target_os = "linux", target_os = "android", target_vendor = "apple"))]
+    socket.set_reuse_port(true)?;
+    socket.bind(&SocketAddr::from(([0, 0, 0, 0], discovery_port)).into())?;
+    Ok(socket.into())
+}
+
 pub(super) fn spawn_discovery_worker(
     identity: DeviceIdentity,
     runtime: Arc<Mutex<DiscoveryRuntime>>,
+    discovery_port: u16,
+    broadcast_ports: Vec<u16>,
+    space_sync_ws_port: u16,
 ) {
+    spawn_mdns_worker(
+        identity.clone(),
+        runtime.clone(),
+        discovery_port,
+        space_sync_ws_port,
+    );
+
     let builder = thread::Builder::new().name("fini-device-discovery".to_string());
     let runtime_worker = runtime.clone();
 
     let spawn_result = builder.spawn(move || {
         let runtime = runtime_worker;
-        let socket = match UdpSocket::bind(("0.0.0.0", DISCOVERY_PORT)) {
+        let socket = match bind_discovery_socket(discovery_port) {
             Ok(sock) => sock,
             Err(err) => {
                 let message = format!("bind discovery socket failed: {err}");
@@ -213,13 +438,29 @@ pub(super) fn spawn_discovery_worker(
             let now = Instant::now();
 
             if now >= next_heartbeat_at {
-                broadcast_beacon(&socket, &runtime, &identity, "heartbeat");
+                broadcast_beacon(
+                    &socket,
+                    &runtime,
+                    &identity,
+                    "heartbeat",
+                    discovery_port,
+                    &broadcast_ports,
+                    space_sync_ws_port,
+                );
                 next_heartbeat_at = now + heartbeat_interval;
             }
 
             if add_mode_enabled {
                 if now >= next_add_broadcast_at {
-                    broadcast_beacon(&socket, &runtime, &identity, "add");
+                    broadcast_beacon(
+                        &socket,
+                        &runtime,
+                        &identity,
+                        "add",
+                        discovery_port,
+                        &broadcast_ports,
+                        space_sync_ws_port,
+                    );
                     next_add_broadcast_at = now + discovery_interval;
                 }
             } else {
@@ -235,13 +476,13 @@ pub(super) fn spawn_discovery_worker(
                             if let Ok(mut guard) = runtime.lock() {
                                 guard.rx_count += 1;
 
-                                upsert_seen_peer(&mut guard.presence, &beacon, addr.ip());
+                                upsert_seen_peer(&mut guard.presence, &beacon, addr.ip(), discovery_port);
 
                                 if guard.add_mode_enabled && beacon.mode == "add" {
                                     let is_new =
                                         !guard.discovered.contains_key(beacon.device_id.as_str());
 
-                                    upsert_seen_peer(&mut guard.discovered, &beacon, addr.ip());
+                                    upsert_seen_peer(&mut guard.discovered, &beacon, addr.ip(), discovery_port);
 
                                     if is_new {
                                         eprintln!(
@@ -381,6 +622,7 @@ pub(super) fn spawn_discovery_worker(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::services::device_connection::{DISCOVERY_PORT, SPACE_SYNC_WS_PORT};
     use chrono::Duration as ChronoDuration;
     use std::path::PathBuf;
 
@@ -397,6 +639,8 @@ mod tests {
             request_id: "req-1".to_string(),
             from_device_id: "device-a".to_string(),
             from_hostname: "alpha".to_string(),
+            from_discovery_port: Some(DISCOVERY_PORT),
+            from_ws_port: Some(SPACE_SYNC_WS_PORT),
             to_device_id: "device-b".to_string(),
             created_at: "2000-01-01T00:00:00Z".to_string(),
             expires_at: expires_at.to_string(),
@@ -415,6 +659,7 @@ mod tests {
                 cooldown_until: None,
             },
             from_addr: "127.0.0.1".to_string(),
+            from_ws_port: Some(SPACE_SYNC_WS_PORT),
         }
     }
 
@@ -425,6 +670,7 @@ mod tests {
             device_id: device_id.to_string(),
             hostname: hostname.to_string(),
             sent_at: utc_now(),
+            discovery_port: Some(DISCOVERY_PORT),
             ws_port: Some(SPACE_SYNC_WS_PORT),
         }
     }
@@ -471,11 +717,13 @@ mod tests {
             &mut peers,
             &first,
             "192.168.1.10".parse().expect("parse ip"),
+            DISCOVERY_PORT,
         );
         upsert_seen_peer(
             &mut peers,
             &second,
             "192.168.1.11".parse().expect("parse ip"),
+            DISCOVERY_PORT,
         );
 
         let peer = peers.get("device-a").expect("peer should exist");
@@ -519,7 +767,10 @@ mod tests {
     fn incoming_pair_request_uses_receiver_local_ttl() {
         let payload = sample_pair_request_payload("1999-01-01T00:00:00Z");
         let before = Utc::now();
-        let stored = build_incoming_pair_request(&payload, "192.168.1.50".to_string());
+        let stored = build_incoming_pair_request(
+            &payload,
+            "192.168.1.50".to_string(),
+        );
         let after = Utc::now();
 
         assert_eq!(stored.request.request_id, payload.request_id);

--- a/src-tauri/src/services/device_connection/types.rs
+++ b/src-tauri/src/services/device_connection/types.rs
@@ -15,6 +15,7 @@ pub struct DiscoveredDevice {
     pub device_id: String,
     pub hostname: String,
     pub addr: String,
+    pub discovery_port: u16,
     pub ws_port: Option<u16>,
     pub last_seen_at: String,
 }
@@ -31,6 +32,7 @@ pub struct DeviceConnectionDebugStatus {
     pub last_broadcast_at: Option<String>,
     pub last_error: Option<String>,
     pub discovery_port: u16,
+    pub discovery_provider: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -85,6 +87,7 @@ pub struct DevicePairRequestInput {
     pub request_id: String,
     pub to_device_id: String,
     pub to_addr: String,
+    pub to_ws_port: Option<u16>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -100,23 +103,29 @@ pub(super) struct DiscoveryBeacon {
     pub hostname: String,
     pub sent_at: String,
     #[serde(default)]
+    pub discovery_port: Option<u16>,
+    #[serde(default)]
     pub ws_port: Option<u16>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(super) struct PairRequestPayload {
+pub(crate) struct PairRequestPayload {
     pub protocol: String,
     pub kind: String,
     pub request_id: String,
     pub from_device_id: String,
     pub from_hostname: String,
+    #[serde(default)]
+    pub from_discovery_port: Option<u16>,
+    #[serde(default)]
+    pub from_ws_port: Option<u16>,
     pub to_device_id: String,
     pub created_at: String,
     pub expires_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(super) struct PairAcceptPayload {
+pub(crate) struct PairAcceptPayload {
     pub protocol: String,
     pub kind: String,
     pub request_id: String,
@@ -127,7 +136,7 @@ pub(super) struct PairAcceptPayload {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(super) struct PairCompletePayload {
+pub(crate) struct PairCompletePayload {
     pub protocol: String,
     pub kind: String,
     pub request_id: String,
@@ -141,12 +150,14 @@ pub(super) struct PairCompletePayload {
 pub(super) struct StoredIncomingPairRequest {
     pub request: IncomingPairRequest,
     pub from_addr: String,
+    pub from_ws_port: Option<u16>,
 }
 
 #[derive(Debug, Clone)]
 pub(super) struct SeenPeer {
     pub hostname: String,
     pub addr: String,
+    pub discovery_port: u16,
     pub ws_port: Option<u16>,
     pub last_seen_at: String,
     pub last_seen_mono: Instant,

--- a/src-tauri/src/services/space_sync/types.rs
+++ b/src-tauri/src/services/space_sync/types.rs
@@ -2,6 +2,9 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 
 use crate::services::device_connection::CustomSpaceDescriptor;
+use crate::services::device_connection::types::{
+    PairAcceptPayload, PairCompletePayload, PairRequestPayload,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SyncEventEnvelope {
@@ -31,6 +34,12 @@ pub enum WsMessage {
     AuthOk,
     #[serde(rename = "auth_fail")]
     AuthFail { reason: String },
+    #[serde(rename = "pair_request")]
+    PairRequest(PairRequestPayload),
+    #[serde(rename = "pair_accept")]
+    PairAccept(PairAcceptPayload),
+    #[serde(rename = "pair_complete")]
+    PairComplete(PairCompletePayload),
     #[serde(rename = "sync_event")]
     SyncEvent(SyncEventEnvelope),
     #[serde(rename = "ack")]

--- a/src-tauri/src/services/space_sync/ws_client.rs
+++ b/src-tauri/src/services/space_sync/ws_client.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use futures_util::{SinkExt, StreamExt};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 
-use crate::services::device_connection::{DeviceConnectionState, SPACE_SYNC_WS_PORT};
+use crate::services::device_connection::DeviceConnectionState;
 use crate::services::space_sync::types::WsMessage;
 use crate::services::space_sync::ws_session;
 
@@ -14,7 +14,7 @@ pub fn ensure_peer_sessions(state: &DeviceConnectionState, db_path: PathBuf) {
     let my_id = state.identity.device_id.clone();
     let peers = state.list_presenced_peers();
 
-    for (peer_id, addr) in peers {
+    for (peer_id, addr, ws_port) in peers {
         if my_id >= peer_id {
             continue; // The peer is the dialer for this pair
         }
@@ -25,7 +25,7 @@ pub fn ensure_peer_sessions(state: &DeviceConnectionState, db_path: PathBuf) {
         let db_path = db_path.clone();
         let peer_id_clone = peer_id.clone();
         tauri::async_runtime::spawn(async move {
-            dial_with_backoff(state, db_path, peer_id_clone, addr).await;
+            dial_with_backoff(state, db_path, peer_id_clone, addr, ws_port).await;
         });
     }
 }
@@ -35,6 +35,7 @@ async fn dial_with_backoff(
     db_path: PathBuf,
     peer_id: String,
     addr: String,
+    ws_port: u16,
 ) {
     let mut delay = Duration::from_secs(1);
     let max_delay = Duration::from_secs(30);
@@ -48,12 +49,12 @@ async fn dial_with_backoff(
         let still_present = state
             .list_presenced_peers()
             .into_iter()
-            .any(|(id, _)| id == peer_id);
+            .any(|(id, _, _)| id == peer_id);
         if !still_present {
             return;
         }
 
-        let url = format!("ws://{}:{}", addr, SPACE_SYNC_WS_PORT);
+        let url = format!("ws://{}:{}", addr, ws_port);
         match connect_async(&url).await {
             Ok((ws, _)) => {
                 let (mut sink, mut source) = ws.split();

--- a/src-tauri/src/services/space_sync/ws_server.rs
+++ b/src-tauri/src/services/space_sync/ws_server.rs
@@ -7,12 +7,13 @@ use tokio_tungstenite::accept_async;
 use tokio_tungstenite::tungstenite::Message;
 
 use crate::services::db::open_db_at_path;
-use crate::services::device_connection::{DeviceConnectionState, SPACE_SYNC_WS_PORT};
+use crate::services::device_connection::DeviceConnectionState;
 use crate::services::space_sync::types::WsMessage;
 use crate::services::space_sync::ws_session;
 
 pub async fn run_ws_server(state: DeviceConnectionState, db_path: PathBuf) {
-    run_ws_server_on_port(state, db_path, SPACE_SYNC_WS_PORT).await;
+    let port = state.space_sync_ws_port;
+    run_ws_server_on_port(state, db_path, port).await;
 }
 
 pub(crate) async fn run_ws_server_on_port(
@@ -53,6 +54,10 @@ async fn handle_connection(
     state: DeviceConnectionState,
     db_path: PathBuf,
 ) -> Result<(), String> {
+    let peer_ip = stream
+        .peer_addr()
+        .map(|addr| addr.ip().to_string())
+        .unwrap_or_default();
     let ws = accept_async(stream)
         .await
         .map_err(|e| format!("WS handshake: {}", e))?;
@@ -68,19 +73,33 @@ async fn handle_connection(
         return Ok(());
     };
 
-    let WsMessage::Auth {
-        device_id,
-        peer_device_id,
-    } = msg
-    else {
-        send_msg(
-            &mut sink,
-            &WsMessage::AuthFail {
-                reason: "expected auth first".into(),
-            },
-        )
-        .await;
-        return Ok(());
+    let (device_id, peer_device_id) = match msg {
+        WsMessage::PairRequest(payload) => {
+            state.receive_ws_pair_request(payload, peer_ip)?;
+            return Ok(());
+        }
+        WsMessage::PairAccept(payload) => {
+            state.receive_ws_pair_accept(payload)?;
+            return Ok(());
+        }
+        WsMessage::PairComplete(payload) => {
+            state.receive_ws_pair_complete(payload)?;
+            return Ok(());
+        }
+        WsMessage::Auth {
+            device_id,
+            peer_device_id,
+        } => (device_id, peer_device_id),
+        _ => {
+            send_msg(
+                &mut sink,
+                &WsMessage::AuthFail {
+                    reason: "expected auth first".into(),
+                },
+            )
+            .await;
+            return Ok(());
+        }
     };
 
     if peer_device_id != state.identity.device_id {

--- a/src-tauri/src/services/space_sync/ws_session.rs
+++ b/src-tauri/src/services/space_sync/ws_session.rs
@@ -123,6 +123,11 @@ async fn handle_inbound<Sk>(
             });
         }
         // Sent by this side, not expected inbound
-        WsMessage::Auth { .. } | WsMessage::AuthOk | WsMessage::AuthFail { .. } => {}
+        WsMessage::Auth { .. }
+        | WsMessage::AuthOk
+        | WsMessage::AuthFail { .. }
+        | WsMessage::PairRequest(_)
+        | WsMessage::PairAccept(_)
+        | WsMessage::PairComplete(_) => {}
     }
 }

--- a/src/stores/device.ts
+++ b/src/stores/device.ts
@@ -15,6 +15,7 @@ export interface DiscoveredDevice {
   device_id: string;
   hostname: string;
   addr: string;
+  discovery_port: number;
   ws_port: number | null;
   last_seen_at: string;
 }
@@ -50,6 +51,7 @@ export interface DeviceConnectionDebugStatus {
   last_broadcast_at: string | null;
   last_error: string | null;
   discovery_port: number;
+  discovery_provider: string;
 }
 
 export interface PairCodeUpdate {
@@ -127,6 +129,7 @@ interface DevicePairRequestInput {
   request_id: string;
   to_device_id: string;
   to_addr: string;
+  to_ws_port?: number | null;
 }
 
 interface DevicePairRequestAckInput {
@@ -703,6 +706,7 @@ export const useDeviceStore = defineStore("device", () => {
       request_id: requestId,
       to_device_id: device.device_id,
       to_addr: device.addr,
+      to_ws_port: device.ws_port,
     };
 
     outgoingRequest.value = {

--- a/src/views/AddDeviceView.vue
+++ b/src/views/AddDeviceView.vue
@@ -132,12 +132,14 @@ function rejectRequest(requestId: string) {
       </p>
     </section>
 
-    <section v-if="deviceStore.incomingRequests.length" class="rounded-xl bg-base-200 p-3">
+    <section v-if="deviceStore.incomingRequests.length" class="rounded-xl bg-base-200 p-3" data-testid="incoming-requests">
       <h2 class="mb-2 text-sm font-semibold uppercase tracking-wide opacity-70">Incoming requests</h2>
       <ul class="flex flex-col gap-2">
         <li
           v-for="request in deviceStore.incomingRequests"
           :key="request.request_id"
+          data-testid="incoming-request-row"
+          :data-from-hostname="request.from_hostname"
           class="rounded-lg bg-base-100 p-3"
         >
           <p class="text-sm font-medium">{{ request.from_hostname }}</p>
@@ -148,7 +150,7 @@ function rejectRequest(requestId: string) {
             v-if="!acceptedIncomingByRequest[request.request_id]"
             class="mt-2 flex flex-wrap gap-2"
           >
-            <button class="btn btn-sm btn-primary" @click="void acceptRequest(request.request_id)">Accept</button>
+            <button class="btn btn-sm btn-primary" data-testid="accept-incoming-request" @click="void acceptRequest(request.request_id)">Accept</button>
             <button class="btn btn-sm btn-ghost" @click="rejectRequest(request.request_id)">Reject</button>
           </div>
           <div v-else class="mt-2 flex gap-2">
@@ -159,9 +161,10 @@ function rejectRequest(requestId: string) {
               inputmode="numeric"
               pattern="[0-9]*"
               class="input input-bordered input-sm w-28"
+              data-testid="pair-code-input"
               placeholder="6-digit"
             />
-            <button class="btn btn-sm" @click="void submitCode(request.request_id)">Submit code</button>
+            <button class="btn btn-sm" data-testid="pair-code-submit" @click="void submitCode(request.request_id)">Submit code</button>
           </div>
           <p v-if="request.cooldown_until && incomingSecondsLeft(request.cooldown_until) > 0" class="mt-2 text-xs text-warning">
             Too many wrong codes. Try again in {{ incomingSecondsLeft(request.cooldown_until) }}s.
@@ -170,16 +173,17 @@ function rejectRequest(requestId: string) {
       </ul>
     </section>
 
-    <section class="rounded-xl bg-base-200 p-3">
+    <section class="rounded-xl bg-base-200 p-3" data-testid="nearby-devices">
       <h2 class="mb-2 text-sm font-semibold uppercase tracking-wide opacity-70">Nearby devices</h2>
       <ul class="flex flex-col gap-1">
-        <li v-for="device in deviceStore.discoveredDevices" :key="device.device_id">
+        <li v-for="device in deviceStore.discoveredDevices" :key="device.device_id" data-testid="nearby-device-row" :data-device-hostname="device.hostname" :data-device-id="device.device_id">
           <div class="flex items-center gap-3 rounded-lg bg-base-100 px-3 py-2">
             <span class="h-2.5 w-2.5 rounded-full bg-green-500" />
             <span class="flex-1 text-sm font-medium">{{ device.hostname }}</span>
             <span class="text-xs opacity-60">{{ deviceStore.shortDeviceId(device.device_id) }} · {{ device.addr }}</span>
             <button
               class="btn btn-sm btn-primary"
+              data-testid="request-pair"
               :disabled="outgoingPending"
               @click="void requestPair(device.device_id)"
             >
@@ -196,7 +200,7 @@ function rejectRequest(requestId: string) {
       </p>
     </section>
 
-    <section v-if="deviceStore.outgoingRequest" class="rounded-xl bg-base-200 p-3">
+    <section v-if="deviceStore.outgoingRequest" class="rounded-xl bg-base-200 p-3" data-testid="outgoing-pair-request">
       <h2 class="mb-2 text-sm font-semibold uppercase tracking-wide opacity-70">Pair request</h2>
       <p class="text-sm font-medium">{{ deviceStore.outgoingRequest.to_hostname }}</p>
       <p class="text-xs opacity-60">
@@ -207,7 +211,7 @@ function rejectRequest(requestId: string) {
       </p>
       <div v-if="deviceStore.outgoingRequest.sender_code" class="mt-2 rounded-lg bg-base-100 px-3 py-2">
         <p class="text-xs opacity-60">Share this code with the receiving device</p>
-        <p class="font-mono text-lg tracking-wider">{{ deviceStore.outgoingRequest.sender_code }}</p>
+        <p class="font-mono text-lg tracking-wider" data-testid="pair-code">{{ deviceStore.outgoingRequest.sender_code }}</p>
       </div>
       <button class="btn btn-sm btn-ghost mt-2" @click="deviceStore.cancelOutgoingRequest()">Cancel request</button>
     </section>

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -76,10 +76,10 @@ function cancelEdit() {
       </div>
     </section>
 
-    <section class="rounded-xl bg-base-200 p-3">
+    <section class="rounded-xl bg-base-200 p-3" data-testid="settings-devices">
       <h2 class="mb-3 text-sm font-semibold uppercase tracking-wide opacity-70">Devices</h2>
       <ul class="flex flex-col gap-1">
-        <li v-for="device in deviceStore.pairedDevices" :key="device.peer_device_id">
+        <li v-for="device in deviceStore.pairedDevices" :key="device.peer_device_id" data-testid="paired-device-row" :data-peer-device-id="device.peer_device_id">
           <router-link
             :to="`/settings/device/${device.peer_device_id}`"
             class="flex items-center gap-3 rounded-lg bg-base-100 px-3 py-2"
@@ -88,7 +88,7 @@ function cancelEdit() {
               class="h-2.5 w-2.5 rounded-full"
               :class="deviceStore.isDeviceOnline(device) ? 'bg-green-500' : 'bg-gray-400'"
             />
-            <span class="flex-1 text-sm font-medium">{{ device.display_name }}</span>
+            <span class="flex-1 text-sm font-medium" data-testid="paired-device-name">{{ device.display_name }}</span>
             <span class="text-xs opacity-60">{{ deviceStore.shortDeviceId(device.peer_device_id) }}</span>
             <span class="text-sm opacity-50">›</span>
           </router-link>
@@ -102,6 +102,7 @@ function cancelEdit() {
         <li>
           <router-link
             to="/settings/add-device"
+            data-testid="add-device-link"
             class="flex items-center gap-3 rounded-lg bg-base-100 px-3 py-2"
           >
             <span class="text-base leading-none">+</span>


### PR DESCRIPTION
## Summary
- Replace fixed-port custom discovery assumptions with `mdns-sd` service publishing/browsing for `_fini-sync._tcp.local.`.
- Move pair request/accept/complete transport onto WebSocket messages while keeping sync auth/session handling intact.
- Add visible/headless multi-actor E2E infrastructure plus reusable `ensureSyncedActors` helpers for future synced-device tests.
- Add repo-local `fini-dev` and `save-to-wiki` skills.

Closes #17

## Verification
- `cargo check`
- `cargo test` (58 passed)
- `npm run build`
- `npm run test:e2e` (2 passed)
- `npm run test:e2e:ci` (11 passed)

## Notes
- Wiki raw docs were created in the sibling `fini-wiki` repo for future ingestion, but are not part of this PR.
- UDP discovery compatibility scaffolding still exists during this migration pass; mDNS now populates peer presence/discovery and WebSocket handles pairing messages.