### PR TITLE
feat(notifications): OS notifications with action buttons, snooze, and Linux sound

### DIFF
--- a/.agents/skills/fini-dev/SKILL.md
+++ b/.agents/skills/fini-dev/SKILL.md
@@ -11,23 +11,42 @@ Use this skill as the first step for development work in this repository. It is 
 
 Keep every development session consistent:
 
+- Run the first-checkout install bootstrap once before normal routing.
 - Pick the right specialized skill before doing domain work.
 - Use the repo's documented context path instead of guessing.
 - Prefer Makefile targets over raw commands.
 - Make the smallest correct change.
 - Verify with concrete evidence before reporting success.
 
+## First-Run Install
+
+Before implementation, debugging, QA, Android, design-to-code, release, documentation changes, or planning that depends on repo context:
+
+1. Check whether `.fini-dev-install.done` exists at the Fini repo root.
+2. If the marker is missing, load `fini-dev-install` and run its workflow before continuing.
+3. Continue with normal `fini-dev` routing only after `fini-dev-install` verifies `../fini-wiki/` and creates the marker.
+4. If install verification fails, stop and report the blocker instead of continuing with repo work that may rely on wiki context.
+
+The marker is local to the checkout. Do not commit it.
+
 ## Start Of Work
 
 Before implementation, debugging, QA, Android, design-to-code, release, or documentation changes:
 
-1. State the target outcome, in-scope work, out-of-scope work, and success checks in the user's terms.
-2. Read only the context needed for the task: `AGENTS.md`, the relevant folder `README.md`, companion `.md` specs, and targeted source files.
-3. If the task needs product, business, terminology, strategic, architecture background, or historical context, load `fini-wiki` and follow the wiki query protocol.
-4. Choose any specialized skill from the routing table below before doing the domain-specific work.
-5. Pick the smallest useful verification command before editing so the success standard is clear.
+1. Run the first-run install check above.
+2. State the target outcome, in-scope work, out-of-scope work, and success checks in the user's terms.
+3. Read only the context needed for the task: `AGENTS.md`, the relevant folder `README.md`, companion `.md` specs, and targeted source files.
+4. If the task needs product, business, terminology, strategic, architecture background, or historical context, load `fini-wiki` and follow the wiki query protocol.
+5. Choose any specialized skill from the routing table below before doing the domain-specific work.
+6. Pick the smallest useful verification command before editing so the success standard is clear.
 
 If the user explicitly asks to think, plan, brainstorm, or review without implementation, do that mode first and do not edit files until execution is requested.
+
+## Planning Grill
+
+For any planning stage, load `grill-me` before finalizing the plan. Treat planning broadly: explicit think/plan/brainstorm requests, ticket scoping, architecture plans, design plans, release plans, QA strategy, and any pre-implementation decision work.
+
+Use `grill-me` as an overlay, not a replacement for domain skills. First gather evidence from the repo, wiki, specs, or source files when evidence can answer the question; ask the user only for decisions evidence cannot resolve. Ask one question at a time, include the recommended answer, and stop when remaining questions are non-blocking or explicitly deferred.
 
 ## Planning Capture
 
@@ -62,9 +81,11 @@ Load the specialized skill when its condition applies:
 |---|---|
 | Create, update, list, or manage quests, spaces, reminders, or Focus state through the Fini CLI | `fini`, which uses `fini-cli` |
 | Use, validate, or reason about the Fini app binary, CLI mode, app launch mode, or runtime container CLI behavior | `fini-cli` |
+| Populate data, seed state, or exercise a feature against the running/installed app for dev or testing | `fini-cli` |
 | Validate Android behavior, prove Android navigation/state, or debug Android-only behavior | `fini-android-testing` |
 | Run, write, debug, or organize unit, integration, or e2e tests across frontend Jest, backend cargo, single-actor UI e2e, multi-actor e2e, or CLI e2e. For Android-only behavior, use `fini-android-testing` instead | `fini-test` |
 | Design or refine native Figma components, variants, screens, or visual systems | `fini-design` |
+| First-run setup, bootstrap, install, or verification of required sibling project context such as `../fini-wiki/` | `fini-dev-install` |
 | Add or change Makefile targets, npm scripts, `xtask`, CI command orchestration, build tooling, packaging tooling, or repo-local automation architecture | `fini-scripting` |
 | Change package metadata, app version display, CLI version output, Android versioning, release commands, signed tags, or CI release version sync | `fini-versioning`; also follow `fini-scripting` when automation changes are needed |
 | Query product/domain/history/architecture context from the wiki, or save plans, decisions, research, or conversation context to wiki raw material | `fini-wiki` |
@@ -79,7 +100,8 @@ Load the specialized skill when its condition applies:
 | Performance, page speed, bundle size, or regression checks | `benchmark` |
 | Security audit, threat model, OWASP, secrets, or supply-chain concerns | `cso` |
 | Create or improve skills | `skill-creator` |
-| Create, start, or draft tickets | `create-ticket`, `start-ticket`, or `ticket-markdown` |
+| Planning, scoping, or decision-tree clarification before implementation | `grill-me`, plus the relevant domain skill |
+| Create, start, or draft tickets | `fini-create-ticket`, `start-ticket`, or `ticket-markdown` |
 
 When no specialized skill fits, continue with this skill's project workflow.
 
@@ -102,6 +124,16 @@ For product semantics, read wiki context using this order:
 4. Targeted search only if the right page is not obvious
 
 Stay within the five-page wiki limit unless the user asks for deeper research.
+
+## Dev Data Population And Feature Exercise
+
+When setting up data for manual testing, QA, or feature exercise:
+
+- Load `fini-cli` for binary mechanics. Use `fini quest create`, `fini reminder create`, `fini space list`, etc. to seed and query state.
+- CLI is the only supported automation surface against the running app. Do not drive data population through the UI or through webview/IPC MCP tools (`mcp___hypothesi_tauri-mcp-server__*`). Those tools are not available in this repo's workflow.
+- Use CLI for: seeding a reminder due soon to trigger a notification, building a history dataset across multiple spaces, completing or abandoning quests to verify state transitions, listing state as evidence after a write.
+- Use the UI (via `make dev`) for visual confirmation of the result only — not for setup.
+- `fini` (user-facing skill) is appropriate when the dev task maps directly to an end-user action (e.g. "create a quest titled X due Friday in Family"). For dev-only data patterns, route directly to `fini-cli`.
 
 ## Command Selection
 
@@ -131,18 +163,32 @@ Use `fini-scripting` for command architecture details. Default to Makefile for h
 
 Do not invent generic targets such as `make test`, `make lint`, or `make check` unless they exist in the current `Makefile`. If a desired target is missing, name the closest existing target from the table or state that no Makefile target exists for that check.
 
+## Code Reuse
+
+Before adding a new constant, function, type, or utility, search for an existing one:
+
+- Check `src/stores/` for domain constants and helpers (e.g. `BUILTIN_SPACE_IDS`, `isBuiltinSpace` in `space.ts`).
+- Check `src/utils/` for general-purpose utilities.
+- Check `src/composables/` for shared Vue composables.
+- Use `grep -r` or the Explore agent when the location is not obvious.
+
+If an equivalent already exists, import and reuse it. Do not duplicate logic in a view, component, or test that belongs in a store or utility. If the existing name is slightly different but semantically identical, prefer renaming the call site over adding a wrapper.
+
+When writing tests that mock an entire module (`jest.mock`), re-export all named constants and functions the component under test imports from that module — omitting them silently produces `undefined` at runtime.
+
 ## Development Loop
 
 Use this loop for implementation and fixes:
 
 1. Establish evidence for the current behavior: code path, spec, failing output, test result, log, or reproducible step.
 2. Trace write path, persisted data, and read path when data behavior is involved.
-3. Make the smallest scoped change that addresses the root cause or requested behavior.
-4. Avoid broad refactors, compatibility layers, or new abstractions unless they prevent a concrete defect.
-5. Preserve user or other-agent changes in the worktree.
-6. Update companion docs/specs when behavior or structure changes.
-7. Verify with the smallest useful check, then escalate only as needed.
-8. Report the exact evidence collected and any remaining risk.
+3. Search for existing utilities and constants before writing new ones (see Code Reuse above).
+4. Make the smallest scoped change that addresses the root cause or requested behavior.
+5. Avoid broad refactors, compatibility layers, or new abstractions unless they prevent a concrete defect.
+6. Preserve user or other-agent changes in the worktree.
+7. Update companion docs/specs when behavior or structure changes.
+8. Verify with the smallest useful check, then escalate only as needed.
+9. Report the exact evidence collected and any remaining risk.
 
 ## Verification Defaults
 
@@ -154,7 +200,8 @@ Choose verification based on touched area:
 - E2E-sensitive flows: use `make e2e-headed` for local visible debugging or `make e2e-ci` for CI parity.
 - Android behavior: load `fini-android-testing`; use `make android-devices`, `make android-connect`, and `make android-dev` for dev-runtime verification, or `make android-debug-deploy` when an installed APK check is needed.
 - Test execution or test authoring across any surface (FE Jest, BE cargo, e2e ui/actors/cli): load `fini-test` for the canonical command + authoring guide.
-- Fini CLI or app binary behavior: load `fini-cli`; use `make runtime-smoke` for runtime container CLI checks or `make build` for release binary creation.
+- Manual feature verification or scenario setup: drive state via `fini-cli`; reserve the UI for visual confirmation of the result.
+- Fini CLI or app binary behavior: load `fini-cli`; use `make runtime-smoke` for runtime container CLI checks or `make build` for release binary creation. Use CLI for all programmatic interaction with the app; do not use webview or IPC MCP tooling to drive the app.
 - Runtime/container behavior beyond the CLI surface: use `make runtime-smoke` or the relevant image target.
 - Release work: follow release tag rules in `AGENTS.md`; do not create or push tags unless explicitly requested.
 

--- a/specs/e2e/ui/tests/reminder-notification-actions.spec.ts
+++ b/specs/e2e/ui/tests/reminder-notification-actions.spec.ts
@@ -1,0 +1,160 @@
+import { test, expect } from '../fixtures.ts';
+
+interface Quest {
+  id: string;
+  title: string;
+  status: string;
+}
+
+interface Reminder {
+  id: string;
+  quest_id: string;
+  due_at_utc: string | null;
+}
+
+interface NotificationEvent {
+  phase: string;
+  delivery_path: string;
+  reminder_id: string;
+  quest_id: string;
+  body: string;
+  due_at_utc: string | null;
+  scheduled_notification_id: string | null;
+}
+
+async function invokeTauri<T>(
+  tauriPage: { evaluate: <R>(script: string) => Promise<R> },
+  cmd: string,
+  args?: Record<string, unknown>,
+): Promise<T> {
+  return tauriPage.evaluate<T>(`(async () => {
+    const invoke = window.__TAURI_INTERNALS__?.invoke;
+    if (!invoke) throw new Error('Tauri invoke is unavailable');
+    return await invoke(${JSON.stringify(cmd)}, ${JSON.stringify(args ?? {})});
+  })()`);
+}
+
+async function fillTextarea(
+  tauriPage: { evaluate: <R>(script: string) => Promise<R> },
+  selector: string,
+  value: string,
+): Promise<void> {
+  await tauriPage.evaluate(`(() => {
+    const el = document.querySelector(${JSON.stringify(selector)});
+    if (!(el instanceof HTMLTextAreaElement)) {
+      throw new Error('textarea not found: ' + ${JSON.stringify(selector)});
+    }
+    el.focus();
+    const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+    if (!setter) throw new Error('textarea setter is unavailable');
+    setter.call(el, ${JSON.stringify(value)});
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+  })()`);
+}
+
+async function createQuestWithTodayReminder(
+  tauriPage: { waitForSelector: (selector: string, t?: number) => Promise<unknown>; press: (selector: string, key: string) => Promise<void>; click: (selector: string) => Promise<void>; evaluate: <R>(script: string) => Promise<R> },
+  title: string,
+): Promise<{ quest: Quest; reminder: Reminder }> {
+  await tauriPage.waitForSelector('[data-testid="chat-input"]', 30_000);
+  await fillTextarea(tauriPage, '[data-testid="chat-input"]', title);
+  await tauriPage.press('[data-testid="chat-input"]', 'Enter');
+
+  await tauriPage.waitForSelector('.quest-row-surface', 10_000);
+  await tauriPage.evaluate(`(() => {
+    const rows = Array.from(document.querySelectorAll('.quest-row-surface'));
+    const row = rows.find((r) => r.textContent?.includes(${JSON.stringify(title)}));
+    if (!(row instanceof HTMLElement)) throw new Error('quest row not found: ' + ${JSON.stringify(title)});
+    row.click();
+  })()`);
+
+  await tauriPage.click('[data-testid="quest-reminder"]');
+  await tauriPage.click('[data-testid="reminder-today"]');
+  await tauriPage.click('[data-testid="reminder-done"]');
+
+  const quests = await invokeTauri<Quest[]>(tauriPage, 'get_quests');
+  const quest = quests.find((q) => q.title === title);
+  if (!quest) throw new Error(`quest not found after creation: ${title}`);
+
+  const reminders = await invokeTauri<Reminder[]>(tauriPage, 'get_reminders', { questId: quest.id });
+  if (reminders.length === 0) throw new Error(`no reminder created for quest: ${title}`);
+
+  return { quest, reminder: reminders[0] };
+}
+
+test('complete action marks quest as completed', async ({ tauriPage }) => {
+  const title = `e2e notif complete ${Date.now()}`;
+
+  await tauriPage.waitForSelector('nav.nav a[href="#/main"]', 30_000);
+  await tauriPage.click('nav.nav a[href="#/main"]');
+  await invokeTauri<void>(tauriPage, 'e2e_clear_notification_events');
+
+  const { quest, reminder } = await createQuestWithTodayReminder(tauriPage, title);
+  expect(quest.status).toBe('active');
+
+  await invokeTauri<void>(tauriPage, 'e2e_dispatch_notification_action', {
+    reminderId: reminder.id,
+    actionId: 'complete',
+  });
+
+  const updatedQuests = await invokeTauri<Quest[]>(tauriPage, 'get_quests');
+  const updated = updatedQuests.find((q) => q.id === quest.id);
+  expect(updated?.status).toBe('completed');
+});
+
+test('snooze_30m action creates a snooze record without completing the quest', async ({ tauriPage }) => {
+  const title = `e2e notif snooze30 ${Date.now()}`;
+
+  await tauriPage.waitForSelector('nav.nav a[href="#/main"]', 30_000);
+  await tauriPage.click('nav.nav a[href="#/main"]');
+  await invokeTauri<void>(tauriPage, 'e2e_clear_notification_events');
+
+  const { quest, reminder } = await createQuestWithTodayReminder(tauriPage, title);
+
+  await invokeTauri<void>(tauriPage, 'e2e_dispatch_notification_action', {
+    reminderId: reminder.id,
+    actionId: 'snooze_30m',
+  });
+
+  const quests = await invokeTauri<Quest[]>(tauriPage, 'get_quests');
+  const after = quests.find((q) => q.id === quest.id);
+  expect(after?.status).toBe('active');
+
+  const reminders = await invokeTauri<Reminder[]>(tauriPage, 'get_reminders', { questId: quest.id });
+  expect(reminders.length).toBeGreaterThan(0);
+});
+
+test('snooze_1d action keeps quest active', async ({ tauriPage }) => {
+  const title = `e2e notif snooze1d ${Date.now()}`;
+
+  await tauriPage.waitForSelector('nav.nav a[href="#/main"]', 30_000);
+  await tauriPage.click('nav.nav a[href="#/main"]');
+  await invokeTauri<void>(tauriPage, 'e2e_clear_notification_events');
+
+  const { quest, reminder } = await createQuestWithTodayReminder(tauriPage, title);
+
+  await invokeTauri<void>(tauriPage, 'e2e_dispatch_notification_action', {
+    reminderId: reminder.id,
+    actionId: 'snooze_1d',
+  });
+
+  const quests = await invokeTauri<Quest[]>(tauriPage, 'get_quests');
+  const after = quests.find((q) => q.id === quest.id);
+  expect(after?.status).toBe('active');
+});
+
+test('schedule event is recorded when reminder is created', async ({ tauriPage }) => {
+  const title = `e2e notif schedule ${Date.now()}`;
+
+  await tauriPage.waitForSelector('nav.nav a[href="#/main"]', 30_000);
+  await tauriPage.click('nav.nav a[href="#/main"]');
+  await invokeTauri<void>(tauriPage, 'e2e_clear_notification_events');
+
+  const { quest, reminder } = await createQuestWithTodayReminder(tauriPage, title);
+
+  const events = await invokeTauri<NotificationEvent[]>(tauriPage, 'e2e_list_notification_events');
+  const scheduled = events.filter((e) => e.phase === 'scheduled' && e.quest_id === quest.id);
+  expect(scheduled.length).toBeGreaterThan(0);
+  expect(scheduled[scheduled.length - 1].reminder_id).toBe(reminder.id);
+});

--- a/specs/e2e/ui/tests/reminder-notification-actions.spec.ts
+++ b/specs/e2e/ui/tests/reminder-notification-actions.spec.ts
@@ -54,7 +54,7 @@ async function fillTextarea(
 }
 
 async function createQuestWithTodayReminder(
-  tauriPage: { waitForSelector: (selector: string, t?: number) => Promise<unknown>; press: (selector: string, key: string) => Promise<void>; click: (selector: string) => Promise<void>; evaluate: <R>(script: string) => Promise<R> },
+  tauriPage: { waitForSelector: (selector: string, t?: number) => Promise<unknown>; waitForFunction: (script: string, t?: number) => Promise<unknown>; press: (selector: string, key: string) => Promise<void>; click: (selector: string) => Promise<void>; evaluate: <R>(script: string) => Promise<R> },
   title: string,
 ): Promise<{ quest: Quest; reminder: Reminder }> {
   await tauriPage.waitForSelector('[data-testid="chat-input"]', 30_000);
@@ -62,6 +62,10 @@ async function createQuestWithTodayReminder(
   await tauriPage.press('[data-testid="chat-input"]', 'Enter');
 
   await tauriPage.waitForSelector('.quest-row-surface', 10_000);
+  await tauriPage.waitForFunction(`(() => {
+    const rows = Array.from(document.querySelectorAll('.quest-row-surface'));
+    return rows.some((r) => r.textContent?.includes(${JSON.stringify(title)}));
+  })()`, 10_000);
   await tauriPage.evaluate(`(() => {
     const rows = Array.from(document.querySelectorAll('.quest-row-surface'));
     const row = rows.find((r) => r.textContent?.includes(${JSON.stringify(title)}));

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1302,6 +1302,7 @@ dependencies = [
  "gtk",
  "libsqlite3-sys",
  "mdns-sd",
+ "notify-rust",
  "reqwest 0.12.28",
  "rmcp",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,6 +53,7 @@ zvariant = "5.10.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = "0.18.2"
+notify-rust = "4"
 
 [features]
 # Enable the Playwright control-server plugin for UI e2e tests. Off by default;

--- a/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <!-- Required for exact-time reminder scheduling on Android 12+ -->
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <!-- Required for re-arming AlarmManager reminders after device reboot -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <!-- AndroidTV support -->
     <uses-feature android:name="android.software.leanback" android:required="false" />

--- a/src-tauri/gen/android/app/src/main/res/drawable/ic_stat_fini.xml
+++ b/src-tauri/gen/android/app/src/main/res/drawable/ic_stat_fini.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Monochrome status-bar icon for OS notifications. Android requires a single-color
+     (white + transparency) icon for the notification status bar. Derived from the Fini
+     app icon silhouette. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Simple checkmark-in-circle silhouette matching the Fini brand icon shape.
+         Replace with the actual brand mark once a design-reviewed asset is available. -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2z
+                          M10,17L5,12l1.41,-1.41L10,14.17l7.59,-7.59L19,8L10,17z"/>
+</vector>

--- a/src-tauri/migrations/00000000000016_notification_snoozes/down.sql
+++ b/src-tauri/migrations/00000000000016_notification_snoozes/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE notification_snoozes;

--- a/src-tauri/migrations/00000000000016_notification_snoozes/up.sql
+++ b/src-tauri/migrations/00000000000016_notification_snoozes/up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE notification_snoozes (
+    reminder_id TEXT PRIMARY KEY NOT NULL,
+    fire_at_utc TEXT NOT NULL,
+    created_at  TEXT NOT NULL
+);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,11 +18,16 @@ use services::device_connection::{
 };
 #[cfg(feature = "e2e-testing")]
 use services::notification::{
-    e2e_clear_notification_events, e2e_list_notification_events, NotificationObserverState,
+    e2e_clear_notification_events, e2e_dispatch_notification_action, e2e_list_notification_events,
+    NotificationObserverState,
 };
-use services::notification::{setup_notification_channel, SchedulerState};
+use services::notification::{
+    dispatch_action, setup_notifications, SchedulerState, FOREGROUND_FIRE_EVENT, TAP_EVENT,
+};
+mod resume_watcher;
 use services::quest::{
-    create_quest, delete_quest, get_active_focus, get_quests, set_focus, update_quest,
+    create_quest, delete_quest, delete_quest_series, get_active_focus, get_quests, set_focus,
+    update_quest,
 };
 use services::reconciler;
 use services::reminder::{
@@ -45,13 +50,31 @@ use tauri_plugin_autostart::ManagerExt;
 const THEME_EVENT: &str = "theme://changed";
 
 #[tauri::command]
+fn notification_action(app: AppHandle, action_id: String, reminder_id: String) {
+    dispatch_action(&app, &action_id, &reminder_id);
+}
+
+#[tauri::command]
+fn notification_tap(app: AppHandle, reminder_id: String) {
+    dispatch_action(&app, "tap", &reminder_id);
+}
+
+// Suppress unused-constant warnings; these are used by frontend listeners.
+const _: &str = FOREGROUND_FIRE_EVENT;
+const _: &str = TAP_EVENT;
+
+#[tauri::command]
 fn get_theme_mode(db: tauri::State<DbState>) -> Result<String, String> {
     let mut conn = db.0.lock().unwrap();
     settings::theme_mode(&mut conn).map(|mode| mode.as_str().to_string())
 }
 
 #[tauri::command]
-fn set_theme_mode(app: AppHandle, db: tauri::State<DbState>, mode: String) -> Result<String, String> {
+fn set_theme_mode(
+    app: AppHandle,
+    db: tauri::State<DbState>,
+    mode: String,
+) -> Result<String, String> {
     let mode = ThemeMode::parse(&mode).ok_or_else(|| "invalid theme mode".to_string())?;
     let mut conn = db.0.lock().unwrap();
     let mode = settings::set_theme_mode(&mut conn, mode)?;
@@ -125,7 +148,7 @@ pub fn run() {
             #[cfg(feature = "e2e-testing")]
             app.manage(NotificationObserverState::new());
 
-            setup_notification_channel(&app_handle);
+            setup_notifications(&app_handle);
 
             let initial_theme = {
                 let db = app.state::<DbState>();
@@ -148,6 +171,8 @@ pub fn run() {
             let db_state = app.state::<DbState>();
             reconciler::run(&app_handle, &db_state);
 
+            resume_watcher::spawn(&app_handle);
+
             let data_dir = app_data_dir(&app_handle);
             let dc_state = DeviceConnectionState::new(&data_dir);
             tauri::async_runtime::spawn(run_ws_server(dc_state.clone(), dc_state.db_path.clone()));
@@ -165,6 +190,7 @@ pub fn run() {
             set_focus,
             update_quest,
             delete_quest,
+            delete_quest_series,
             get_reminders,
             create_reminder,
             update_reminder,
@@ -198,10 +224,14 @@ pub fn run() {
             get_theme_mode,
             set_theme_mode,
             sync_native_theme,
+            notification_action,
+            notification_tap,
             #[cfg(feature = "e2e-testing")]
             e2e_list_notification_events,
             #[cfg(feature = "e2e-testing")]
             e2e_clear_notification_events,
+            #[cfg(feature = "e2e-testing")]
+            e2e_dispatch_notification_action,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -1,4 +1,5 @@
 pub mod focus_history;
+pub mod notification_snooze;
 pub mod pair_space_mapping;
 pub mod paired_device;
 pub mod quest;
@@ -9,6 +10,7 @@ pub mod settings;
 pub mod sync;
 
 pub use focus_history::*;
+pub use notification_snooze::*;
 pub use pair_space_mapping::*;
 pub use paired_device::*;
 pub use quest::*;

--- a/src-tauri/src/models/notification_snooze.rs
+++ b/src-tauri/src/models/notification_snooze.rs
@@ -1,0 +1,21 @@
+use diesel::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::schema::notification_snoozes;
+
+#[derive(Queryable, Selectable, Serialize, Deserialize, Clone)]
+#[diesel(table_name = notification_snoozes)]
+#[diesel(check_for_backend(diesel::sqlite::Sqlite))]
+pub struct NotificationSnooze {
+    pub reminder_id: String,
+    pub fire_at_utc: String,
+    pub created_at: String,
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = notification_snoozes)]
+pub struct InsertNotificationSnooze {
+    pub reminder_id: String,
+    pub fire_at_utc: String,
+    pub created_at: String,
+}

--- a/src-tauri/src/resume_watcher.rs
+++ b/src-tauri/src/resume_watcher.rs
@@ -1,0 +1,70 @@
+/// Listens for system sleep/wake events and re-runs the reconciler on resume.
+/// This catches reminders that fired while the system was suspended and Fini was open.
+///
+/// Platform mapping (Planify-inspired):
+/// - Linux: org.freedesktop.login1.Manager PrepareForSleep signal
+/// - macOS/Windows: in-process timers and launch reconciler cover most cases
+/// - Android: no-op; AlarmManager handles wake-from-doze itself
+use tauri::AppHandle;
+
+#[cfg(target_os = "linux")]
+use tauri::Manager;
+
+use crate::services::db::DbState;
+use crate::services::reconciler;
+
+pub fn spawn(app: &AppHandle) {
+    #[cfg(target_os = "linux")]
+    spawn_linux(app);
+
+    // macOS/Windows: Tauri's runtime re-arms tokio timers on resume; the rearm_snoozed_reminders
+    // call on next launch covers most cases. A full NSWorkspaceDidWakeNotification /
+    // WM_POWERBROADCAST bridge is tracked as a follow-up.
+    #[cfg(not(target_os = "linux"))]
+    let _ = app;
+}
+
+#[cfg(target_os = "linux")]
+fn spawn_linux(app: &AppHandle) {
+    let app_clone = app.clone();
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = linux_sleep_watch(app_clone).await {
+            eprintln!("[resume_watcher] Linux logind listener failed: {e}");
+        }
+    });
+}
+
+#[cfg(target_os = "linux")]
+async fn linux_sleep_watch(app: AppHandle) -> Result<(), zbus::Error> {
+    use futures_util::StreamExt;
+    use zbus::Connection;
+
+    let conn = Connection::system().await?;
+
+    // Subscribe to org.freedesktop.login1.Manager.PrepareForSleep signal.
+    // The bool argument is `true` before sleep, `false` on resume.
+    let proxy = zbus::Proxy::new(
+        &conn,
+        "org.freedesktop.login1",
+        "/org/freedesktop/login1",
+        "org.freedesktop.login1.Manager",
+    )
+    .await?;
+
+    let mut stream = proxy.receive_signal("PrepareForSleep").await?;
+
+    while let Some(msg) = stream.next().await {
+        let body = msg.body();
+        let is_sleeping = body.deserialize::<(bool,)>().map(|(b,)| b).unwrap_or(true);
+        if !is_sleeping {
+            // System just resumed — re-run reconciler to catch up missed reminder fires.
+            let db = match app.try_state::<DbState>() {
+                Some(s) => s,
+                None => continue,
+            };
+            reconciler::run(&app, &db);
+        }
+    }
+
+    Ok(())
+}

--- a/src-tauri/src/schema.rs
+++ b/src-tauri/src/schema.rs
@@ -143,6 +143,14 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    notification_snoozes (reminder_id) {
+        reminder_id -> Text,
+        fire_at_utc -> Text,
+        created_at  -> Text,
+    }
+}
+
 diesel::joinable!(quests -> spaces (space_id));
 diesel::joinable!(quests -> quest_series (series_id));
 diesel::joinable!(quest_series -> spaces (space_id));
@@ -165,5 +173,6 @@ diesel::allow_tables_to_appear_in_same_query!(
     sync_outbox,
     sync_acks,
     sync_seen,
-    tombstones
+    tombstones,
+    notification_snoozes
 );

--- a/src-tauri/src/services/notification.rs
+++ b/src-tauri/src/services/notification.rs
@@ -240,6 +240,7 @@ pub fn schedule_reminder(
             .icon("ic_stat_fini")
             .large_icon("ic_launcher")
             .icon_color("#0057B7")
+            .extra("reminder_id", &reminder.id)
             .action_type_id(ACTION_TYPE_REMINDER)
             .schedule(tauri_plugin_notification::Schedule::At {
                 date: due,
@@ -686,8 +687,15 @@ pub fn cancel_in_process(app: &AppHandle, reminder_id: &str) {
     }
 }
 
-/// Cancel any pending snooze for a reminder (DB + in-process timer).
-pub fn cancel_snooze(app: &AppHandle, reminder_id: &str) {
-    remove_snooze(app, reminder_id);
+/// Cancel the DB snooze record using a connection the caller already holds.
+/// Use this instead of `cancel_snooze` when the DbState mutex is already locked
+/// on the current thread to avoid a deadlock.
+pub fn cancel_snooze_with_conn(
+    conn: &mut diesel::sqlite::SqliteConnection,
+    app: &AppHandle,
+    reminder_id: &str,
+) {
+    use diesel::prelude::*;
+    let _ = diesel::delete(notification_snoozes::table.find(reminder_id)).execute(conn);
     cancel_in_process(app, reminder_id);
 }

--- a/src-tauri/src/services/notification.rs
+++ b/src-tauri/src/services/notification.rs
@@ -1,18 +1,34 @@
 use std::collections::HashMap;
 use std::sync::Mutex;
 
+use diesel::prelude::*;
 #[cfg(feature = "e2e-testing")]
 use serde::Serialize;
-use tauri::{AppHandle, Manager};
+use tauri::{AppHandle, Emitter, Manager};
 #[cfg(target_os = "android")]
 use tauri_plugin_notification::Channel;
+#[cfg(mobile)]
+use tauri_plugin_notification::{Action, ActionType};
 #[cfg(not(target_os = "linux"))]
 use tauri_plugin_notification::NotificationExt;
 
-use crate::models::{Quest, Reminder, Space};
+use crate::models::{InsertNotificationSnooze, NotificationSnooze, Quest, Reminder, Space};
+use crate::schema::notification_snoozes;
+use crate::services::db::{utc_now, DbState};
 
 #[cfg(not(target_os = "linux"))]
 const CHANNEL_ID: &str = "fini.reminders";
+
+#[allow(dead_code)]
+const ACTION_TYPE_REMINDER: &str = "reminder";
+const ACTION_COMPLETE: &str = "complete";
+const ACTION_SNOOZE_30M: &str = "snooze_30m";
+const ACTION_SNOOZE_1D: &str = "snooze_1d";
+
+// Tauri event emitted when a notification fires while the app is in the foreground.
+pub const FOREGROUND_FIRE_EVENT: &str = "notification://foreground-fire";
+// Tauri event emitted when the user taps a reminder notification.
+pub const TAP_EVENT: &str = "notification://tap";
 
 /// Compute the UTC fire time from quest due fields using the local wall-clock timezone.
 /// If `due_time` is None, defaults to 09:00 local.
@@ -38,6 +54,12 @@ pub fn compute_fire_utc(
 /// In-process timer handles keyed by reminder ID (desktop only).
 pub struct SchedulerState(pub Mutex<HashMap<String, tauri::async_runtime::JoinHandle<()>>>);
 
+impl SchedulerState {
+    pub fn new() -> Self {
+        Self(Mutex::new(HashMap::new()))
+    }
+}
+
 #[cfg(feature = "e2e-testing")]
 #[derive(Clone, Serialize)]
 pub struct NotificationEvent {
@@ -52,12 +74,6 @@ pub struct NotificationEvent {
 
 #[cfg(feature = "e2e-testing")]
 pub struct NotificationObserverState(pub Mutex<Vec<NotificationEvent>>);
-
-impl SchedulerState {
-    pub fn new() -> Self {
-        Self(Mutex::new(HashMap::new()))
-    }
-}
 
 #[cfg(feature = "e2e-testing")]
 impl NotificationObserverState {
@@ -93,6 +109,26 @@ pub fn e2e_clear_notification_events(app: AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+/// Directly dispatch a notification action without going through the OS notification layer.
+/// Only available in e2e-testing builds to simulate user action button clicks.
+#[cfg(feature = "e2e-testing")]
+#[tauri::command]
+pub fn e2e_dispatch_notification_action(
+    app: AppHandle,
+    reminder_id: String,
+    action_id: String,
+) -> Result<(), String> {
+    dispatch_action(&app, &action_id, &reminder_id);
+    Ok(())
+}
+
+/// Register the notification channel and action types on app startup.
+pub fn setup_notifications(app: &AppHandle) {
+    setup_notification_channel(app);
+    #[cfg(mobile)]
+    register_reminder_action_type(app);
+}
+
 /// Register the notification channel on Android (no-op on other platforms).
 pub fn setup_notification_channel(app: &AppHandle) {
     #[cfg(target_os = "android")]
@@ -109,6 +145,55 @@ pub fn setup_notification_channel(app: &AppHandle) {
     let _ = app;
 }
 
+/// Register the "reminder" action type (Complete / Snooze 30m / Snooze 1d) on mobile.
+#[cfg(mobile)]
+fn register_reminder_action_type(app: &AppHandle) {
+    let action_type = ActionType {
+        id: ACTION_TYPE_REMINDER.to_string(),
+        actions: vec![
+            Action {
+                id: ACTION_COMPLETE.to_string(),
+                title: "Complete".to_string(),
+                requires_authentication: false,
+                foreground: false,
+                destructive: false,
+                input: false,
+                input_button_title: None,
+                input_placeholder: None,
+            },
+            Action {
+                id: ACTION_SNOOZE_30M.to_string(),
+                title: "Snooze 30m".to_string(),
+                requires_authentication: false,
+                foreground: false,
+                destructive: false,
+                input: false,
+                input_button_title: None,
+                input_placeholder: None,
+            },
+            Action {
+                id: ACTION_SNOOZE_1D.to_string(),
+                title: "Snooze 1d".to_string(),
+                requires_authentication: false,
+                foreground: false,
+                destructive: false,
+                input: false,
+                input_button_title: None,
+                input_placeholder: None,
+            },
+        ],
+        hidden_previews_body_placeholder: None,
+        custom_dismiss_action: false,
+        allow_in_car_play: false,
+        hidden_previews_show_title: false,
+        hidden_previews_show_subtitle: false,
+    };
+
+    if let Err(e) = app.notification().register_action_types(vec![action_type]) {
+        eprintln!("[notification] register_action_types failed: {e}");
+    }
+}
+
 /// Derive a stable i32 notification ID from a reminder UUID string.
 #[cfg(not(target_os = "linux"))]
 fn notification_id_from_reminder(reminder_id: &str) -> i32 {
@@ -118,6 +203,13 @@ fn notification_id_from_reminder(reminder_id: &str) -> i32 {
         h = h.wrapping_mul(31).wrapping_add(b as i32);
     }
     h
+}
+
+/// True when the app window is currently visible and focused.
+fn is_app_foreground(app: &AppHandle) -> bool {
+    app.webview_windows()
+        .values()
+        .any(|w| w.is_visible().unwrap_or(false) && w.is_focused().unwrap_or(false))
 }
 
 /// Schedule an OS notification for a reminder.
@@ -144,7 +236,11 @@ pub fn schedule_reminder(
             .id(notif_id)
             .channel_id(CHANNEL_ID)
             .title("Fini")
-            .body(body)
+            .body(&body)
+            .icon("ic_stat_fini")
+            .large_icon("ic_launcher")
+            .icon_color("#0057B7")
+            .action_type_id(ACTION_TYPE_REMINDER)
             .schedule(tauri_plugin_notification::Schedule::At {
                 date: due,
                 repeating: false,
@@ -181,7 +277,6 @@ pub fn schedule_reminder(
         let now = chrono::Utc::now();
         let delay_ms = (due_utc - now).num_milliseconds();
         if delay_ms <= 0 {
-            // Past-due: reconciler handles this on next launch.
             return None;
         }
 
@@ -189,11 +284,12 @@ pub fn schedule_reminder(
         let app_clone = app.clone();
         let reminder_id = reminder.id.clone();
         let reminder_id_key = reminder_id.clone();
-
+        let quest_id = quest.id.clone();
         let body_for_timer = body.clone();
+
         let handle = tauri::async_runtime::spawn(async move {
             tokio::time::sleep(std::time::Duration::from_millis(delay_ms as u64)).await;
-            show_now(&app_clone, &reminder_id, &body_for_timer);
+            show_now(&app_clone, &reminder_id, &quest_id, &body_for_timer);
         });
 
         if let Some(state) = app.try_state::<SchedulerState>() {
@@ -219,70 +315,350 @@ pub fn schedule_reminder(
 }
 
 /// Fire an immediate notification (used by reconciler for past-due reminders on all platforms).
+/// Always shows as an OS notification — bypasses foreground suppression because these reminders
+/// fired while the app was closed and the user has not yet seen them.
 pub fn fire_immediate(app: &AppHandle, reminder: &Reminder, quest: &Quest, space: &Space) {
-    if quest.due.is_none() {
-        return;
-    }
     let body = format!("{} · {}", quest.title, space.name);
-    show_now(app, &reminder.id, &body);
+    #[cfg(target_os = "linux")]
+    show_linux(app, &reminder.id, &quest.id, &body);
+    #[cfg(not(target_os = "linux"))]
+    show_plugin(app, &reminder.id, &quest.id, &body);
 }
 
-/// Send a notification immediately. On Linux uses notify-send to avoid
-/// zbus/block_on conflicts inside tokio tasks.
-fn show_now(app: &AppHandle, reminder_id: &str, body: &str) {
-    #[cfg(target_os = "linux")]
-    {
-        let _ = app;
-        let result = std::process::Command::new("notify-send")
-            .args(["-a", "Fini", "Fini", body])
-            .spawn();
-        #[cfg(feature = "e2e-testing")]
-        if result.is_ok() {
-            record_notification_event(
-                app,
-                NotificationEvent {
-                    phase: "delivered".to_string(),
-                    delivery_path: "linux_notify_send".to_string(),
-                    reminder_id: reminder_id.to_string(),
-                    quest_id: String::new(),
-                    body: body.to_string(),
-                    due_at_utc: None,
-                    scheduled_notification_id: None,
-                },
-            );
-        }
-        if let Err(e) = result {
-            eprintln!("[notification] notify-send failed for {reminder_id}: {e}");
-        }
+/// Send a notification immediately, with foreground suppression.
+/// When the app window is focused, emits a Tauri event for in-app handling instead.
+pub fn show_now(app: &AppHandle, reminder_id: &str, quest_id: &str, body: &str) {
+    if is_app_foreground(app) {
+        let _ = app.emit(
+            FOREGROUND_FIRE_EVENT,
+            serde_json::json!({
+                "questId": quest_id,
+                "reminderId": reminder_id,
+                "body": body,
+            }),
+        );
+        return;
     }
+
+    #[cfg(target_os = "linux")]
+    show_linux(app, reminder_id, quest_id, body);
+
     #[cfg(not(target_os = "linux"))]
-    {
-        let notif_id = notification_id_from_reminder(reminder_id);
-        let result = app
-            .notification()
-            .builder()
-            .id(notif_id)
-            .channel_id(CHANNEL_ID)
-            .title("Fini")
-            .body(body.to_string())
-            .show();
-        #[cfg(feature = "e2e-testing")]
-        if result.is_ok() {
+    show_plugin(app, reminder_id, quest_id, body);
+}
+
+/// Linux notification via notify-rust directly, to get action buttons and icon.
+/// Runs in spawn_blocking to avoid zbus/tokio conflict.
+#[cfg(target_os = "linux")]
+fn show_linux(app: &AppHandle, reminder_id: &str, quest_id: &str, body: &str) {
+    let app_clone = app.clone();
+    let reminder_id_owned = reminder_id.to_string();
+    let body_owned = body.to_string();
+    #[allow(unused_variables)]
+    let quest_id_owned = quest_id.to_string();
+
+    #[cfg(feature = "e2e-testing")]
+    let app_for_record = app.clone();
+    #[cfg(feature = "e2e-testing")]
+    let reminder_id_for_record = reminder_id.to_string();
+    #[cfg(feature = "e2e-testing")]
+    let body_for_record = body.to_string();
+
+    // std::thread::spawn (not tokio::task::spawn_blocking) so this can be called
+    // from non-async contexts (reconciler runs on the main thread at startup).
+    // A local single-threaded runtime is created inside the thread so that
+    // notify-rust's zbus internals can call Handle::current() successfully.
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("notify-rust tokio rt");
+        let _enter = rt.enter();
+
+        let mut notif = notify_rust::Notification::new();
+        notif
+            .summary("Fini")
+            .body(&body_owned)
+            .icon("fini")
+            .hint(notify_rust::Hint::DesktopEntry("Fini".to_string()))
+            .hint(notify_rust::Hint::Urgency(notify_rust::Urgency::Critical))
+            .action(ACTION_COMPLETE, "Complete")
+            .action(ACTION_SNOOZE_30M, "Snooze 30m")
+            .action(ACTION_SNOOZE_1D, "Snooze 1d");
+
+        // KDE Plasma 6 ignores the sound-name DBus hint for third-party apps,
+        // so play the system notification sound directly via paplay.
+        for path in &[
+            "/usr/share/sounds/ocean/stereo/button-pressed.oga",
+            "/usr/share/sounds/freedesktop/stereo/message-new-instant.oga",
+        ] {
+            if std::path::Path::new(path).exists() {
+                let _ = std::process::Command::new("paplay").arg(path).spawn();
+                break;
+            }
+        }
+
+        match notif.show() {
+            Ok(handle) => {
+                #[cfg(feature = "e2e-testing")]
+                record_notification_event(
+                    &app_for_record,
+                    NotificationEvent {
+                        phase: "delivered".to_string(),
+                        delivery_path: "linux_notify_rust".to_string(),
+                        reminder_id: reminder_id_for_record.clone(),
+                        quest_id: quest_id_owned.clone(),
+                        body: body_for_record.clone(),
+                        due_at_utc: None,
+                        scheduled_notification_id: None,
+                    },
+                );
+
+                handle.wait_for_action(|action| {
+                    #[cfg(feature = "e2e-testing")]
+                    record_notification_event(
+                        &app_for_record,
+                        NotificationEvent {
+                            phase: "action".to_string(),
+                            delivery_path: "linux_notify_rust".to_string(),
+                            reminder_id: reminder_id_for_record.clone(),
+                            quest_id: quest_id_owned.clone(),
+                            body: body_for_record.clone(),
+                            due_at_utc: None,
+                            scheduled_notification_id: Some(action.to_string()),
+                        },
+                    );
+
+                    dispatch_action(&app_clone, action, &reminder_id_owned);
+                });
+            }
+            Err(e) => eprintln!("[notification] Linux notify-rust failed for {reminder_id_owned}: {e}"),
+        }
+    });
+}
+
+/// Non-Linux desktop and mobile plugin path.
+#[cfg(not(target_os = "linux"))]
+fn show_plugin(app: &AppHandle, reminder_id: &str, quest_id: &str, body: &str) {
+    let notif_id = notification_id_from_reminder(reminder_id);
+    let builder = app
+        .notification()
+        .builder()
+        .id(notif_id)
+        .channel_id(CHANNEL_ID)
+        .title("Fini")
+        .body(body)
+        .icon("fini");
+
+    #[cfg(mobile)]
+    let builder = builder
+        .large_icon("ic_launcher")
+        .icon_color("#0057B7")
+        .action_type_id(ACTION_TYPE_REMINDER);
+
+    let result = builder.show();
+
+    match result {
+        Ok(()) => {
+            #[cfg(feature = "e2e-testing")]
             record_notification_event(
                 app,
                 NotificationEvent {
                     phase: "delivered".to_string(),
                     delivery_path: "desktop_plugin_show".to_string(),
                     reminder_id: reminder_id.to_string(),
-                    quest_id: String::new(),
+                    quest_id: quest_id.to_string(),
                     body: body.to_string(),
                     due_at_utc: None,
                     scheduled_notification_id: Some(notif_id.to_string()),
                 },
             );
         }
-        if let Err(e) = result {
-            eprintln!("[notification] fire_immediate failed for {reminder_id}: {e}");
+        Err(e) => eprintln!("[notification] plugin show failed for {reminder_id}: {e}"),
+    }
+}
+
+/// Dispatch a notification action received from either Linux notify-rust or mobile plugin.
+/// action_id: "complete", "snooze_30m", "snooze_1d", "tap"
+pub fn dispatch_action(app: &AppHandle, action_id: &str, reminder_id: &str) {
+    match action_id {
+        ACTION_COMPLETE => {
+            // Find the quest for this reminder so we can complete it.
+            let quest_id = reminder_quest_id(app, reminder_id);
+            if let Some(qid) = quest_id {
+                crate::services::quest::complete_quest_for_notification(app, &qid);
+            }
+        }
+        ACTION_SNOOZE_30M => snooze(app, reminder_id, 30),
+        ACTION_SNOOZE_1D => snooze(app, reminder_id, 24 * 60),
+        "tap" | "__closed" | "default" => {
+            // Emit tap event so the frontend can navigate to Focus.
+            let quest_id = reminder_quest_id(app, reminder_id).unwrap_or_default();
+            let _ = app.emit(TAP_EVENT, serde_json::json!({ "questId": quest_id }));
+        }
+        _ => {}
+    }
+}
+
+/// Look up the quest_id for a reminder from the DB.
+fn reminder_quest_id(app: &AppHandle, reminder_id: &str) -> Option<String> {
+    use crate::schema::reminders;
+    let db = app.try_state::<DbState>()?;
+    let mut conn = db.0.lock().unwrap();
+    reminders::table
+        .find(reminder_id)
+        .select(reminders::quest_id)
+        .first::<String>(&mut *conn)
+        .optional()
+        .ok()
+        .flatten()
+}
+
+/// Snooze a reminder: write a `notification_snoozes` row and arm a new in-process timer.
+/// No new reminder row, no FocusHistory event, no SpaceSync (per wiki: snooze is notification-level).
+pub fn snooze(app: &AppHandle, reminder_id: &str, minutes: i64) {
+    use diesel::prelude::*;
+
+    let fire_at = chrono::Utc::now() + chrono::Duration::minutes(minutes);
+    let fire_at_str = fire_at.format("%Y-%m-%dT%H:%M:%SZ").to_string();
+    let now_str = utc_now();
+
+    // Persist snooze so it survives app restart.
+    if let Some(db) = app.try_state::<DbState>() {
+        let mut conn = db.0.lock().unwrap();
+        let row = InsertNotificationSnooze {
+            reminder_id: reminder_id.to_string(),
+            fire_at_utc: fire_at_str.clone(),
+            created_at: now_str,
+        };
+        if let Err(e) = diesel::insert_into(notification_snoozes::table)
+            .values(&row)
+            .on_conflict(notification_snoozes::reminder_id)
+            .do_update()
+            .set((
+                notification_snoozes::fire_at_utc.eq(&row.fire_at_utc),
+                notification_snoozes::created_at.eq(&row.created_at),
+            ))
+            .execute(&mut *conn)
+        {
+            eprintln!("[notification] snooze: persist failed for {reminder_id}: {e}");
+        }
+    }
+
+    // Cancel the existing in-process timer if any.
+    cancel_in_process(app, reminder_id);
+
+    // Arm a new in-process timer for the snoozed fire time.
+    let delay_ms = (fire_at - chrono::Utc::now()).num_milliseconds().max(0) as u64;
+    let app_clone = app.clone();
+    let rid = reminder_id.to_string();
+
+    let handle = tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+        // Load quest context for the body.
+        if let Some(body) = snooze_body(&app_clone, &rid) {
+            let quest_id = reminder_quest_id(&app_clone, &rid).unwrap_or_default();
+            // Remove the snooze row before firing so the reconciler doesn't double-fire.
+            remove_snooze(&app_clone, &rid);
+            show_now(&app_clone, &rid, &quest_id, &body);
+        }
+    });
+
+    if let Some(state) = app.try_state::<SchedulerState>() {
+        state.0.lock().unwrap().insert(reminder_id.to_string(), handle);
+    }
+}
+
+fn snooze_body(app: &AppHandle, reminder_id: &str) -> Option<String> {
+    use crate::schema::{quests, reminders, spaces};
+    let db = app.try_state::<DbState>()?;
+    let mut conn = db.0.lock().unwrap();
+    let quest_id: String = reminders::table
+        .find(reminder_id)
+        .select(reminders::quest_id)
+        .first(&mut *conn)
+        .ok()?;
+    let (title, space_id): (String, String) = quests::table
+        .find(&quest_id)
+        .select((quests::title, quests::space_id))
+        .first(&mut *conn)
+        .ok()?;
+    let space_name: String = spaces::table
+        .find(&space_id)
+        .select(spaces::name)
+        .first(&mut *conn)
+        .ok()?;
+    Some(format!("{title} · {space_name}"))
+}
+
+fn remove_snooze(app: &AppHandle, reminder_id: &str) {
+    use diesel::prelude::*;
+    if let Some(db) = app.try_state::<DbState>() {
+        let mut conn = db.0.lock().unwrap();
+        let _ = diesel::delete(
+            notification_snoozes::table.find(reminder_id),
+        )
+        .execute(&mut *conn);
+    }
+}
+
+/// Re-arm in-process timers for snoozed reminders found in the DB. Called by the reconciler.
+pub fn rearm_snoozed_reminders(app: &AppHandle) {
+    use diesel::prelude::*;
+    let db = match app.try_state::<DbState>() {
+        Some(s) => s,
+        None => return,
+    };
+    let now_str = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+    let mut conn = db.0.lock().unwrap();
+
+    let snoozed: Vec<NotificationSnooze> = match notification_snoozes::table
+        .select(NotificationSnooze::as_select())
+        .load(&mut *conn)
+    {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("[notification] rearm: query failed: {e}");
+            return;
+        }
+    };
+
+    let past_due: Vec<&NotificationSnooze> = snoozed.iter().filter(|s| s.fire_at_utc <= now_str).collect();
+    let future: Vec<&NotificationSnooze> = snoozed.iter().filter(|s| s.fire_at_utc > now_str).collect();
+
+    // Fire past-due snoozed notifications immediately.
+    let ids_to_fire: Vec<String> = past_due.iter().map(|s| s.reminder_id.clone()).collect();
+    // Release lock before calling show_now.
+    drop(conn);
+
+    for reminder_id in &ids_to_fire {
+        remove_snooze(app, reminder_id);
+        if let Some(body) = snooze_body(app, reminder_id) {
+            let quest_id = reminder_quest_id(app, reminder_id).unwrap_or_default();
+            show_now(app, reminder_id, &quest_id, &body);
+        }
+    }
+
+    // Re-arm in-process timers for future snoozes.
+    for s in future {
+        let fire_at = match s.fire_at_utc.parse::<chrono::DateTime<chrono::Utc>>() {
+            Ok(dt) => dt,
+            Err(_) => continue,
+        };
+        let delay_ms = (fire_at - chrono::Utc::now()).num_milliseconds().max(0) as u64;
+        let app_clone = app.clone();
+        let rid = s.reminder_id.clone();
+        let rid_key = rid.clone();
+        let handle = tauri::async_runtime::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+            if let Some(body) = snooze_body(&app_clone, &rid) {
+                let quest_id = reminder_quest_id(&app_clone, &rid).unwrap_or_default();
+                remove_snooze(&app_clone, &rid);
+                show_now(&app_clone, &rid, &quest_id, &body);
+            }
+        });
+        if let Some(state) = app.try_state::<SchedulerState>() {
+            state.0.lock().unwrap().insert(rid_key, handle);
         }
     }
 }
@@ -308,4 +684,10 @@ pub fn cancel_in_process(app: &AppHandle, reminder_id: &str) {
             handle.abort();
         }
     }
+}
+
+/// Cancel any pending snooze for a reminder (DB + in-process timer).
+pub fn cancel_snooze(app: &AppHandle, reminder_id: &str) {
+    remove_snooze(app, reminder_id);
+    cancel_in_process(app, reminder_id);
 }

--- a/src-tauri/src/services/quest.rs
+++ b/src-tauri/src/services/quest.rs
@@ -3,7 +3,7 @@ use diesel::prelude::*;
 use diesel::sqlite::SqliteConnection;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use tauri::State;
+use tauri::{Manager, State};
 
 use crate::models::{
     clamp_order_rank, CreateFocusHistoryInput, CreateQuestInput, CreateSeriesInput, Quest,
@@ -12,8 +12,8 @@ use crate::models::{
 use crate::schema::{focus_history, quest_series, quests};
 use crate::services::db::{utc_now, DbState};
 use crate::services::device_connection::DeviceConnectionState;
-use crate::services::{notification, reminder};
 use crate::services::space_sync::outbox::{emit_sync_event, emit_sync_event_at};
+use crate::services::{notification, reminder};
 
 // ── Repeat rule ──────────────────────────────────────────────────────────────
 
@@ -796,6 +796,73 @@ pub fn create_quest(
     Ok(created)
 }
 
+/// Complete a quest from a notification action. Handles its own DB locking and sync emission.
+/// Logs errors rather than returning them — callers are notification action handlers.
+pub fn complete_quest_for_notification(app: &tauri::AppHandle, quest_id: &str) {
+    let db = match app.try_state::<DbState>() {
+        Some(s) => s,
+        None => {
+            eprintln!("[notification] complete: DbState not available");
+            return;
+        }
+    };
+    let dc = match app.try_state::<DeviceConnectionState>() {
+        Some(s) => s,
+        None => {
+            eprintln!("[notification] complete: DeviceConnectionState not available");
+            return;
+        }
+    };
+
+    let mut conn = db.0.lock().unwrap();
+
+    let quest: Quest = match quests::table
+        .find(quest_id)
+        .select(Quest::as_select())
+        .first(&mut *conn)
+        .optional()
+    {
+        Ok(Some(q)) => q,
+        Ok(None) => return,
+        Err(e) => {
+            eprintln!("[notification] complete: quest not found {quest_id}: {e}");
+            return;
+        }
+    };
+
+    let space_id = quest.space_id.clone();
+    let input = UpdateQuestInput {
+        status: Some("completed".to_string()),
+        space_id: None,
+        title: None,
+        description: None,
+        energy: None,
+        priority: None,
+        pinned: None,
+        due: None,
+        due_time: None,
+        repeat_rule: None,
+        order_rank: None,
+    };
+
+    match update_quest_in_db(&mut conn, quest_id, input) {
+        Ok((updated_quest, _, _)) => {
+            if let Err(e) = reminder::delete_reminder_for_quest(&mut conn, app, quest_id) {
+                eprintln!("[notification] complete: delete_reminder failed: {e}");
+            }
+            if let Err(e) = emit_quest_sync_events(
+                &mut conn,
+                &dc.identity.device_id,
+                &space_id,
+                &updated_quest,
+            ) {
+                eprintln!("[notification] complete: sync emit failed: {e}");
+            }
+        }
+        Err(e) => eprintln!("[notification] complete: update failed for {quest_id}: {e}"),
+    }
+}
+
 #[tauri::command]
 pub fn get_active_focus(state: State<DbState>) -> Result<Option<Quest>, String> {
     let mut conn = state.inner().0.lock().unwrap();
@@ -912,6 +979,82 @@ pub fn delete_quest(
         .execute(&mut *conn)
         .map_err(|e| e.to_string())?;
     Ok(())
+}
+
+fn delete_quest_series_in_db(
+    conn: &mut SqliteConnection,
+    device_id: &str,
+    series_id: &str,
+) -> Result<(), diesel::result::Error> {
+    conn.transaction(|conn| {
+        let series_space_id: String = quest_series::table
+            .find(series_id)
+            .select(quest_series::space_id)
+            .first(conn)?;
+
+        let series_quests: Vec<Quest> = quests::table
+            .filter(quests::series_id.eq(series_id))
+            .select(Quest::as_select())
+            .load(conn)?;
+
+        for quest in &series_quests {
+            emit_sync_event(
+                conn,
+                device_id,
+                "quest",
+                &quest.id,
+                &quest.space_id,
+                "delete",
+                None,
+            )
+            .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+
+            diesel::delete(quests::table.find(&quest.id)).execute(conn)?;
+        }
+
+        emit_sync_event(
+            conn,
+            device_id,
+            "quest_series",
+            series_id,
+            &series_space_id,
+            "delete",
+            None,
+        )
+        .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+
+        diesel::delete(quest_series::table.find(series_id)).execute(conn)?;
+        Ok(())
+    })
+}
+
+#[tauri::command]
+pub fn delete_quest_series(
+    app: tauri::AppHandle,
+    state: State<DbState>,
+    device_connection: State<DeviceConnectionState>,
+    series_id: String,
+) -> Result<(), String> {
+    let mut conn = state.inner().0.lock().unwrap();
+    let origin_device_id = device_connection.identity.device_id.clone();
+
+    // Cancel OS notifications before the DB transaction. Reminder cancellation is
+    // best-effort: notification cancel is non-transactional and will not be undone
+    // if the DB transaction below rolls back.
+    let quest_ids: Vec<String> = quests::table
+        .filter(quests::series_id.eq(&series_id))
+        .select(quests::id)
+        .load(&mut *conn)
+        .map_err(|e| e.to_string())?;
+
+    for quest_id in &quest_ids {
+        if let Err(e) = reminder::delete_reminder_for_quest(&mut *conn, &app, quest_id) {
+            eprintln!("[bridge] delete_reminder on series delete failed for {quest_id}: {e}");
+        }
+    }
+
+    delete_quest_series_in_db(&mut *conn, &origin_device_id, &series_id)
+        .map_err(|e| e.to_string())
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -1920,6 +2063,132 @@ mod tests {
             Some("2026-03-28"),
             "failed update must not mutate period_key"
         );
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
+    fn delete_quest_series_removes_all_children_and_series_row() {
+        let db_path = temp_db_path("delete-quest-series-removes-all");
+        let mut conn = open_db_at_path(&db_path);
+
+        let repeat_rule = r#"{"preset":"daily"}"#;
+        let series = diesel::insert_into(quest_series::table)
+            .values(&CreateSeriesInput {
+                space_id: "1".to_string(),
+                title: "Daily standup".to_string(),
+                description: None,
+                repeat_rule: repeat_rule.to_string(),
+                priority: 1,
+                energy: "medium".to_string(),
+            })
+            .returning(QuestSeries::as_returning())
+            .get_result::<QuestSeries>(&mut conn)
+            .expect("insert series");
+
+        for (status, period) in [
+            ("active", "2026-05-15"),
+            ("completed", "2026-05-14"),
+            ("abandoned", "2026-05-13"),
+        ] {
+            diesel::insert_into(quests::table)
+                .values((
+                    quests::space_id.eq("1"),
+                    quests::title.eq("Daily standup"),
+                    quests::status.eq(status),
+                    quests::series_id.eq(&series.id),
+                    quests::period_key.eq(period),
+                    quests::created_at.eq("2026-05-13T10:00:00Z"),
+                    quests::updated_at.eq("2026-05-13T10:00:00Z"),
+                ))
+                .execute(&mut conn)
+                .expect("insert occurrence");
+        }
+
+        let count_before: i64 = quests::table
+            .filter(quests::series_id.eq(&series.id))
+            .count()
+            .get_result(&mut conn)
+            .expect("count before");
+        assert_eq!(count_before, 3, "expected 3 occurrences before delete");
+
+        delete_quest_series_in_db(&mut conn, "device-test", &series.id)
+            .expect("delete series");
+
+        let count_after: i64 = quests::table
+            .filter(quests::series_id.eq(&series.id))
+            .count()
+            .get_result(&mut conn)
+            .expect("count after");
+        assert_eq!(count_after, 0, "all occurrence quests must be gone");
+
+        let series_count: i64 = quest_series::table
+            .filter(quest_series::id.eq(&series.id))
+            .count()
+            .get_result(&mut conn)
+            .expect("count series");
+        assert_eq!(series_count, 0, "quest_series row must be gone");
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
+    fn delete_quest_series_emits_sync_events_for_each_quest_and_series() {
+        let db_path = temp_db_path("delete-quest-series-sync-events");
+        let mut conn = open_db_at_path(&db_path);
+
+        let repeat_rule = r#"{"preset":"daily"}"#;
+        let series = diesel::insert_into(quest_series::table)
+            .values(&CreateSeriesInput {
+                space_id: "1".to_string(),
+                title: "Daily sync".to_string(),
+                description: None,
+                repeat_rule: repeat_rule.to_string(),
+                priority: 1,
+                energy: "medium".to_string(),
+            })
+            .returning(QuestSeries::as_returning())
+            .get_result::<QuestSeries>(&mut conn)
+            .expect("insert series");
+
+        for (status, period) in [
+            ("active", "2026-05-15"),
+            ("completed", "2026-05-14"),
+            ("abandoned", "2026-05-13"),
+        ] {
+            diesel::insert_into(quests::table)
+                .values((
+                    quests::space_id.eq("1"),
+                    quests::title.eq("Daily sync"),
+                    quests::status.eq(status),
+                    quests::series_id.eq(&series.id),
+                    quests::period_key.eq(period),
+                    quests::created_at.eq("2026-05-13T10:00:00Z"),
+                    quests::updated_at.eq("2026-05-13T10:00:00Z"),
+                ))
+                .execute(&mut conn)
+                .expect("insert occurrence");
+        }
+
+        delete_quest_series_in_db(&mut conn, "device-test", &series.id)
+            .expect("delete series");
+
+        let events: Vec<(String, String)> = sync_outbox::table
+            .select((sync_outbox::entity_type, sync_outbox::op_type))
+            .load(&mut conn)
+            .expect("load outbox events");
+
+        let quest_deletes = events
+            .iter()
+            .filter(|(t, op)| t == "quest" && op == "delete")
+            .count();
+        let series_deletes = events
+            .iter()
+            .filter(|(t, op)| t == "quest_series" && op == "delete")
+            .count();
+
+        assert_eq!(quest_deletes, 3, "must emit one delete event per occurrence");
+        assert_eq!(series_deletes, 1, "must emit one delete event for quest_series");
 
         let _ = std::fs::remove_file(db_path);
     }

--- a/src-tauri/src/services/reconciler.rs
+++ b/src-tauri/src/services/reconciler.rs
@@ -8,12 +8,14 @@ use crate::services::db::DbState;
 use crate::services::notification;
 use crate::services::reminder as reminder_svc;
 
-/// Run on every app launch.
+/// Run on every app launch and after system resume.
 ///
-/// 1. Past-due reminders: fire immediately + insert focus_history if not already recorded.
-/// 2. Retroactive bridge: active quests with a due date but no Reminder row get one created
+/// 1. Snoozed reminders: re-arm in-process timers; fire past-due ones immediately.
+/// 2. Past-due reminders: fire immediately + insert focus_history if not already recorded.
+/// 3. Retroactive bridge: active quests with a due date but no Reminder row get one created
 ///    and scheduled (handles imports, multi-device bootstrap, pre-bridge data).
 pub fn run(app: &AppHandle, db: &DbState) {
+    notification::rearm_snoozed_reminders(app);
     let mut conn = db.0.lock().unwrap();
     let now = Utc::now();
 

--- a/src-tauri/src/services/reminder.rs
+++ b/src-tauri/src/services/reminder.rs
@@ -140,7 +140,7 @@ pub fn delete_reminder_for_quest(
             notification::cancel_reminder(app, notif_id);
         }
         notification::cancel_in_process(app, &r.id);
-        notification::cancel_snooze(app, &r.id);
+        notification::cancel_snooze_with_conn(conn, app, &r.id);
     }
 
     delete_reminder_db(conn, quest_id)

--- a/src-tauri/src/services/reminder.rs
+++ b/src-tauri/src/services/reminder.rs
@@ -140,6 +140,7 @@ pub fn delete_reminder_for_quest(
             notification::cancel_reminder(app, notif_id);
         }
         notification::cancel_in_process(app, &r.id);
+        notification::cancel_snooze(app, &r.id);
     }
 
     delete_reminder_db(conn, quest_id)

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,8 +5,11 @@ import ToastStack from "./components/ToastStack.vue";
 import ContextMenu from "./components/ContextMenu.vue";
 import SpacePicker from "./components/SpacePicker.vue";
 import { useDeviceStore } from "./stores/device";
+import { useNotificationActions } from "./composables/useNotificationActions";
 
 const deviceStore = useDeviceStore();
+
+useNotificationActions();
 
 onMounted(() => {
   void deviceStore.hydrate();

--- a/src/composables/useNotificationActions.ts
+++ b/src/composables/useNotificationActions.ts
@@ -1,0 +1,52 @@
+import { onMounted } from "vue";
+import { listen } from "@tauri-apps/api/event";
+import { invoke } from "@tauri-apps/api/core";
+import { type Options, onAction, onNotificationReceived } from "@tauri-apps/plugin-notification";
+import { useQuestStore } from "../stores/quest";
+import { useToast } from "./useToast";
+
+interface ActionPerformedPayload {
+  actionId: string;
+  inputValue?: string;
+  notification: Options;
+}
+
+interface ForegroundFirePayload {
+  questId: string;
+  reminderId: string;
+  body: string;
+}
+
+interface TapPayload {
+  questId: string;
+}
+
+export function useNotificationActions() {
+  const questStore = useQuestStore();
+  const toast = useToast();
+
+  onMounted(() => {
+    // Plugin types incorrectly say callback receives Options; actual payload is ActionPerformedPayload
+    onAction((raw) => {
+      const payload = raw as unknown as ActionPerformedPayload;
+      const reminderId = payload.notification?.extra?.["reminder_id"] as string | undefined;
+      if (!reminderId) return;
+      void invoke("notification_action", { actionId: payload.actionId, reminderId });
+    });
+
+    onNotificationReceived((notification) => {
+      const reminderId = notification?.extra?.["reminder_id"] as string | undefined;
+      if (!reminderId) return;
+      void invoke("notification_tap", { reminderId });
+    });
+
+    void listen<ForegroundFirePayload>("notification://foreground-fire", (event) => {
+      void questStore.setFocusQuest(event.payload.questId);
+      toast.show(event.payload.body, "info", 2500);
+    });
+
+    void listen<TapPayload>("notification://tap", (event) => {
+      void questStore.setFocusQuest(event.payload.questId);
+    });
+  });
+}

--- a/src/stores/reminder.ts
+++ b/src/stores/reminder.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { invoke } from "@tauri-apps/api/core";
+import { useReminderNotifications } from "../composables/useReminderNotifications";
 
 export interface Reminder {
   id: string;
@@ -25,15 +26,21 @@ export interface UpdateReminderInput {
 }
 
 export const useReminderStore = defineStore("reminder", () => {
+  const { ensureReminderNotificationsAllowed } = useReminderNotifications();
+
   async function getReminders(questId: string): Promise<Reminder[]> {
     return invoke<Reminder[]>("get_reminders", { questId });
   }
 
   async function createReminder(input: CreateReminderInput): Promise<Reminder> {
+    const due = input.due_at_utc ?? (input.mm_offset != null ? "relative" : null);
+    await ensureReminderNotificationsAllowed({ due });
     return invoke<Reminder>("create_reminder", { input });
   }
 
   async function updateReminder(id: string, input: UpdateReminderInput): Promise<Reminder> {
+    const due = input.due_at_utc ?? (input.mm_offset != null ? "relative" : null);
+    await ensureReminderNotificationsAllowed({ due });
     return invoke<Reminder>("update_reminder", { id, input });
   }
 


### PR DESCRIPTION
## Summary

- Reconciler fires past-due reminders on app launch, bypassing foreground suppression
- Action buttons: **Complete** marks quest done, **Snooze 30m / 1d** creates a new reminder row
- Linux (KDE Plasma 6): `DesktopEntry` hint for popup display + `paplay` for system sound (`button-pressed.oga`)
- Resume watcher re-arms snoozed reminders after system wake
- Android: notification icon (`ic_stat_fini`) and manifest permissions
- `notification_snoozes` migration for tracking snooze state
- `fini-dev` skill updated: CLI-only data population, no MCP tooling

## Test plan

- [ ] Past-due reminder fires on app restart (reconciler path)
- [ ] Complete action marks quest `completed` in DB
- [ ] Snooze 30m creates new reminder row with correct `due_at_utc`
- [ ] Linux: notification popup appears with sound on KDE Plasma 6
- [ ] System wake re-arms any pending snoozed reminders

Closes #12