### PR TITLE
feat(backup): portable backup import/export (#28)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.27",
       "dependencies": {
         "@heroicons/vue": "^2.2.0",
-        "@tauri-apps/api": "^2",
+        "@tauri-apps/api": "^2.11.0",
+        "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-notification": "^2.3.3",
         "@tauri-apps/plugin-opener": "^2",
         "daisyui": "^5.5.19",
@@ -24,7 +25,7 @@
         "@playwright/test": "^1.51.0",
         "@srsholmes/tauri-playwright": "^0.2.2",
         "@tailwindcss/vite": "^4.2.1",
-        "@tauri-apps/cli": "^2",
+        "@tauri-apps/cli": "^2.11.0",
         "@types/jest": "^29.5.14",
         "@vitejs/plugin-vue": "^5.2.1",
         "@vue/test-utils": "^2.4.6",
@@ -3872,9 +3873,9 @@
       }
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
-      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
+      "integrity": "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -3882,9 +3883,9 @@
       }
     },
     "node_modules/@tauri-apps/cli": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.10.1.tgz",
-      "integrity": "sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.11.0.tgz",
+      "integrity": "sha512-W5Wbuqsb2pHFPTj4TaRNKTj5rwXhDShPiLSY9T18y4ouSR/NNCptAEFxFsBtyNRgL6Vs1a/q9LzfqqYzEwC+Jw==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "bin": {
@@ -3898,23 +3899,23 @@
         "url": "https://opencollective.com/tauri"
       },
       "optionalDependencies": {
-        "@tauri-apps/cli-darwin-arm64": "2.10.1",
-        "@tauri-apps/cli-darwin-x64": "2.10.1",
-        "@tauri-apps/cli-linux-arm-gnueabihf": "2.10.1",
-        "@tauri-apps/cli-linux-arm64-gnu": "2.10.1",
-        "@tauri-apps/cli-linux-arm64-musl": "2.10.1",
-        "@tauri-apps/cli-linux-riscv64-gnu": "2.10.1",
-        "@tauri-apps/cli-linux-x64-gnu": "2.10.1",
-        "@tauri-apps/cli-linux-x64-musl": "2.10.1",
-        "@tauri-apps/cli-win32-arm64-msvc": "2.10.1",
-        "@tauri-apps/cli-win32-ia32-msvc": "2.10.1",
-        "@tauri-apps/cli-win32-x64-msvc": "2.10.1"
+        "@tauri-apps/cli-darwin-arm64": "2.11.0",
+        "@tauri-apps/cli-darwin-x64": "2.11.0",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.0",
+        "@tauri-apps/cli-linux-arm64-gnu": "2.11.0",
+        "@tauri-apps/cli-linux-arm64-musl": "2.11.0",
+        "@tauri-apps/cli-linux-riscv64-gnu": "2.11.0",
+        "@tauri-apps/cli-linux-x64-gnu": "2.11.0",
+        "@tauri-apps/cli-linux-x64-musl": "2.11.0",
+        "@tauri-apps/cli-win32-arm64-msvc": "2.11.0",
+        "@tauri-apps/cli-win32-ia32-msvc": "2.11.0",
+        "@tauri-apps/cli-win32-x64-msvc": "2.11.0"
       }
     },
     "node_modules/@tauri-apps/cli-darwin-arm64": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.10.1.tgz",
-      "integrity": "sha512-Z2OjCXiZ+fbYZy7PmP3WRnOpM9+Fy+oonKDEmUE6MwN4IGaYqgceTjwHucc/kEEYZos5GICve35f7ZiizgqEnQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.0.tgz",
+      "integrity": "sha512-UfMeDNlgIP252rm/KSTuu8yHatPua5TjtUEUf+jyIzVwBNcIl7Ywkdpfj+e5jVVg3EfCTp+4gwuL1dNpgF8clg==",
       "cpu": [
         "arm64"
       ],
@@ -3929,9 +3930,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-darwin-x64": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.10.1.tgz",
-      "integrity": "sha512-V/irQVvjPMGOTQqNj55PnQPVuH4VJP8vZCN7ajnj+ZS8Kom1tEM2hR3qbbIRoS3dBKs5mbG8yg1WC+97dq17Pw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.11.0.tgz",
+      "integrity": "sha512-lY1+aPlgyMN7vgjtCdQ3+WODfZkebAcxnrCrO0HjqDpKSXieDkrJbimqeaoM4RwhTSrCLRHfVYiYrfE5E131tg==",
       "cpu": [
         "x64"
       ],
@@ -3946,9 +3947,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.10.1.tgz",
-      "integrity": "sha512-Hyzwsb4VnCWKGfTw+wSt15Z2pLw2f0JdFBfq2vHBOBhvg7oi6uhKiF87hmbXOBXUZaGkyRDkCHsdzJcIfoJC2w==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.11.0.tgz",
+      "integrity": "sha512-5uCP0AusgN3NrKC8EpkuJwjek1k8pEffBdugJSpXPey/QGbPEb8vZ542n/giJ2mZPjMSllDkdhG2QIDpBY4PpQ==",
       "cpu": [
         "arm"
       ],
@@ -3963,9 +3964,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.10.1.tgz",
-      "integrity": "sha512-OyOYs2t5GkBIvyWjA1+h4CZxTcdz1OZPCWAPz5DYEfB0cnWHERTnQ/SLayQzncrT0kwRoSfSz9KxenkyJoTelA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.11.0.tgz",
+      "integrity": "sha512-loDPqtRHMSbIcrH2VBd4GgHoQlF7jJnrZj7MxA2lj1cixS/jEgMAPFqj83U6Wvjete4HfYplbE/gCpSFifA9jw==",
       "cpu": [
         "arm64"
       ],
@@ -3980,9 +3981,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-musl": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.10.1.tgz",
-      "integrity": "sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.11.0.tgz",
+      "integrity": "sha512-DtSE8ZBlB9H+L+eHkfZ3myt00EVEyAB3e41juEHoE2qT88fgVlJvyrwa9SZYc/xTwCS9TnmK+R84tpg+ZsAg7Q==",
       "cpu": [
         "arm64"
       ],
@@ -3997,9 +3998,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-riscv64-gnu": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.10.1.tgz",
-      "integrity": "sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.11.0.tgz",
+      "integrity": "sha512-5QdgS4LD+kntClI1aj2JmwjW38LosNXxwCe8viIHEwqYIWuMPdNEIau6/cLogI38Yzx9DnfCPRfEWLyI+5li8Q==",
       "cpu": [
         "riscv64"
       ],
@@ -4014,9 +4015,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-gnu": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.10.1.tgz",
-      "integrity": "sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.11.0.tgz",
+      "integrity": "sha512-5UynPXo3Zq9khjVdAbD+YogeLltdVUeOah2ioSIM3tu6H7wY9vMy6rgGJhv9r5R8ZXmk9GttMippdqYJWrnLnA==",
       "cpu": [
         "x64"
       ],
@@ -4031,9 +4032,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-musl": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.10.1.tgz",
-      "integrity": "sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.11.0.tgz",
+      "integrity": "sha512-CNz7fHbApz1Zyhhq73jtGn9JqgNEV/lIWnTnUo6h6ujw+mHsTmkLszvJSM8W6JBaDjNpTTFr/RSNoVL5FMwcTg==",
       "cpu": [
         "x64"
       ],
@@ -4048,9 +4049,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-arm64-msvc": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.10.1.tgz",
-      "integrity": "sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.11.0.tgz",
+      "integrity": "sha512-K+br+VXZ+Xx0n/9FdWohpW5Ugq+2FQUpJScqcPl1hTxXfh3fgjYgt4qA2NgrjlJo+zZPNrmUMl+NLvm0ufEqBQ==",
       "cpu": [
         "arm64"
       ],
@@ -4065,9 +4066,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-ia32-msvc": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.10.1.tgz",
-      "integrity": "sha512-gXyxgEzsFegmnWywYU5pEBURkcFN/Oo45EAwvZrHMh+zUSEAvO5E8TXsgPADYm31d1u7OQU3O3HsYfVBf2moHw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.11.0.tgz",
+      "integrity": "sha512-OFV+s3MLZnd75zl0ZAFU5riMpGK4waUEA8ZDuijDsnkU0btz/gHhqh5jVlOn8thyvgdtT3Xyoxqo099MMifH3g==",
       "cpu": [
         "ia32"
       ],
@@ -4082,9 +4083,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-x64-msvc": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.10.1.tgz",
-      "integrity": "sha512-6Cn7YpPFwzChy0ERz6djKEmUehWrYlM+xTaNzGPgZocw3BD7OfwfWHKVWxXzdjEW2KfKkHddfdxK1XXTYqBRLg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.11.0.tgz",
+      "integrity": "sha512-AeDTWBd2cOZ6TX133BWsoo+LutG9o0JRcgjMsIfLE13ZugpgCMv/2dJbUiBGeRvbPOGin5A3aYmsArPVV6ZSHQ==",
       "cpu": [
         "x64"
       ],
@@ -4096,6 +4097,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
+      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@tauri-apps/plugin-notification": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "@heroicons/vue": "^2.2.0",
-    "@tauri-apps/api": "^2",
+    "@tauri-apps/api": "^2.11.0",
+    "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "^2",
     "daisyui": "^5.5.19",
@@ -30,7 +31,7 @@
     "@playwright/test": "^1.51.0",
     "@srsholmes/tauri-playwright": "^0.2.2",
     "@tailwindcss/vite": "^4.2.1",
-    "@tauri-apps/cli": "^2",
+    "@tauri-apps/cli": "^2.11.0",
     "@types/jest": "^29.5.14",
     "@vitejs/plugin-vue": "^5.2.1",
     "@vue/test-utils": "^2.4.6",

--- a/specs/README.md
+++ b/specs/README.md
@@ -9,6 +9,7 @@ These specs are the implementation contract for the main `fini` repo.
 - `device-connect/` - device discovery, pairing, presence, and paired-device lifecycle
 - `space-sync/` - pair-scoped space mapping, bootstrap sync, sync sessions, and sync status
 - `space/` - local space model and space management behavior
+- `backup/` - portable zip import/export for quests and spaces
 
 ## Convention
 
@@ -43,3 +44,4 @@ If both are needed, keep the enforceable contract in `fini/specs` and link to th
 - `specs/device-connect/README.md`
 - `specs/space-sync/README.md`
 - `specs/space/README.md`
+- `specs/backup/README.md`

--- a/specs/backup/README.md
+++ b/specs/backup/README.md
@@ -1,0 +1,171 @@
+# Backup Import/Export
+
+Issue: #28
+
+## Goal
+
+Implement user-controlled portable backup import/export for Fini quests and spaces.
+
+Backups are local files. Version 1 does not include cloud backup, scheduled backup, archive encryption, password protection, or an exact clone of every runtime table.
+
+## File Format
+
+Backup files are `.zip` archives named by default:
+
+```text
+fini-backup-YYYY-MM-DD.zip
+```
+
+The archive must contain exactly:
+
+```text
+manifest.json
+fini-backup.sqlite
+```
+
+`manifest.json` records:
+
+```json
+{
+  "format": "fini-backup",
+  "version": 1,
+  "app_version": "0.1.27",
+  "exported_at": "2026-05-19T12:00:00Z",
+  "domains": ["spaces", "quest_series", "quests"],
+  "spaces": [{ "id": "1", "name": "Personal" }],
+  "counts": { "spaces": 1, "quest_series": 0, "quests": 0 }
+}
+```
+
+Import rejects non-zip files, raw SQLite files, JSON backup files, archives missing required files, archives with extra files, unsupported manifest versions, malformed backup SQLite databases, and databases missing required backup tables.
+
+## Export
+
+Export includes:
+
+- Selected spaces.
+- All quests in selected spaces, including active, completed, and abandoned.
+- `quest_series` rows whose `space_id` is selected.
+
+Export excludes:
+
+- settings
+- device identity
+- paired devices
+- space sync mappings
+- sync outbox, acks, seen rows, and tombstones
+- reminders
+- series reminder templates
+- notification snoozes
+- focus history
+
+Settings export flow:
+
+1. User clicks `Export backup`.
+2. Show a space checklist dialog.
+3. No spaces are checked by default.
+4. `Export` is disabled until at least one space is selected.
+5. User chooses a save location through the native save/create-document picker.
+6. Backend writes the zip.
+7. Show `Backup exported`.
+
+CLI export requires one or more `--space-id` values or explicit `--all-spaces`.
+
+## Import
+
+Settings import flow:
+
+1. User clicks `Import backup`.
+2. Native document picker opens and accepts `.zip` files.
+3. Backend validates the zip and manifest before any write.
+4. Backend preflights imported spaces, quests, and quest series.
+5. Built-in spaces are hidden from mapping and automatically use matching IDs.
+6. Custom backup spaces with existing local IDs use that ID automatically.
+7. Missing custom backup spaces are resolved one at a time.
+8. User chooses `Create new` or selects an existing local space to map.
+9. After space mapping, item conflicts are resolved.
+10. Import applies changes in one transaction.
+11. Spaces, quests, and focus refresh in place; user stays on Settings.
+12. Show `Backup imported`.
+
+CLI import does no space mapping UI. It imports as-is by IDs, fails on conflicts by default, and `--force` uses backup versions.
+
+## Space Mapping
+
+Built-in space IDs are `1`, `2`, and `3`.
+
+- Built-in spaces map to matching built-in IDs and are hidden from mapping UI.
+- Incoming custom spaces whose IDs already exist locally map to that same ID automatically.
+- Missing custom spaces require `create_new` or `use_existing`.
+- `create_new` creates the local space using the backup space ID.
+- `use_existing` assigns imported quests and quest series from that backup space to the selected local space ID.
+
+## MergeConflictDialog
+
+`MergeConflictDialog` is a reusable global dialog for one-at-a-time item conflicts. Backup is its first consumer.
+
+User-facing labels:
+
+- `Local` means current app data.
+- `Backup` means incoming backup file data.
+
+Layout:
+
+```text
+[Conflict title]                                      3/10
+
+Local                         Backup
+--------------------------    --------------------------
+Current local summary         Incoming backup summary
+
+[Copy]                        [Copy]
+[Show]                        [Show]
+
+[Use local]                   [Use backup]
+```
+
+Rules:
+
+- Counter appears in the top-right corner in short `3/10` format.
+- Counter numerator is the number of conflicts with selected resolutions.
+- `Use local` and `Use backup` are the lowest buttons in their columns.
+- `Copy` copies that column's visible/details content.
+- `Show` expands full details for that column.
+- `Use local` keeps current app data.
+- `Use backup` applies the incoming backup version.
+- There is no `Skip` button; `Use local` covers that behavior.
+- Apply is disabled until every conflict has a selected resolution.
+- Selected choice is visibly highlighted.
+
+## Relations
+
+Use the term `relations` for normal data relationships.
+
+Relevant relations:
+
+- A quest belongs to a space.
+- A repeating quest belongs to a quest series.
+
+The importer must not write quests or quest series in a state that breaks these relations.
+
+## Acceptance Criteria
+
+- Settings has a Backup section with `Export backup` and `Import backup`.
+- Settings export uses a native save/create-document flow.
+- Settings import uses a native open-document flow restricted to `.zip`.
+- Android Settings import/export uses document picker/create-document style flows.
+- Export checklist starts with no spaces selected.
+- Export button is disabled until at least one space is selected.
+- Export writes a `.zip` containing exactly `manifest.json` and `fini-backup.sqlite`.
+- Export includes only selected spaces, their quests, and selected-space quest series.
+- Import rejects any file that is not the v1 backup zip format.
+- Import maps custom incoming spaces one at a time using the device-sync-style mapping pattern.
+- Built-in spaces are auto-mapped and hidden from mapping.
+- Existing local custom space IDs are reused without mapping.
+- Missing custom space IDs require create-new or map-to-existing choice.
+- Quest and quest-series conflicts use the generic `MergeConflictDialog`.
+- CLI export requires `--space-id` or `--all-spaces`.
+- CLI import fails on conflicts by default.
+- CLI import `--force` uses backup versions for conflicts.
+- Import applies changes in one transaction.
+- After Settings import succeeds, app state refreshes and user stays on Settings.

--- a/specs/e2e/ui/tests/backup-flow.spec.ts
+++ b/specs/e2e/ui/tests/backup-flow.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from '../fixtures.ts';
+
+interface Space { id: string; name: string }
+interface PreflightResult { required_space_mappings: unknown[]; conflicts: unknown[] }
+
+async function invokeTauri<T>(
+  tauriPage: { evaluate: <R>(script: string) => Promise<R> },
+  cmd: string,
+  args?: Record<string, unknown>,
+): Promise<T> {
+  return tauriPage.evaluate<T>(`(async () => {
+    const invoke = window.__TAURI_INTERNALS__?.invoke;
+    if (!invoke) throw new Error('Tauri invoke is unavailable');
+    return await invoke(${JSON.stringify(cmd)}, ${JSON.stringify(args ?? {})});
+  })()`);
+}
+
+/**
+ * Set window globals read by the frontend's E2E hooks to bypass native OS dialogs.
+ * open → returned by useBackupImport's startImport()
+ * save → returned by ExportSpacesDialog's exportSelected()
+ */
+async function setDialogPath(
+  tauriPage: { evaluate: <R>(script: string) => Promise<R> },
+  patches: { open?: string | null; save?: string | null },
+): Promise<void> {
+  await tauriPage.evaluate(`(() => {
+    ${patches.open !== undefined ? `window.__FINI_E2E_OPEN_PATH__ = ${JSON.stringify(patches.open)};` : ''}
+    ${patches.save !== undefined ? `window.__FINI_E2E_SAVE_PATH__ = ${JSON.stringify(patches.save)};` : ''}
+  })()`);
+}
+
+async function clickRowButton(
+  tauriPage: { evaluate: <R>(script: string) => Promise<R> },
+  testId: string,
+): Promise<void> {
+  await tauriPage.evaluate(`(() => {
+    const row = document.querySelector('[data-testid="${testId}"]');
+    if (!(row instanceof HTMLElement)) throw new Error('${testId} not found');
+    row.scrollIntoView({ behavior: 'instant', block: 'center' });
+    const btn = row.querySelector('button') ?? row;
+    (btn instanceof HTMLElement ? btn : row).click();
+  })()`);
+}
+
+async function navigateToSettings(
+  tauriPage: { waitForSelector: (s: string, t?: number) => Promise<unknown>; evaluate: <R>(s: string) => Promise<R> },
+): Promise<void> {
+  await tauriPage.waitForSelector('nav.nav', 30_000);
+  await tauriPage.evaluate(`(() => { window.location.hash = '#/settings'; })()`);
+  await tauriPage.waitForSelector('[data-testid="settings-backup"]', 10_000);
+}
+
+test('Settings page renders backup section with export and import rows', async ({ tauriPage }) => {
+  await navigateToSettings(tauriPage);
+
+  expect(await tauriPage.isVisible('[data-testid="backup-export-row"]')).toBe(true);
+  expect(await tauriPage.isVisible('[data-testid="backup-import-row"]')).toBe(true);
+});
+
+test('export: dialog opens, select-all enables Export button, export completes with toast', async ({ tauriPage }) => {
+  const exportPath = '/var/tmp/fini-e2e-export-ui.zip';
+
+  await navigateToSettings(tauriPage);
+  await setDialogPath(tauriPage, { save: exportPath });
+
+  // Click the inner button inside the export row
+  await clickRowButton(tauriPage, 'backup-export-row');
+  await tauriPage.waitForSelector('[data-testid="export-spaces-dialog"]', 5_000);
+
+  // Export button is disabled until a space is selected
+  const exportBtnDisabled = await tauriPage.evaluate<boolean>(`(() => {
+    const btns = Array.from(document.querySelectorAll('[data-testid="export-spaces-dialog"] button'));
+    const btn = btns.find(b => b.textContent?.trim().startsWith('Export'));
+    return btn instanceof HTMLButtonElement && btn.disabled;
+  })()`);
+  expect(exportBtnDisabled).toBe(true);
+
+  // Click "Select all"
+  await tauriPage.evaluate(`(() => {
+    const btns = Array.from(document.querySelectorAll('[data-testid="export-spaces-dialog"] button'));
+    const btn = btns.find(b => b.textContent?.trim() === 'Select all');
+    if (!(btn instanceof HTMLElement)) throw new Error('Select all button not found');
+    btn.click();
+  })()`);
+
+  // Export button is now enabled with space count
+  await tauriPage.waitForFunction(`(() => {
+    const btns = Array.from(document.querySelectorAll('[data-testid="export-spaces-dialog"] button'));
+    const btn = btns.find(b => b.textContent?.trim().startsWith('Export'));
+    return btn instanceof HTMLButtonElement && !btn.disabled;
+  })()`, 5_000);
+
+  // Click Export — save path is intercepted via window global, backup_export runs, toast appears
+  await tauriPage.evaluate(`(() => {
+    const btns = Array.from(document.querySelectorAll('[data-testid="export-spaces-dialog"] button'));
+    const btn = btns.find(b => b.textContent?.trim().startsWith('Export'));
+    if (!(btn instanceof HTMLElement)) throw new Error('Export button not found');
+    btn.click();
+  })()`);
+
+  await tauriPage.waitForFunction(`(() =>
+    document.body.textContent?.includes('Backup exported')
+  )()`, 8_000);
+
+  const hasOpenLocation = await tauriPage.evaluate<boolean>(`(() =>
+    document.body.textContent?.includes('Open location') ?? false
+  )()`);
+  expect(hasOpenLocation).toBe(true);
+});
+
+test('import: picking a backup with no conflicts auto-applies and shows toast', async ({ tauriPage }) => {
+  const backupPath = '/var/tmp/fini-e2e-import-ui.zip';
+  const spaces = await invokeTauri<Space[]>(tauriPage, 'get_spaces');
+  await invokeTauri<void>(tauriPage, 'backup_export', { path: backupPath, spaceIds: spaces.map(s => s.id) });
+
+  // Verify preflight has no conflicts (the import should auto-apply)
+  const preflight = await invokeTauri<PreflightResult>(tauriPage, 'backup_preflight_import', {
+    path: backupPath,
+    mappings: [],
+  });
+  expect(preflight.required_space_mappings).toHaveLength(0);
+  expect(preflight.conflicts).toHaveLength(0);
+
+  await navigateToSettings(tauriPage);
+  await setDialogPath(tauriPage, { open: backupPath });
+
+  // Click the inner button inside the import row — open() intercepted, preflight runs, auto-apply fires
+  await clickRowButton(tauriPage, 'backup-import-row');
+
+  await tauriPage.waitForFunction(`(() =>
+    document.body.textContent?.includes('Backup imported')
+  )()`, 10_000);
+});

--- a/specs/e2e/ui/tests/reminder-notification-actions.spec.ts
+++ b/specs/e2e/ui/tests/reminder-notification-actions.spec.ts
@@ -157,17 +157,16 @@ test('schedule event is recorded when reminder is created', async ({ tauriPage }
 
   const { quest, reminder } = await createQuestWithTodayReminder(tauriPage, title);
 
-  // The scheduler is async — poll until the event lands (up to 3s).
+  // The scheduler is async — poll from the test runner until the event lands (up to 3s).
   let scheduled: NotificationEvent[] = [];
-  await tauriPage.waitForFunction(`(async () => {
-    const invoke = window.__TAURI_INTERNALS__?.invoke;
-    if (!invoke) return false;
-    const events = await invoke('e2e_list_notification_events', {});
-    return events.some((e) => e.phase === 'scheduled' && e.quest_id === ${JSON.stringify(quest.id)});
-  })()`, 3_000);
+  const deadline = Date.now() + 3_000;
+  while (Date.now() < deadline) {
+    const events = await invokeTauri<NotificationEvent[]>(tauriPage, 'e2e_list_notification_events');
+    scheduled = events.filter((e) => e.phase === 'scheduled' && e.quest_id === quest.id);
+    if (scheduled.length > 0) break;
+    await new Promise((r) => setTimeout(r, 100));
+  }
 
-  const events = await invokeTauri<NotificationEvent[]>(tauriPage, 'e2e_list_notification_events');
-  scheduled = events.filter((e) => e.phase === 'scheduled' && e.quest_id === quest.id);
   expect(scheduled.length).toBeGreaterThan(0);
   expect(scheduled[scheduled.length - 1].reminder_id).toBe(reminder.id);
 });

--- a/specs/e2e/ui/tests/reminder-notification-actions.spec.ts
+++ b/specs/e2e/ui/tests/reminder-notification-actions.spec.ts
@@ -157,8 +157,17 @@ test('schedule event is recorded when reminder is created', async ({ tauriPage }
 
   const { quest, reminder } = await createQuestWithTodayReminder(tauriPage, title);
 
+  // The scheduler is async — poll until the event lands (up to 3s).
+  let scheduled: NotificationEvent[] = [];
+  await tauriPage.waitForFunction(`(async () => {
+    const invoke = window.__TAURI_INTERNALS__?.invoke;
+    if (!invoke) return false;
+    const events = await invoke('e2e_list_notification_events', {});
+    return events.some((e) => e.phase === 'scheduled' && e.quest_id === ${JSON.stringify(quest.id)});
+  })()`, 3_000);
+
   const events = await invokeTauri<NotificationEvent[]>(tauriPage, 'e2e_list_notification_events');
-  const scheduled = events.filter((e) => e.phase === 'scheduled' && e.quest_id === quest.id);
+  scheduled = events.filter((e) => e.phase === 'scheduled' && e.quest_id === quest.id);
   expect(scheduled.length).toBeGreaterThan(0);
   expect(scheduled[scheduled.length - 1].reminder_id).toBe(reminder.id);
 });

--- a/specs/e2e/ui/tests/reminder-notification-actions.spec.ts
+++ b/specs/e2e/ui/tests/reminder-notification-actions.spec.ts
@@ -152,20 +152,26 @@ test('schedule event is recorded when reminder is created', async ({ tauriPage }
   const title = `e2e notif schedule ${Date.now()}`;
 
   await tauriPage.waitForSelector('nav.nav a[href="#/main"]', 30_000);
-  await tauriPage.click('nav.nav a[href="#/main"]');
   await invokeTauri<void>(tauriPage, 'e2e_clear_notification_events');
 
-  const { quest, reminder } = await createQuestWithTodayReminder(tauriPage, title);
+  // Use IPC to create quest with an explicit future due date (tomorrow at 09:00 UTC).
+  // The "today" UI shortcut defaults to 09:00 UTC which is already past in most CI runs,
+  // causing schedule_reminder to early-return with delay_ms <= 0 and record no event.
+  const tomorrow = new Date();
+  tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+  const dueDate = tomorrow.toISOString().slice(0, 10); // "YYYY-MM-DD"
+  const dueAtUtc = `${dueDate}T09:00:00Z`;
 
-  // The scheduler is async — poll from the test runner until the event lands (up to 3s).
-  let scheduled: NotificationEvent[] = [];
-  const deadline = Date.now() + 3_000;
-  while (Date.now() < deadline) {
-    const events = await invokeTauri<NotificationEvent[]>(tauriPage, 'e2e_list_notification_events');
-    scheduled = events.filter((e) => e.phase === 'scheduled' && e.quest_id === quest.id);
-    if (scheduled.length > 0) break;
-    await new Promise((r) => setTimeout(r, 100));
-  }
+  const quest = await invokeTauri<Quest>(tauriPage, 'create_quest', {
+    input: { title, due: dueDate, due_time: '09:00' },
+  });
+  const reminder = await invokeTauri<Reminder>(tauriPage, 'create_reminder', {
+    input: { quest_id: quest.id, kind: 'absolute', due_at_utc: dueAtUtc },
+  });
+
+  // schedule_reminder is synchronous within create_reminder — event should be immediate.
+  const events = await invokeTauri<NotificationEvent[]>(tauriPage, 'e2e_list_notification_events');
+  const scheduled = events.filter((e) => e.phase === 'scheduled' && e.quest_id === quest.id);
 
   expect(scheduled.length).toBeGreaterThan(0);
   expect(scheduled[scheduled.length - 1].reminder_id).toBe(reminder.id);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -120,6 +120,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +334,21 @@ dependencies = [
  "shlex",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -812,6 +836,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.13.1",
+ "smallvec",
+]
+
+[[package]]
 name = "cssparser-macros"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,13 +860,19 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.9"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
 dependencies = [
- "quote",
- "syn 2.0.117",
+ "ctor-proc-macro",
+ "dtor",
 ]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "darling"
@@ -913,6 +956,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,12 +977,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
  "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1100,6 +1186,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "dom_query"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
+dependencies = [
+ "bit-set",
+ "cssparser 0.36.0",
+ "foldhash 0.2.0",
+ "html5ever 0.38.0",
+ "precomputed-hash",
+ "selectors 0.36.1",
+ "tendril 0.5.0",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1142,6 +1243,21 @@ checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
  "dtoa",
 ]
+
+[[package]]
+name = "dtor"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dunce"
@@ -1313,6 +1429,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
+ "tauri-plugin-dialog",
  "tauri-plugin-mcp-bridge",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
@@ -1322,6 +1439,7 @@ dependencies = [
  "tokio-tungstenite 0.26.2",
  "uuid",
  "zbus",
+ "zip",
  "zvariant",
 ]
 
@@ -1884,8 +2002,18 @@ checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
 dependencies = [
  "log",
  "mac",
- "markup5ever",
+ "markup5ever 0.14.1",
  "match_token",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
+dependencies = [
+ "log",
+ "markup5ever 0.38.0",
 ]
 
 [[package]]
@@ -2353,10 +2481,10 @@ version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
 dependencies = [
- "cssparser",
- "html5ever",
+ "cssparser 0.29.6",
+ "html5ever 0.29.1",
  "indexmap 2.13.0",
- "selectors",
+ "selectors 0.24.0",
 ]
 
 [[package]]
@@ -2394,6 +2522,15 @@ name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -2504,9 +2641,20 @@ dependencies = [
  "log",
  "phf 0.11.3",
  "phf_codegen 0.11.3",
- "string_cache",
- "string_cache_codegen",
- "tendril",
+ "string_cache 0.8.9",
+ "string_cache_codegen 0.5.4",
+ "tendril 0.4.3",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
+dependencies = [
+ "log",
+ "tendril 0.5.0",
+ "web_atoms",
 ]
 
 [[package]]
@@ -2622,9 +2770,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c1738382f66ed56b3b9c8119e794a2e23148ac8ea214eda86622d4cb9d415a"
+checksum = "47a2e3dff89cd322c66647942668faee0a2b1f88ea6cbb4d374b4a8d7e92528c"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -2635,10 +2783,10 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
  "once_cell",
- "png 0.17.16",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2814,8 +2962,8 @@ dependencies = [
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
- "objc2-core-data",
- "objc2-core-image",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
  "objc2-foundation 0.2.2",
  "objc2-quartz-core 0.2.2",
 ]
@@ -2842,8 +2990,19 @@ dependencies = [
  "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-core-location",
+ "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2867,6 +3026,16 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2906,6 +3075,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-core-location"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2915,6 +3094,28 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-contacts",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -3036,16 +3237,16 @@ dependencies = [
  "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-cloud-kit",
- "objc2-core-data",
- "objc2-core-image",
- "objc2-core-location",
+ "objc2-cloud-kit 0.2.2",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
+ "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",
  "objc2-quartz-core 0.2.2",
  "objc2-symbols",
  "objc2-uniform-type-identifiers",
- "objc2-user-notifications",
+ "objc2-user-notifications 0.2.2",
 ]
 
 [[package]]
@@ -3055,9 +3256,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
  "objc2 0.6.4",
+ "objc2-cloud-kit 0.3.2",
+ "objc2-core-data 0.3.2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image 0.3.2",
+ "objc2-core-location 0.3.2",
+ "objc2-core-text",
  "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "objc2-user-notifications 0.3.2",
 ]
 
 [[package]]
@@ -3080,8 +3290,18 @@ dependencies = [
  "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-core-location",
+ "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3272,8 +3492,18 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros 0.11.3",
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -3294,6 +3524,16 @@ checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -3327,6 +3567,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
 name = "phf_macros"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3342,12 +3592,12 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3376,6 +3626,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher 1.0.2",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher 1.0.2",
 ]
@@ -3942,6 +4201,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2 0.6.2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4162,14 +4445,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416"
 dependencies = [
  "bitflags 1.3.2",
- "cssparser",
- "derive_more",
+ "cssparser 0.29.6",
+ "derive_more 0.99.20",
  "fxhash",
  "log",
  "phf 0.8.0",
  "phf_codegen 0.8.0",
  "precomputed-hash",
- "servo_arc",
+ "servo_arc 0.2.0",
+ "smallvec",
+]
+
+[[package]]
+name = "selectors"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
+dependencies = [
+ "bitflags 2.11.0",
+ "cssparser 0.36.0",
+ "derive_more 2.1.1",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc 0.4.3",
  "smallvec",
 ]
 
@@ -4350,6 +4652,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52aa42f8fdf0fed91e5ce7f23d8138441002fa31dca008acf47e6fd4721f741"
 dependencies = [
  "nodrop",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
  "stable_deref_trait",
 ]
 
@@ -4545,6 +4856,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "string_cache_codegen"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4552,6 +4875,18 @@ checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
 ]
@@ -4636,15 +4971,16 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.34.6"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d52c379e63da659a483a958110bbde891695a0ecb53e48cc7786d5eda7bb"
+checksum = "a33f7f9e486ade65fcf1e45c440f9236c904f5c1002cdc7fc6ae582777345ce4"
 dependencies = [
  "bitflags 2.11.0",
  "block2 0.6.2",
  "core-foundation",
  "core-graphics",
  "crossbeam-channel",
+ "dbus",
  "dispatch2",
  "dlopen2",
  "dpi",
@@ -4655,13 +4991,14 @@ dependencies = [
  "libc",
  "log",
  "ndk 0.9.0",
- "ndk-context",
  "ndk-sys 0.6.0+11769913",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
  "once_cell",
  "parking_lot",
+ "percent-encoding",
  "raw-window-handle",
  "tao-macros",
  "unicode-segmentation",
@@ -4691,9 +5028,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.10.3"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da77cc00fb9028caf5b5d4650f75e31f1ef3693459dfca7f7e506d1ecef0ba2d"
+checksum = "d059f2527558d9dba6f186dec4772610e1aecfd3f94002397613e7e648752b66"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4742,9 +5079,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.5.6"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d"
+checksum = "4aa1f9055fc23919a54e4e125052bed16ed04aef0487086e758fe01a67b451c7"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -4758,15 +5095,14 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "tauri-winres",
- "toml 0.9.12+spec-1.1.0",
  "walkdir",
 ]
 
 [[package]]
 name = "tauri-codegen"
-version = "2.5.5"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a24476afd977c5d5d169f72425868613d82747916dd29e0a357c84c4bd6d29"
+checksum = "e4a0319528a025a38c4078e7dae2c446f4e63620ddb0659a643ede1cb38f90e9"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -4791,9 +5127,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.5.5"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39b349a98dadaffebb73f0a40dcd1f23c999211e5a2e744403db384d0c33de7"
+checksum = "ae6cb4e3896c21d2f6da5b31251d2faea0153bba56ed0e970f918115dbee4924"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4832,6 +5168,48 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation 0.3.2",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.0.6+spec-1.1.0",
+ "url",
 ]
 
 [[package]]
@@ -4920,9 +5298,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.10.1"
+version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2826d79a3297ed08cd6ea7f412644ef58e32969504bc4fbd8d7dbeabc4445ea2"
+checksum = "48222d7116c8807eaa6fe2f372e023fae125084e61e6eca6d70b7961cdf129ef"
 dependencies = [
  "cookie",
  "dpi",
@@ -4945,9 +5323,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.10.1"
+version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e"
+checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
  "http",
@@ -4971,24 +5349,26 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.8.3"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219a1f983a2af3653f75b5747f76733b0da7ff03069c7a41901a5eb3ace4557d"
+checksum = "092379df9a707631978e6c56b1bc2401d387f01e2d4a3c123360d167bbb9aa95"
 dependencies = [
  "anyhow",
  "brotli",
  "cargo_metadata",
  "ctor",
+ "dom_query",
  "dunce",
  "glob",
- "html5ever",
+ "html5ever 0.29.1",
  "http",
  "infer",
  "json-patch",
  "kuchikiki",
  "log",
  "memchr",
- "phf 0.11.3",
+ "phf 0.13.1",
+ "plist",
  "proc-macro2",
  "quote",
  "regex",
@@ -5000,7 +5380,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.0.6+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -5051,6 +5431,16 @@ checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
 dependencies = [
  "futf",
  "mac",
+ "utf-8",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
  "utf-8",
 ]
 
@@ -5253,6 +5643,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned 1.0.4",
+ "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5408,9 +5813,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.21.3"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
+checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
 dependencies = [
  "crossbeam-channel",
  "dirs 6.0.0",
@@ -5422,10 +5827,10 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation 0.3.2",
  "once_cell",
- "png 0.17.16",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5835,6 +6240,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
+dependencies = [
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache 0.9.0",
+ "string_cache_codegen 0.6.1",
 ]
 
 [[package]]
@@ -6588,24 +7005,23 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wry"
-version = "0.54.2"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb26159b420aa77684589a744ae9a9461a95395b848764ad12290a14d960a11a"
+checksum = "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514"
 dependencies = [
  "base64 0.22.1",
  "block2 0.6.2",
  "cookie",
  "crossbeam-channel",
  "dirs 6.0.0",
+ "dom_query",
  "dpi",
  "dunce",
  "gdkx11",
  "gtk",
- "html5ever",
  "http",
  "javascriptcore-rs",
  "jni",
- "kuchikiki",
  "libc",
  "ndk 0.9.0",
  "objc2 0.6.4",
@@ -6817,10 +7233,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.13.0",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-core"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -50,6 +50,8 @@ socket2 = "0.6"
 mdns-sd = "0.13"
 zbus = { version = "5.14.0", features = ["blocking-api"] }
 zvariant = "5.10.0"
+zip = { version = "2", default-features = false, features = ["deflate"] }
+tauri-plugin-dialog = "2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = "0.18.2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "core:window:allow-set-size",
+    "dialog:default",
     "opener:default",
     "notification:default",
     "mcp-bridge:default",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod services;
 // mod voice;       // postponed
 // mod model_download; // postponed
 
+use services::backup::{backup_apply_import, backup_export, backup_preflight_import};
 use services::db::{app_data_dir, open_db, DbState};
 use services::device_connection::{
     device_connection_consume_space_mapping_updates, device_connection_debug_status,
@@ -16,13 +17,13 @@ use services::device_connection::{
     device_connection_save_paired_device, device_connection_send_pair_request,
     device_connection_unpair, device_connection_update_last_seen, DeviceConnectionState,
 };
+use services::notification::{
+    dispatch_action, setup_notifications, SchedulerState, FOREGROUND_FIRE_EVENT, TAP_EVENT,
+};
 #[cfg(feature = "e2e-testing")]
 use services::notification::{
     e2e_clear_notification_events, e2e_dispatch_notification_action, e2e_list_notification_events,
     NotificationObserverState,
-};
-use services::notification::{
-    dispatch_action, setup_notifications, SchedulerState, FOREGROUND_FIRE_EVENT, TAP_EVENT,
 };
 mod resume_watcher;
 use services::quest::{
@@ -119,6 +120,7 @@ pub fn run() {
 
     let builder = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_notification::init());
     #[cfg(all(
         any(target_os = "linux", target_os = "macos", target_os = "windows"),
@@ -181,6 +183,9 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             get_spaces,
+            backup_export,
+            backup_preflight_import,
+            backup_apply_import,
             create_space,
             update_space,
             delete_space,

--- a/src-tauri/src/services/backup.rs
+++ b/src-tauri/src/services/backup.rs
@@ -1,0 +1,957 @@
+use std::collections::{HashMap, HashSet};
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use diesel::connection::SimpleConnection;
+use diesel::prelude::*;
+use diesel::sql_types::Text;
+use diesel::sqlite::SqliteConnection;
+use serde::{Deserialize, Serialize};
+use tauri::State;
+use uuid::Uuid;
+use zip::write::SimpleFileOptions;
+
+use crate::models::{Quest, QuestSeries, Space};
+use crate::schema::{quest_series, quests, spaces};
+use crate::services::db::{utc_now, DbState};
+
+const MANIFEST_NAME: &str = "manifest.json";
+const BACKUP_DB_NAME: &str = "fini-backup.sqlite";
+const BACKUP_FORMAT: &str = "fini-backup";
+const BACKUP_VERSION: u32 = 1;
+const BUILTIN_SPACE_IDS: [&str; 3] = ["1", "2", "3"];
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BackupManifest {
+    pub format: String,
+    pub version: u32,
+    pub app_version: String,
+    pub exported_at: String,
+    pub domains: Vec<String>,
+    pub spaces: Vec<ManifestSpace>,
+    pub counts: ManifestCounts,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ManifestSpace {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ManifestCounts {
+    pub spaces: usize,
+    pub quest_series: usize,
+    pub quests: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BackupExportResult {
+    pub path: String,
+    pub manifest: BackupManifest,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BackupImportPreflight {
+    pub manifest: BackupManifest,
+    pub required_space_mappings: Vec<BackupSpaceMappingRequest>,
+    pub conflicts: Vec<BackupConflict>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BackupSpaceMappingRequest {
+    pub backup_space_id: String,
+    pub backup_space_name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BackupConflict {
+    pub entity_type: String,
+    pub id: String,
+    pub title: String,
+    pub local_summary: String,
+    pub backup_summary: String,
+    pub local: serde_json::Value,
+    pub backup: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct BackupSpaceMappingInput {
+    pub backup_space_id: String,
+    pub mode: String,
+    pub local_space_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct BackupConflictResolutionInput {
+    pub entity_type: String,
+    pub id: String,
+    pub resolution: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BackupImportResult {
+    pub imported: bool,
+    pub spaces: usize,
+    pub quest_series: usize,
+    pub quests: usize,
+}
+
+#[derive(QueryableByName)]
+struct TableNameRow {
+    #[diesel(sql_type = Text)]
+    name: String,
+}
+
+#[tauri::command]
+pub fn backup_export(
+    state: State<DbState>,
+    path: String,
+    space_ids: Vec<String>,
+) -> Result<BackupExportResult, String> {
+    let mut conn = state.inner().0.lock().unwrap();
+    export_backup(&mut conn, Path::new(&path), &space_ids)
+}
+
+#[tauri::command]
+pub fn backup_preflight_import(
+    state: State<DbState>,
+    path: String,
+    mappings: Vec<BackupSpaceMappingInput>,
+) -> Result<BackupImportPreflight, String> {
+    let mut conn = state.inner().0.lock().unwrap();
+    preflight_import(&mut conn, Path::new(&path), &mappings)
+}
+
+#[tauri::command]
+pub fn backup_apply_import(
+    state: State<DbState>,
+    path: String,
+    mappings: Vec<BackupSpaceMappingInput>,
+    resolutions: Vec<BackupConflictResolutionInput>,
+) -> Result<BackupImportResult, String> {
+    let mut conn = state.inner().0.lock().unwrap();
+    apply_import(&mut conn, Path::new(&path), &mappings, &resolutions)
+}
+
+pub fn export_backup(
+    conn: &mut SqliteConnection,
+    output_path: &Path,
+    space_ids: &[String],
+) -> Result<BackupExportResult, String> {
+    if space_ids.is_empty() {
+        return Err("select at least one space to export".to_string());
+    }
+
+    let selected: HashSet<&str> = space_ids.iter().map(String::as_str).collect();
+    let selected_spaces = spaces::table
+        .filter(spaces::id.eq_any(space_ids))
+        .select(Space::as_select())
+        .order(spaces::item_order.asc())
+        .load::<Space>(conn)
+        .map_err(|e| e.to_string())?;
+
+    if selected_spaces.len() != selected.len() {
+        return Err("one or more selected spaces were not found".to_string());
+    }
+
+    let selected_series = quest_series::table
+        .filter(quest_series::space_id.eq_any(space_ids))
+        .select(QuestSeries::as_select())
+        .load::<QuestSeries>(conn)
+        .map_err(|e| e.to_string())?;
+    let selected_quests = quests::table
+        .filter(quests::space_id.eq_any(space_ids))
+        .select(Quest::as_select())
+        .load::<Quest>(conn)
+        .map_err(|e| e.to_string())?;
+
+    let manifest = BackupManifest {
+        format: BACKUP_FORMAT.to_string(),
+        version: BACKUP_VERSION,
+        app_version: env!("CARGO_PKG_VERSION").to_string(),
+        exported_at: utc_now(),
+        domains: vec![
+            "spaces".to_string(),
+            "quest_series".to_string(),
+            "quests".to_string(),
+        ],
+        spaces: selected_spaces
+            .iter()
+            .map(|space| ManifestSpace {
+                id: space.id.clone(),
+                name: space.name.clone(),
+            })
+            .collect(),
+        counts: ManifestCounts {
+            spaces: selected_spaces.len(),
+            quest_series: selected_series.len(),
+            quests: selected_quests.len(),
+        },
+    };
+
+    let temp_dir = create_temp_dir("export")?;
+    let backup_db_path = temp_dir.join(BACKUP_DB_NAME);
+    let mut backup_conn = SqliteConnection::establish(path_str(&backup_db_path)?)
+        .map_err(|e| format!("failed to create backup database: {e}"))?;
+    create_backup_schema(&mut backup_conn)?;
+
+    for space in &selected_spaces {
+        insert_space(&mut backup_conn, space).map_err(|e| e.to_string())?;
+    }
+    for series in &selected_series {
+        insert_series(&mut backup_conn, series).map_err(|e| e.to_string())?;
+    }
+    for quest in &selected_quests {
+        insert_quest(&mut backup_conn, quest).map_err(|e| e.to_string())?;
+    }
+
+    write_zip(output_path, &manifest, &backup_db_path)?;
+    let _ = fs::remove_dir_all(&temp_dir);
+
+    Ok(BackupExportResult {
+        path: output_path.to_string_lossy().to_string(),
+        manifest,
+    })
+}
+
+pub fn preflight_import(
+    conn: &mut SqliteConnection,
+    path: &Path,
+    mappings: &[BackupSpaceMappingInput],
+) -> Result<BackupImportPreflight, String> {
+    let extracted = extract_backup(path)?;
+    let mut backup_conn = SqliteConnection::establish(path_str(&extracted.db_path)?)
+        .map_err(|e| format!("failed to open backup database: {e}"))?;
+    validate_backup_schema(&mut backup_conn)?;
+    validate_manifest(&extracted.manifest)?;
+
+    let backup_spaces = load_backup_spaces(&mut backup_conn)?;
+    let space_map = resolve_space_map(conn, &backup_spaces, mappings)?;
+    let required_space_mappings = required_space_mappings(conn, &backup_spaces, mappings)?;
+    let conflicts = collect_conflicts(conn, &mut backup_conn, &space_map)?;
+    let _ = fs::remove_dir_all(&extracted.temp_dir);
+
+    Ok(BackupImportPreflight {
+        manifest: extracted.manifest,
+        required_space_mappings,
+        conflicts,
+    })
+}
+
+pub fn apply_import(
+    conn: &mut SqliteConnection,
+    path: &Path,
+    mappings: &[BackupSpaceMappingInput],
+    resolutions: &[BackupConflictResolutionInput],
+) -> Result<BackupImportResult, String> {
+    let preflight = preflight_import(conn, path, mappings)?;
+    if !preflight.required_space_mappings.is_empty() {
+        return Err("resolve all backup space mappings before import".to_string());
+    }
+
+    let resolution_map: HashMap<(String, String), String> = resolutions
+        .iter()
+        .map(|resolution| {
+            (
+                (resolution.entity_type.clone(), resolution.id.clone()),
+                resolution.resolution.clone(),
+            )
+        })
+        .collect();
+    for conflict in &preflight.conflicts {
+        let key = (conflict.entity_type.clone(), conflict.id.clone());
+        if !matches!(
+            resolution_map.get(&key).map(String::as_str),
+            Some("local" | "backup")
+        ) {
+            return Err("resolve every backup conflict before import".to_string());
+        }
+    }
+
+    let extracted = extract_backup(path)?;
+    let mut backup_conn = SqliteConnection::establish(path_str(&extracted.db_path)?)
+        .map_err(|e| format!("failed to open backup database: {e}"))?;
+    validate_backup_schema(&mut backup_conn)?;
+    validate_manifest(&extracted.manifest)?;
+
+    let backup_spaces = load_backup_spaces(&mut backup_conn)?;
+    let backup_series = load_backup_series(&mut backup_conn)?;
+    let backup_quests = load_backup_quests(&mut backup_conn)?;
+    let space_map = resolve_space_map(conn, &backup_spaces, mappings)?;
+    let backup_space_by_id: HashMap<&str, &Space> = backup_spaces
+        .iter()
+        .map(|space| (space.id.as_str(), space))
+        .collect();
+
+    conn.transaction::<_, diesel::result::Error, _>(|tx| {
+        for (backup_space_id, local_space_id) in &space_map {
+            if backup_space_id != local_space_id {
+                continue;
+            }
+            let exists = local_space_exists(tx, local_space_id)?;
+            if !exists {
+                if let Some(space) = backup_space_by_id.get(backup_space_id.as_str()) {
+                    insert_space(tx, space)?;
+                }
+            }
+        }
+
+        for series in &backup_series {
+            let mapped = mapped_series(series, &space_map);
+            let action = conflict_action(&resolution_map, "quest_series", &mapped.id);
+            upsert_series_for_import(tx, &mapped, action)?;
+        }
+
+        for quest in &backup_quests {
+            let mapped = mapped_quest(quest, &space_map);
+            let action = conflict_action(&resolution_map, "quest", &mapped.id);
+            upsert_quest_for_import(tx, &mapped, action)?;
+        }
+
+        Ok(())
+    })
+    .map_err(|e| e.to_string())?;
+
+    let _ = fs::remove_dir_all(&extracted.temp_dir);
+    Ok(BackupImportResult {
+        imported: true,
+        spaces: preflight.manifest.counts.spaces,
+        quest_series: preflight.manifest.counts.quest_series,
+        quests: preflight.manifest.counts.quests,
+    })
+}
+
+pub fn import_cli(
+    conn: &mut SqliteConnection,
+    path: &Path,
+    force: bool,
+) -> Result<BackupImportResult, String> {
+    let preflight = preflight_import(conn, path, &[])?;
+    let mappings: Vec<BackupSpaceMappingInput> = preflight
+        .required_space_mappings
+        .iter()
+        .map(|mapping| BackupSpaceMappingInput {
+            backup_space_id: mapping.backup_space_id.clone(),
+            mode: "create_new".to_string(),
+            local_space_id: None,
+        })
+        .collect();
+    let preflight = preflight_import(conn, path, &mappings)?;
+    if !force && !preflight.conflicts.is_empty() {
+        return Err(format!(
+            "backup import has {} conflict(s); rerun with --force to use backup versions",
+            preflight.conflicts.len()
+        ));
+    }
+    let resolutions = preflight
+        .conflicts
+        .iter()
+        .map(|conflict| BackupConflictResolutionInput {
+            entity_type: conflict.entity_type.clone(),
+            id: conflict.id.clone(),
+            resolution: "backup".to_string(),
+        })
+        .collect::<Vec<_>>();
+    apply_import(conn, path, &mappings, &resolutions)
+}
+
+struct ExtractedBackup {
+    temp_dir: PathBuf,
+    db_path: PathBuf,
+    manifest: BackupManifest,
+}
+
+fn create_backup_schema(conn: &mut SqliteConnection) -> Result<(), String> {
+    conn.batch_execute(
+        "
+        PRAGMA foreign_keys = ON;
+        CREATE TABLE spaces (
+            id TEXT PRIMARY KEY NOT NULL,
+            name TEXT NOT NULL,
+            item_order INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL
+        );
+        CREATE TABLE quest_series (
+            id TEXT PRIMARY KEY NOT NULL,
+            space_id TEXT NOT NULL REFERENCES spaces(id) ON DELETE SET DEFAULT,
+            title TEXT NOT NULL,
+            description TEXT,
+            repeat_rule TEXT NOT NULL,
+            priority INTEGER NOT NULL DEFAULT 1,
+            energy TEXT NOT NULL DEFAULT 'medium',
+            active BOOLEAN NOT NULL DEFAULT 1,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+        CREATE TABLE quests (
+            id TEXT PRIMARY KEY NOT NULL,
+            space_id TEXT NOT NULL REFERENCES spaces(id) ON DELETE SET DEFAULT,
+            title TEXT NOT NULL,
+            description TEXT,
+            status TEXT NOT NULL DEFAULT 'active',
+            energy TEXT NOT NULL DEFAULT 'medium',
+            priority INTEGER NOT NULL DEFAULT 1,
+            pinned BOOLEAN NOT NULL DEFAULT 0,
+            due TEXT,
+            due_time TEXT,
+            repeat_rule TEXT,
+            completed_at TEXT,
+            order_rank REAL NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            series_id TEXT REFERENCES quest_series(id) ON DELETE CASCADE,
+            period_key TEXT
+        );
+        ",
+    )
+    .map_err(|e| e.to_string())
+}
+
+fn validate_backup_schema(conn: &mut SqliteConnection) -> Result<(), String> {
+    let rows = diesel::sql_query(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('spaces', 'quest_series', 'quests')",
+    )
+    .load::<TableNameRow>(conn)
+    .map_err(|e| format!("failed to inspect backup schema: {e}"))?;
+    let names: HashSet<String> = rows.into_iter().map(|row| row.name).collect();
+    for required in ["spaces", "quest_series", "quests"] {
+        if !names.contains(required) {
+            return Err(format!(
+                "backup database is missing required table {required}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_manifest(manifest: &BackupManifest) -> Result<(), String> {
+    if manifest.format != BACKUP_FORMAT {
+        return Err("unsupported backup format".to_string());
+    }
+    if manifest.version != BACKUP_VERSION {
+        return Err("unsupported backup version".to_string());
+    }
+    Ok(())
+}
+
+fn write_zip(output_path: &Path, manifest: &BackupManifest, db_path: &Path) -> Result<(), String> {
+    if let Some(parent) = output_path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("failed to create backup directory: {e}"))?;
+    }
+
+    let file =
+        File::create(output_path).map_err(|e| format!("failed to create backup zip: {e}"))?;
+    let mut zip = zip::ZipWriter::new(file);
+    let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+
+    zip.start_file(MANIFEST_NAME, options)
+        .map_err(|e| e.to_string())?;
+    let manifest_text = serde_json::to_vec_pretty(manifest).map_err(|e| e.to_string())?;
+    zip.write_all(&manifest_text).map_err(|e| e.to_string())?;
+
+    zip.start_file(BACKUP_DB_NAME, options)
+        .map_err(|e| e.to_string())?;
+    let mut db_file = File::open(db_path).map_err(|e| e.to_string())?;
+    std::io::copy(&mut db_file, &mut zip).map_err(|e| e.to_string())?;
+    zip.finish().map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn extract_backup(path: &Path) -> Result<ExtractedBackup, String> {
+    let file = File::open(path).map_err(|e| format!("failed to open backup: {e}"))?;
+    let mut archive =
+        zip::ZipArchive::new(file).map_err(|_| "backup must be a zip file".to_string())?;
+    if archive.len() != 2 {
+        return Err(
+            "backup zip must contain exactly manifest.json and fini-backup.sqlite".to_string(),
+        );
+    }
+    let mut names = Vec::new();
+    for index in 0..archive.len() {
+        let file = archive.by_index(index).map_err(|e| e.to_string())?;
+        names.push(file.name().to_string());
+    }
+    names.sort();
+    if names != [BACKUP_DB_NAME.to_string(), MANIFEST_NAME.to_string()] {
+        return Err(
+            "backup zip must contain exactly manifest.json and fini-backup.sqlite".to_string(),
+        );
+    }
+
+    let mut manifest_file = archive.by_name(MANIFEST_NAME).map_err(|e| e.to_string())?;
+    let mut manifest_text = String::new();
+    manifest_file
+        .read_to_string(&mut manifest_text)
+        .map_err(|e| e.to_string())?;
+    let manifest: BackupManifest =
+        serde_json::from_str(&manifest_text).map_err(|e| format!("invalid manifest.json: {e}"))?;
+    drop(manifest_file);
+
+    let temp_dir = create_temp_dir("import")?;
+    let db_path = temp_dir.join(BACKUP_DB_NAME);
+    let mut db_file = archive.by_name(BACKUP_DB_NAME).map_err(|e| e.to_string())?;
+    let mut out = File::create(&db_path).map_err(|e| e.to_string())?;
+    std::io::copy(&mut db_file, &mut out).map_err(|e| e.to_string())?;
+
+    Ok(ExtractedBackup {
+        temp_dir,
+        db_path,
+        manifest,
+    })
+}
+
+fn load_backup_spaces(conn: &mut SqliteConnection) -> Result<Vec<Space>, String> {
+    spaces::table
+        .select(Space::as_select())
+        .order(spaces::item_order.asc())
+        .load(conn)
+        .map_err(|e| e.to_string())
+}
+
+fn load_backup_series(conn: &mut SqliteConnection) -> Result<Vec<QuestSeries>, String> {
+    quest_series::table
+        .select(QuestSeries::as_select())
+        .load(conn)
+        .map_err(|e| e.to_string())
+}
+
+fn load_backup_quests(conn: &mut SqliteConnection) -> Result<Vec<Quest>, String> {
+    quests::table
+        .select(Quest::as_select())
+        .load(conn)
+        .map_err(|e| e.to_string())
+}
+
+fn required_space_mappings(
+    conn: &mut SqliteConnection,
+    backup_spaces: &[Space],
+    mappings: &[BackupSpaceMappingInput],
+) -> Result<Vec<BackupSpaceMappingRequest>, String> {
+    let mapped: HashSet<&str> = mappings
+        .iter()
+        .map(|m| m.backup_space_id.as_str())
+        .collect();
+    let mut required = Vec::new();
+    for space in backup_spaces {
+        if is_builtin_space(&space.id)
+            || local_space_exists(conn, &space.id).map_err(|e| e.to_string())?
+        {
+            continue;
+        }
+        if mapped.contains(space.id.as_str()) {
+            continue;
+        }
+        required.push(BackupSpaceMappingRequest {
+            backup_space_id: space.id.clone(),
+            backup_space_name: space.name.clone(),
+        });
+    }
+    Ok(required)
+}
+
+fn resolve_space_map(
+    conn: &mut SqliteConnection,
+    backup_spaces: &[Space],
+    mappings: &[BackupSpaceMappingInput],
+) -> Result<HashMap<String, String>, String> {
+    let mapping_by_backup: HashMap<&str, &BackupSpaceMappingInput> = mappings
+        .iter()
+        .map(|mapping| (mapping.backup_space_id.as_str(), mapping))
+        .collect();
+    let mut result = HashMap::new();
+    for space in backup_spaces {
+        if is_builtin_space(&space.id)
+            || local_space_exists(conn, &space.id).map_err(|e| e.to_string())?
+        {
+            result.insert(space.id.clone(), space.id.clone());
+            continue;
+        }
+        let Some(mapping) = mapping_by_backup.get(space.id.as_str()) else {
+            continue;
+        };
+        match mapping.mode.as_str() {
+            "create_new" => {
+                result.insert(space.id.clone(), space.id.clone());
+            }
+            "use_existing" => {
+                let local_space_id = mapping
+                    .local_space_id
+                    .as_deref()
+                    .ok_or_else(|| "existing local space id is required".to_string())?;
+                if !local_space_exists(conn, local_space_id).map_err(|e| e.to_string())? {
+                    return Err("selected local space does not exist".to_string());
+                }
+                result.insert(space.id.clone(), local_space_id.to_string());
+            }
+            _ => return Err("invalid backup space mapping mode".to_string()),
+        }
+    }
+    Ok(result)
+}
+
+fn collect_conflicts(
+    conn: &mut SqliteConnection,
+    backup_conn: &mut SqliteConnection,
+    space_map: &HashMap<String, String>,
+) -> Result<Vec<BackupConflict>, String> {
+    let mut conflicts = Vec::new();
+
+    for backup in load_backup_series(backup_conn)? {
+        let mapped = mapped_series(&backup, space_map);
+        if let Some(local) = quest_series::table
+            .find(&mapped.id)
+            .select(QuestSeries::as_select())
+            .first::<QuestSeries>(conn)
+            .optional()
+            .map_err(|e| e.to_string())?
+        {
+            if series_value(&local)? != series_value(&mapped)? {
+                conflicts.push(BackupConflict {
+                    entity_type: "quest_series".to_string(),
+                    id: mapped.id.clone(),
+                    title: mapped.title.clone(),
+                    local_summary: local.title.clone(),
+                    backup_summary: mapped.title.clone(),
+                    local: series_value(&local)?,
+                    backup: series_value(&mapped)?,
+                });
+            }
+        }
+    }
+
+    for backup in load_backup_quests(backup_conn)? {
+        let mapped = mapped_quest(&backup, space_map);
+        if let Some(local) = quests::table
+            .find(&mapped.id)
+            .select(Quest::as_select())
+            .first::<Quest>(conn)
+            .optional()
+            .map_err(|e| e.to_string())?
+        {
+            if quest_value(&local)? != quest_value(&mapped)? {
+                conflicts.push(BackupConflict {
+                    entity_type: "quest".to_string(),
+                    id: mapped.id.clone(),
+                    title: mapped.title.clone(),
+                    local_summary: format!("{} ({})", local.title, local.status),
+                    backup_summary: format!("{} ({})", mapped.title, mapped.status),
+                    local: quest_value(&local)?,
+                    backup: quest_value(&mapped)?,
+                });
+            }
+        }
+    }
+
+    Ok(conflicts)
+}
+
+fn insert_space(
+    conn: &mut SqliteConnection,
+    space: &Space,
+) -> Result<usize, diesel::result::Error> {
+    diesel::insert_into(spaces::table)
+        .values((
+            spaces::id.eq(&space.id),
+            spaces::name.eq(&space.name),
+            spaces::item_order.eq(space.item_order),
+            spaces::created_at.eq(&space.created_at),
+        ))
+        .execute(conn)
+}
+
+fn insert_series(
+    conn: &mut SqliteConnection,
+    series: &QuestSeries,
+) -> Result<usize, diesel::result::Error> {
+    diesel::insert_into(quest_series::table)
+        .values((
+            quest_series::id.eq(&series.id),
+            quest_series::space_id.eq(&series.space_id),
+            quest_series::title.eq(&series.title),
+            quest_series::description.eq(&series.description),
+            quest_series::repeat_rule.eq(&series.repeat_rule),
+            quest_series::priority.eq(series.priority),
+            quest_series::energy.eq(&series.energy),
+            quest_series::active.eq(series.active),
+            quest_series::created_at.eq(&series.created_at),
+            quest_series::updated_at.eq(&series.updated_at),
+        ))
+        .execute(conn)
+}
+
+fn insert_quest(
+    conn: &mut SqliteConnection,
+    quest: &Quest,
+) -> Result<usize, diesel::result::Error> {
+    diesel::insert_into(quests::table)
+        .values((
+            quests::id.eq(&quest.id),
+            quests::space_id.eq(&quest.space_id),
+            quests::title.eq(&quest.title),
+            quests::description.eq(&quest.description),
+            quests::status.eq(&quest.status),
+            quests::energy.eq(&quest.energy),
+            quests::priority.eq(quest.priority),
+            quests::pinned.eq(quest.pinned),
+            quests::due.eq(&quest.due),
+            quests::due_time.eq(&quest.due_time),
+            quests::repeat_rule.eq(&quest.repeat_rule),
+            quests::completed_at.eq(&quest.completed_at),
+            quests::order_rank.eq(quest.order_rank),
+            quests::created_at.eq(&quest.created_at),
+            quests::updated_at.eq(&quest.updated_at),
+            quests::series_id.eq(&quest.series_id),
+            quests::period_key.eq(&quest.period_key),
+        ))
+        .execute(conn)
+}
+
+fn upsert_series_for_import(
+    conn: &mut SqliteConnection,
+    series: &QuestSeries,
+    action: ConflictAction,
+) -> Result<(), diesel::result::Error> {
+    if matches!(action, ConflictAction::KeepLocal) {
+        return Ok(());
+    }
+    let exists = quest_series::table
+        .find(&series.id)
+        .select(quest_series::id)
+        .first::<String>(conn)
+        .optional()?
+        .is_some();
+    if exists {
+        diesel::update(quest_series::table.find(&series.id))
+            .set((
+                quest_series::space_id.eq(&series.space_id),
+                quest_series::title.eq(&series.title),
+                quest_series::description.eq(&series.description),
+                quest_series::repeat_rule.eq(&series.repeat_rule),
+                quest_series::priority.eq(series.priority),
+                quest_series::energy.eq(&series.energy),
+                quest_series::active.eq(series.active),
+                quest_series::created_at.eq(&series.created_at),
+                quest_series::updated_at.eq(&series.updated_at),
+            ))
+            .execute(conn)?;
+    } else {
+        insert_series(conn, series)?;
+    }
+    Ok(())
+}
+
+fn upsert_quest_for_import(
+    conn: &mut SqliteConnection,
+    quest: &Quest,
+    action: ConflictAction,
+) -> Result<(), diesel::result::Error> {
+    if matches!(action, ConflictAction::KeepLocal) {
+        return Ok(());
+    }
+    let exists = quests::table
+        .find(&quest.id)
+        .select(quests::id)
+        .first::<String>(conn)
+        .optional()?
+        .is_some();
+    if exists {
+        diesel::update(quests::table.find(&quest.id))
+            .set((
+                quests::space_id.eq(&quest.space_id),
+                quests::title.eq(&quest.title),
+                quests::description.eq(&quest.description),
+                quests::status.eq(&quest.status),
+                quests::energy.eq(&quest.energy),
+                quests::priority.eq(quest.priority),
+                quests::pinned.eq(quest.pinned),
+                quests::due.eq(&quest.due),
+                quests::due_time.eq(&quest.due_time),
+                quests::repeat_rule.eq(&quest.repeat_rule),
+                quests::completed_at.eq(&quest.completed_at),
+                quests::order_rank.eq(quest.order_rank),
+                quests::created_at.eq(&quest.created_at),
+                quests::updated_at.eq(&quest.updated_at),
+                quests::series_id.eq(&quest.series_id),
+                quests::period_key.eq(&quest.period_key),
+            ))
+            .execute(conn)?;
+    } else {
+        insert_quest(conn, quest)?;
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum ConflictAction {
+    KeepLocal,
+    UseBackup,
+}
+
+fn conflict_action(
+    resolution_map: &HashMap<(String, String), String>,
+    entity_type: &str,
+    id: &str,
+) -> ConflictAction {
+    match resolution_map
+        .get(&(entity_type.to_string(), id.to_string()))
+        .map(String::as_str)
+    {
+        Some("local") => ConflictAction::KeepLocal,
+        _ => ConflictAction::UseBackup,
+    }
+}
+
+fn local_space_exists(
+    conn: &mut SqliteConnection,
+    id: &str,
+) -> Result<bool, diesel::result::Error> {
+    spaces::table
+        .find(id)
+        .select(spaces::id)
+        .first::<String>(conn)
+        .optional()
+        .map(|row| row.is_some())
+}
+
+fn mapped_series(series: &QuestSeries, space_map: &HashMap<String, String>) -> QuestSeries {
+    QuestSeries {
+        id: series.id.clone(),
+        space_id: space_map
+            .get(&series.space_id)
+            .cloned()
+            .unwrap_or_else(|| series.space_id.clone()),
+        title: series.title.clone(),
+        description: series.description.clone(),
+        repeat_rule: series.repeat_rule.clone(),
+        priority: series.priority,
+        energy: series.energy.clone(),
+        active: series.active,
+        created_at: series.created_at.clone(),
+        updated_at: series.updated_at.clone(),
+    }
+}
+
+fn mapped_quest(quest: &Quest, space_map: &HashMap<String, String>) -> Quest {
+    Quest {
+        id: quest.id.clone(),
+        space_id: space_map
+            .get(&quest.space_id)
+            .cloned()
+            .unwrap_or_else(|| quest.space_id.clone()),
+        title: quest.title.clone(),
+        description: quest.description.clone(),
+        status: quest.status.clone(),
+        energy: quest.energy.clone(),
+        priority: quest.priority,
+        pinned: quest.pinned,
+        due: quest.due.clone(),
+        due_time: quest.due_time.clone(),
+        repeat_rule: quest.repeat_rule.clone(),
+        completed_at: quest.completed_at.clone(),
+        order_rank: quest.order_rank,
+        created_at: quest.created_at.clone(),
+        updated_at: quest.updated_at.clone(),
+        series_id: quest.series_id.clone(),
+        period_key: quest.period_key.clone(),
+    }
+}
+
+fn series_value(series: &QuestSeries) -> Result<serde_json::Value, String> {
+    serde_json::to_value(series).map_err(|e| e.to_string())
+}
+
+fn quest_value(quest: &Quest) -> Result<serde_json::Value, String> {
+    serde_json::to_value(quest).map_err(|e| e.to_string())
+}
+
+fn is_builtin_space(id: &str) -> bool {
+    BUILTIN_SPACE_IDS.contains(&id)
+}
+
+fn create_temp_dir(label: &str) -> Result<PathBuf, String> {
+    let dir = std::env::temp_dir().join(format!("fini-backup-{label}-{}", Uuid::new_v4()));
+    fs::create_dir_all(&dir).map_err(|e| format!("failed to create temp directory: {e}"))?;
+    Ok(dir)
+}
+
+fn path_str(path: &Path) -> Result<&str, String> {
+    path.to_str()
+        .ok_or_else(|| "path must be valid UTF-8".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::db::{open_db_at_path, temp_db_path};
+
+    fn backup_path(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("fini-{label}-{}.zip", Uuid::new_v4()))
+    }
+
+    fn seed_custom_space(conn: &mut SqliteConnection, id: &str, name: &str) {
+        diesel::insert_into(spaces::table)
+            .values((
+                spaces::id.eq(id),
+                spaces::name.eq(name),
+                spaces::item_order.eq(10_i64),
+            ))
+            .execute(conn)
+            .expect("insert custom space");
+    }
+
+    #[test]
+    fn export_creates_zip_with_exact_required_files() {
+        let db_path = temp_db_path("backup-export-exact-files");
+        let mut conn = open_db_at_path(&db_path);
+        let out_path = backup_path("backup-export-exact-files");
+
+        export_backup(&mut conn, &out_path, &["1".to_string()]).expect("export backup");
+
+        let file = File::open(&out_path).expect("open zip");
+        let mut archive = zip::ZipArchive::new(file).expect("read zip");
+        let mut names = Vec::new();
+        for index in 0..archive.len() {
+            names.push(
+                archive
+                    .by_index(index)
+                    .expect("zip file")
+                    .name()
+                    .to_string(),
+            );
+        }
+        names.sort();
+        assert_eq!(
+            names,
+            [BACKUP_DB_NAME.to_string(), MANIFEST_NAME.to_string()]
+        );
+
+        let _ = fs::remove_file(out_path);
+        let _ = fs::remove_file(db_path);
+    }
+
+    #[test]
+    fn import_preflight_requires_missing_custom_space_mapping() {
+        let source_db_path = temp_db_path("backup-source-custom-space");
+        let mut source = open_db_at_path(&source_db_path);
+        seed_custom_space(&mut source, "space-custom", "Custom");
+        let out_path = backup_path("backup-source-custom-space");
+        export_backup(&mut source, &out_path, &["space-custom".to_string()]).expect("export");
+
+        let target_db_path = temp_db_path("backup-target-custom-space");
+        let mut target = open_db_at_path(&target_db_path);
+        let preflight = preflight_import(&mut target, &out_path, &[]).expect("preflight");
+
+        assert_eq!(preflight.required_space_mappings.len(), 1);
+        assert_eq!(
+            preflight.required_space_mappings[0].backup_space_id,
+            "space-custom"
+        );
+
+        let _ = fs::remove_file(out_path);
+        let _ = fs::remove_file(source_db_path);
+        let _ = fs::remove_file(target_db_path);
+    }
+}

--- a/src-tauri/src/services/cli.rs
+++ b/src-tauri/src/services/cli.rs
@@ -1,7 +1,8 @@
 use clap::{ArgAction, Args, Parser, Subcommand};
 use serde_json::Value;
 
-use crate::services::db::db_default_path;
+use crate::services::backup;
+use crate::services::db::{db_default_path, open_db_at_path};
 use crate::services::mcp::{FiniServer, UpdateQuestParams};
 
 const EXIT_SUCCESS: i32 = 0;
@@ -33,6 +34,10 @@ enum Command {
     Space {
         #[command(subcommand)]
         command: SpaceCommand,
+    },
+    Backup {
+        #[command(subcommand)]
+        command: BackupCommand,
     },
     Reminder {
         #[command(subcommand)]
@@ -132,6 +137,30 @@ enum SpaceCommand {
     Create(SpaceCreateArgs),
     Update(SpaceUpdateArgs),
     Delete(IdArg),
+}
+
+#[derive(Subcommand)]
+enum BackupCommand {
+    Export(BackupExportArgs),
+    Import(BackupImportArgs),
+}
+
+#[derive(Args)]
+struct BackupExportArgs {
+    #[arg(long)]
+    path: String,
+    #[arg(long = "space-id")]
+    space_id: Vec<String>,
+    #[arg(long, action = ArgAction::SetTrue)]
+    all_spaces: bool,
+}
+
+#[derive(Args)]
+struct BackupImportArgs {
+    #[arg(long)]
+    path: String,
+    #[arg(long, action = ArgAction::SetTrue)]
+    force: bool,
 }
 
 #[derive(Args)]
@@ -353,6 +382,7 @@ impl CliError {
 type CliResult<T> = Result<T, CliError>;
 
 struct CliContext {
+    db_path: std::path::PathBuf,
     server: FiniServer,
     runtime: tokio::runtime::Runtime,
 }
@@ -371,6 +401,7 @@ impl CliContext {
             .map_err(|err| CliError::runtime(format!("failed to create tokio runtime: {err}")))?;
 
         Ok(Self {
+            db_path: db_path.clone(),
             server: FiniServer::new(&db_path),
             runtime,
         })
@@ -417,6 +448,7 @@ fn execute(cli: Cli) -> CliResult<i32> {
         Some(Command::Focus { command }) => handle_focus(&ctx, command)?,
         Some(Command::Quest { command }) => handle_quest(&ctx, command)?,
         Some(Command::Space { command }) => handle_space(&ctx, command)?,
+        Some(Command::Backup { command }) => handle_backup(&ctx, command)?,
         Some(Command::Reminder { command }) => handle_reminder(&ctx, command)?,
         Some(Command::Device { command: _ }) => {
             return Err(CliError::runtime(
@@ -527,6 +559,44 @@ fn handle_space(ctx: &CliContext, command: SpaceCommand) -> CliResult<Value> {
             .runtime
             .block_on(ctx.server.cli_delete_space(args.id))
             .map_err(CliError::from_string)?,
+    };
+    Ok(value)
+}
+
+fn handle_backup(ctx: &CliContext, command: BackupCommand) -> CliResult<Value> {
+    let mut conn = open_db_at_path(&ctx.db_path);
+    let value = match command {
+        BackupCommand::Export(args) => {
+            if args.all_spaces && !args.space_id.is_empty() {
+                return Err(CliError::from_string(
+                    "cannot combine --all-spaces with --space-id".to_string(),
+                ));
+            }
+            let space_ids = if args.all_spaces {
+                use crate::schema::spaces;
+                use diesel::prelude::*;
+                spaces::table
+                    .select(spaces::id)
+                    .load::<String>(&mut conn)
+                    .map_err(|e| CliError::runtime(e.to_string()))?
+            } else if args.space_id.is_empty() {
+                return Err(CliError::from_string(
+                    "backup export requires --space-id or --all-spaces".to_string(),
+                ));
+            } else {
+                args.space_id
+            };
+            serde_json::to_value(
+                backup::export_backup(&mut conn, std::path::Path::new(&args.path), &space_ids)
+                    .map_err(CliError::from_string)?,
+            )
+            .map_err(|e| CliError::runtime(e.to_string()))?
+        }
+        BackupCommand::Import(args) => serde_json::to_value(
+            backup::import_cli(&mut conn, std::path::Path::new(&args.path), args.force)
+                .map_err(CliError::from_string)?,
+        )
+        .map_err(|e| CliError::runtime(e.to_string()))?,
     };
     Ok(value)
 }

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -1,3 +1,4 @@
+pub mod backup;
 pub mod cli;
 pub mod db;
 pub mod device_connection;

--- a/src/components/DeviceView/IncomingSpaceResolutionDialog.vue
+++ b/src/components/DeviceView/IncomingSpaceResolutionDialog.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, ref, watch } from "vue";
 import { useDeviceStore } from "../../stores/device";
 import { useSpaceStore } from "../../stores/space";
 import { shortUuid } from "../../utils/shortUuid";
+import MapToExistingDialog from "../MapToExistingDialog.vue";
 
 const EMBEDDED_SPACE_IDS = new Set(["1", "2", "3"]);
 
@@ -17,6 +18,7 @@ const spaceStore = useSpaceStore();
 const saving = ref(false);
 const error = ref<string | null>(null);
 const deferredKey = ref<string | null>(null);
+const showMapPicker = ref(false);
 const resolutionModeByRemoteId = ref<Record<string, ResolutionMode>>({});
 const resolutionExistingByRemoteId = ref<Record<string, string>>({});
 
@@ -183,11 +185,18 @@ function setResolutionMode(mode: ResolutionMode) {
   }
 }
 
-function onSelectExistingSpace(event: Event) {
+async function createAndConfirm() {
+  setResolutionMode("create_new");
+  await confirmDialog();
+}
+
+async function mapToExistingAndConfirm(spaceId: string) {
+  showMapPicker.value = false;
   const incomingSpace = activeIncomingSpace.value;
   if (!incomingSpace) return;
-  const target = event.target as HTMLSelectElement;
-  resolutionExistingByRemoteId.value[incomingSpace.space_id] = target.value;
+  resolutionModeByRemoteId.value[incomingSpace.space_id] = "use_existing";
+  resolutionExistingByRemoteId.value[incomingSpace.space_id] = spaceId;
+  await confirmDialog();
 }
 
 async function confirmDialog() {
@@ -258,55 +267,48 @@ async function confirmDialog() {
           <p class="font-mono text-xs opacity-60" :title="activeIncomingSpace.space_id">
             {{ shortUuid(activeIncomingSpace.space_id) }}
           </p>
-
-          <div class="mt-4 flex flex-wrap gap-2">
-            <button
-              class="btn btn-sm"
-              :class="activeResolutionMode === 'create_new' ? 'btn-primary' : 'btn-ghost'"
-              @click="setResolutionMode('create_new')"
-            >
-              Create
-            </button>
-            <button
-              class="btn btn-sm"
-              :class="activeResolutionMode === 'use_existing' ? 'btn-primary' : 'btn-ghost'"
-              @click="setResolutionMode('use_existing')"
-            >
-              Select space to map
-            </button>
-          </div>
-
-          <div v-if="activeResolutionMode === 'use_existing'" class="mt-3">
-            <select
-              class="select select-bordered w-full"
-              :value="activeExistingSpaceId"
-              @change="onSelectExistingSpace"
-            >
-              <option disabled value="">Select local space</option>
-              <option v-for="space in selectableSpaces" :key="space.id" :value="space.id">
-                {{ space.name }}<template v-if="!isEmbeddedSpaceId(space.id)"> ({{ shortUuid(space.id) }})</template>
-              </option>
-            </select>
-          </div>
         </template>
 
         <div v-if="error" class="mt-3 text-xs text-error">{{ error }}</div>
 
         <div class="mt-4 flex justify-end gap-2">
           <button class="btn btn-ghost btn-sm" @click="dismissDialog">Not now</button>
-          <button
-            class="btn btn-primary btn-sm"
-            data-testid="approve-space-sync"
-            :disabled="!canConfirm || saving"
-            @click="void confirmDialog()"
-          >
-            <template v-if="saving">Saving...</template>
-            <template v-else-if="activeDialog.kind === 'approve'">Approve sync</template>
-            <template v-else-if="activeResolutionMode === 'create_new'">Create</template>
-            <template v-else>Select space to map</template>
-          </button>
+          <template v-if="activeDialog.kind === 'approve'">
+            <button
+              class="btn btn-primary btn-sm"
+              data-testid="approve-space-sync"
+              :disabled="!canConfirm || saving"
+              @click="void confirmDialog()"
+            >
+              <template v-if="saving">Saving…</template>
+              <template v-else>Approve sync</template>
+            </button>
+          </template>
+          <template v-else-if="activeIncomingSpace">
+            <button
+              class="btn btn-sm"
+              @click="showMapPicker = true"
+            >Map to existing</button>
+            <button
+              class="btn btn-primary btn-sm"
+              data-testid="approve-space-sync"
+              :disabled="saving"
+              @click="void createAndConfirm()"
+            >
+              <template v-if="saving">Saving…</template>
+              <template v-else>Create</template>
+            </button>
+          </template>
         </div>
       </div>
     </div>
+
+    <MapToExistingDialog
+      v-if="showMapPicker && activeIncomingSpace"
+      :context="{ kind: 'peer-space', name: activeIncomingSpace.name }"
+      :spaces="selectableSpaces"
+      @cancel="showMapPicker = false"
+      @confirm="(id) => void mapToExistingAndConfirm(id)"
+    />
   </Teleport>
 </template>

--- a/src/components/MapToExistingDialog.vue
+++ b/src/components/MapToExistingDialog.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { shortUuid } from "../utils/shortUuid";
+import { SPACE_COLOR_CLASS, type Space } from "../stores/space";
+
+const props = defineProps<{
+  context: { kind: "backup-space" | "peer-space"; name: string };
+  spaces: Space[];
+}>();
+
+const emit = defineEmits<{
+  cancel: [];
+  confirm: [spaceId: string];
+}>();
+
+const selectedId = ref("");
+const canConfirm = computed(() => Boolean(selectedId.value));
+
+const blurb = computed(() =>
+  props.context.kind === "peer-space"
+    ? `Pick the local space to keep in sync with ${props.context.name}.`
+    : `Pick the local space to merge ${props.context.name} into. Imported quests and series will be reassigned to it.`,
+);
+
+function spaceColor(id: string): string {
+  const cls = SPACE_COLOR_CLASS[id];
+  if (!cls) return "oklch(var(--bc) / 0.35)";
+  return `var(--${cls.replace("space-color-", "space-color-")})`;
+}
+
+function confirmSelection() {
+  if (canConfirm.value) emit("confirm", selectedId.value);
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div class="fixed inset-0 z-[1300] flex items-end justify-center p-3 sm:items-center sm:p-4" data-testid="map-to-existing-dialog">
+      <button type="button" class="absolute inset-0 bg-black/60" aria-label="Close" @click="emit('cancel')"></button>
+      <div class="relative w-full max-w-sm rounded-xl bg-base-100 shadow-2xl">
+        <div class="p-4 pb-3">
+          <h3 class="text-base font-semibold">Map to existing space</h3>
+          <p class="mt-1 text-sm opacity-60">{{ blurb }}</p>
+        </div>
+
+        <ul class="max-h-64 overflow-y-auto border-t border-base-200" role="listbox" aria-label="Pick a local space">
+          <li
+            v-for="space in spaces"
+            :key="space.id"
+            role="option"
+            :aria-selected="selectedId === space.id"
+            class="flex cursor-pointer items-center gap-3 px-4 py-3 transition-colors hover:bg-base-200"
+            :class="selectedId === space.id ? 'bg-base-200' : ''"
+            @click="selectedId = space.id"
+          >
+            <span
+              class="inline-block h-3 w-3 flex-shrink-0 rounded-full"
+              :style="{ backgroundColor: spaceColor(space.id) }"
+            ></span>
+            <span class="flex-1 text-sm font-medium">{{ space.name }}</span>
+            <span class="font-mono text-xs opacity-40" :title="space.id">{{ shortUuid(space.id, 8) }}</span>
+            <span
+              class="inline-flex h-4 w-4 items-center justify-center rounded-full border-2 flex-shrink-0"
+              :class="selectedId === space.id ? 'border-primary bg-primary' : 'border-base-content/30'"
+              aria-hidden="true"
+            >
+              <span v-if="selectedId === space.id" class="inline-block h-1.5 w-1.5 rounded-full bg-primary-content"></span>
+            </span>
+          </li>
+          <li v-if="spaces.length === 0" class="px-4 py-6 text-center text-sm opacity-50">No local custom spaces yet.</li>
+        </ul>
+
+        <div class="flex items-center justify-end gap-2 border-t border-base-200 p-4 pt-3">
+          <button class="btn btn-ghost btn-sm" @click="emit('cancel')">Cancel</button>
+          <span class="flex-1"></span>
+          <button class="btn btn-primary btn-sm" :disabled="!canConfirm" @click="confirmSelection">
+            Map<template v-if="selectedId"> to {{ spaces.find(s => s.id === selectedId)?.name }}</template>
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/src/components/SettingsView/ExportSpacesDialog.vue
+++ b/src/components/SettingsView/ExportSpacesDialog.vue
@@ -1,0 +1,157 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+import { save } from "@tauri-apps/plugin-dialog";
+import { revealItemInDir } from "@tauri-apps/plugin-opener";
+import { useBackupStore } from "../../stores/backup";
+import { useSpaceStore, SPACE_COLOR_CLASS } from "../../stores/space";
+import { useQuestStore } from "../../stores/quest";
+import { useToast } from "../../composables/useToast";
+
+const emit = defineEmits<{ close: []; exported: [path: string] }>();
+
+const backupStore = useBackupStore();
+const spaceStore = useSpaceStore();
+const questStore = useQuestStore();
+const toast = useToast();
+
+const selected = ref<Set<string>>(new Set());
+const saving = ref(false);
+const error = ref<string | null>(null);
+
+const canExport = computed(() => selected.value.size > 0 && !saving.value);
+const allSelected = computed(() => spaceStore.spaces.length > 0 && selected.value.size === spaceStore.spaces.length);
+
+const today = new Date().toISOString().slice(0, 10);
+const filename = `fini-backup-${today}.zip`;
+
+function questsInSpace(spaceId: string): number {
+  return questStore.quests.filter((q) => q.space_id === spaceId).length;
+}
+
+function spaceColor(id: string): string {
+  const cls = SPACE_COLOR_CLASS[id];
+  if (!cls) return "oklch(var(--bc) / 0.35)";
+  return `var(--${cls})`;
+}
+
+function toggleSpace(id: string) {
+  const next = new Set(selected.value);
+  if (next.has(id)) next.delete(id);
+  else next.add(id);
+  selected.value = next;
+}
+
+function toggleAll() {
+  if (allSelected.value) {
+    selected.value = new Set();
+  } else {
+    selected.value = new Set(spaceStore.spaces.map((s) => s.id));
+  }
+}
+
+async function exportSelected() {
+  if (!canExport.value) return;
+  error.value = null;
+  let path: string | null;
+  // E2E test hook: bypasses native OS dialog
+  const e2eHook = (window as Window & { __FINI_E2E_SAVE_PATH__?: string | null }).__FINI_E2E_SAVE_PATH__;
+  if (e2eHook !== undefined) {
+    path = e2eHook ?? null;
+    delete (window as Window & { __FINI_E2E_SAVE_PATH__?: string | null }).__FINI_E2E_SAVE_PATH__;
+  } else {
+    path = await save({
+      defaultPath: filename,
+      filters: [{ name: "Fini backup", extensions: ["zip"] }],
+    });
+  }
+  if (!path) return;
+
+  saving.value = true;
+  try {
+    await backupStore.exportBackup(path, Array.from(selected.value));
+    toast.show("Backup exported", "success", 4000, {
+      label: "Open location",
+      onClick: () => void revealItemInDir(path),
+    });
+    emit("exported", path);
+    emit("close");
+  } catch (err) {
+    error.value = String(err);
+    toast.error("Backup export failed");
+  } finally {
+    saving.value = false;
+  }
+}
+
+onMounted(() => {
+  void spaceStore.fetchSpaces();
+  void questStore.fetchQuests();
+});
+</script>
+
+<template>
+  <Teleport to="body">
+    <div class="fixed inset-0 z-[1200] flex items-end justify-center p-3 sm:items-center sm:p-4" data-testid="export-spaces-dialog">
+      <button type="button" class="absolute inset-0 bg-black/45" aria-label="Close export dialog" @click="emit('close')"></button>
+      <div class="relative w-full max-w-md rounded-xl bg-base-100 shadow-2xl">
+        <div class="p-4 pb-3">
+          <h3 class="text-base font-semibold">Export backup</h3>
+          <p class="mt-1 text-sm opacity-60">Pick the spaces to include. The backup contains every quest in those spaces — active, completed, and abandoned — plus their quest series.</p>
+        </div>
+
+        <div class="border-t border-base-200 px-4 py-3">
+          <div class="mb-2 flex items-center justify-between">
+            <span class="text-xs font-medium uppercase tracking-wide opacity-50">Spaces</span>
+            <button class="btn btn-ghost btn-xs" @click="toggleAll">
+              {{ allSelected ? "Clear all" : "Select all" }}
+            </button>
+          </div>
+          <ul class="flex flex-col gap-1" role="listbox" aria-label="Spaces to back up">
+            <li
+              v-for="space in spaceStore.spaces"
+              :key="space.id"
+              role="option"
+              :aria-selected="selected.has(space.id)"
+              class="flex cursor-pointer items-center gap-3 rounded-lg border border-base-300 px-3 py-2 transition-colors"
+              :class="selected.has(space.id) ? 'border-primary/40 bg-primary/5' : 'hover:bg-base-200'"
+              @click="toggleSpace(space.id)"
+            >
+              <input
+                type="checkbox"
+                class="checkbox checkbox-sm checkbox-primary"
+                :checked="selected.has(space.id)"
+                @change="toggleSpace(space.id)"
+                @click.stop
+              />
+              <span
+                class="inline-block h-2.5 w-2.5 flex-shrink-0 rounded-full"
+                :style="{ backgroundColor: spaceColor(space.id) }"
+              ></span>
+              <span class="flex-1 text-sm font-medium">{{ space.name }}</span>
+              <span class="text-xs opacity-40">{{ questsInSpace(space.id) }} quest{{ questsInSpace(space.id) === 1 ? "" : "s" }}</span>
+            </li>
+          </ul>
+        </div>
+
+        <div class="mx-4 mb-3 flex items-start gap-2 rounded-lg bg-warning/10 px-3 py-2 text-xs text-base-content/80">
+          <svg class="mt-0.5 h-3.5 w-3.5 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="9"/><path d="M12 8v5"/><circle cx="12" cy="16" r="0.6" fill="currentColor"/>
+          </svg>
+          <span class="opacity-80">The backup file contains your quest data in plain SQLite. It is not password-protected — keep it somewhere safe.</span>
+        </div>
+
+        <div v-if="error" class="mx-4 mb-3 text-xs text-error">{{ error }}</div>
+
+        <div class="flex items-center gap-2 border-t border-base-200 px-4 py-3">
+          <span class="text-xs opacity-40">Saves as <code class="font-mono">{{ filename }}</code></span>
+          <span class="flex-1"></span>
+          <button class="btn btn-ghost btn-sm" @click="emit('close')">Cancel</button>
+          <button class="btn btn-primary btn-sm" :disabled="!canExport" @click="void exportSelected()">
+            <template v-if="saving">Exporting…</template>
+            <template v-else>Export{{ selected.size ? ` ${selected.size} space${selected.size === 1 ? "" : "s"}` : "" }}</template>
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/src/components/SettingsView/ImportSpaceMappingDialog.vue
+++ b/src/components/SettingsView/ImportSpaceMappingDialog.vue
@@ -1,0 +1,107 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { SPACE_COLOR_CLASS, type Space } from "../../stores/space";
+import { shortUuid } from "../../utils/shortUuid";
+import MapToExistingDialog from "../MapToExistingDialog.vue";
+
+defineProps<{
+  incoming: { backup_space_id: string; backup_space_name: string };
+  localSpaces: Space[];
+  index: number;
+  total: number;
+}>();
+
+const emit = defineEmits<{
+  cancel: [];
+  resolve: [resolution: { mode: "create_new" | "use_existing"; local_space_id?: string }];
+}>();
+
+const pickerOpen = ref(false);
+
+function spaceColor(id: string): string {
+  const cls = SPACE_COLOR_CLASS[id];
+  if (!cls) return "oklch(var(--bc) / 0.35)";
+  return `var(--${cls})`;
+}
+
+function onCreate() {
+  emit("resolve", { mode: "create_new" });
+}
+
+function onMap(spaceId: string) {
+  pickerOpen.value = false;
+  emit("resolve", { mode: "use_existing", local_space_id: spaceId });
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div class="fixed inset-0 z-[1200] flex items-end justify-center p-3 sm:items-center sm:p-4" data-testid="import-space-mapping-dialog">
+      <button type="button" class="absolute inset-0 bg-black/45" aria-label="Close" @click="emit('cancel')"></button>
+      <div class="relative w-full max-w-md rounded-xl bg-base-100 shadow-2xl">
+        <div class="p-4 pb-3">
+          <div class="flex items-start gap-3">
+            <div class="flex-1">
+              <h3 class="text-base font-semibold">Map incoming space</h3>
+              <p class="mt-1 text-sm opacity-60">This backup contains a space you don't have locally. Create it as a new space, or merge its quests into one you already have.</p>
+            </div>
+            <span
+              v-if="total > 1"
+              class="rounded-full bg-base-200 px-2 py-0.5 text-xs font-semibold"
+              :aria-label="`${index + 1} of ${total} spaces`"
+              data-testid="mapping-counter"
+            >{{ index + 1 }}/{{ total }}</span>
+          </div>
+        </div>
+
+        <div class="border-t border-base-200 px-4 py-3">
+          <div class="mb-3 flex items-center gap-2 text-sm">
+            <span class="opacity-50">Backup space</span>
+            <span
+              class="inline-block h-2.5 w-2.5 flex-shrink-0 rounded-full"
+              :style="{ backgroundColor: spaceColor(incoming.backup_space_id) }"
+            ></span>
+            <span class="font-medium">{{ incoming.backup_space_name }}</span>
+            <span class="font-mono text-xs opacity-40" :title="incoming.backup_space_id">{{ shortUuid(incoming.backup_space_id, 8) }}</span>
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <div class="flex items-start gap-3 rounded-lg border border-base-300 p-3">
+              <span class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>
+              </span>
+              <div>
+                <div class="text-sm font-medium">Create</div>
+                <div class="mt-0.5 text-xs opacity-60">A new local space <strong>{{ incoming.backup_space_name }}</strong> is created using the backup's ID. Quests and series keep their IDs.</div>
+              </div>
+            </div>
+            <div class="flex items-start gap-3 rounded-lg border border-base-300 p-3">
+              <span class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-base-200">
+                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12h18M14 5l7 7-7 7"/></svg>
+              </span>
+              <div>
+                <div class="text-sm font-medium">Map to existing</div>
+                <div class="mt-0.5 text-xs opacity-60">Reassign imported quests and series to a local space you already have.</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="flex items-center gap-2 border-t border-base-200 px-4 py-3">
+          <button class="btn btn-ghost btn-sm" @click="emit('cancel')">Cancel</button>
+          <span class="flex-1"></span>
+          <button class="btn btn-sm" @click="pickerOpen = true">Map to existing</button>
+          <button class="btn btn-primary btn-sm" @click="onCreate">Create</button>
+        </div>
+      </div>
+    </div>
+
+    <MapToExistingDialog
+      v-if="pickerOpen"
+      :context="{ kind: 'backup-space', name: incoming.backup_space_name }"
+      :spaces="localSpaces"
+      @cancel="pickerOpen = false"
+      @confirm="onMap"
+    />
+  </Teleport>
+</template>

--- a/src/components/SettingsView/MergeConflictDialog.vue
+++ b/src/components/SettingsView/MergeConflictDialog.vue
@@ -1,0 +1,233 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import type { BackupConflict, BackupConflictResolutionInput } from "../../stores/backup";
+
+const props = defineProps<{ conflicts: BackupConflict[] }>();
+const emit = defineEmits<{ cancel: []; apply: [resolutions: BackupConflictResolutionInput[]] }>();
+
+const index = ref(0);
+const showDetails = ref<Record<string, "local" | "backup" | null>>({});
+const choices = ref<Record<string, "local" | "backup">>({});
+const justCopied = ref<string | null>(null);
+
+const activeConflict = computed(() => props.conflicts[index.value]);
+const resolvedCount = computed(() => Object.keys(choices.value).length);
+const total = computed(() => props.conflicts.length);
+const canApply = computed(() => total.value > 0 && resolvedCount.value === total.value);
+const remaining = computed(() => total.value - resolvedCount.value);
+
+function conflictKey(conflict: BackupConflict) {
+  return `${conflict.entity_type}:${conflict.id}`;
+}
+
+function kindLabel(entityType: string): string {
+  return entityType === "quest_series" ? "Quest series" : "Quest";
+}
+
+function choose(resolution: "local" | "backup") {
+  const conflict = activeConflict.value;
+  if (!conflict) return;
+  const key = conflictKey(conflict);
+  choices.value = { ...choices.value, [key]: resolution };
+  // auto-advance to next unresolved after a short delay
+  setTimeout(() => {
+    const ni = nextUnresolved(index.value, props.conflicts, choices.value);
+    if (ni !== -1) index.value = ni;
+  }, 220);
+}
+
+function nextUnresolved(cur: number, conflicts: BackupConflict[], resolutions: Record<string, "local" | "backup">): number {
+  for (let i = cur + 1; i < conflicts.length; i++) {
+    if (!resolutions[conflictKey(conflicts[i])]) return i;
+  }
+  for (let i = 0; i < cur; i++) {
+    if (!resolutions[conflictKey(conflicts[i])]) return i;
+  }
+  return -1;
+}
+
+function selectedFor(resolution: "local" | "backup"): boolean {
+  const conflict = activeConflict.value;
+  return conflict ? choices.value[conflictKey(conflict)] === resolution : false;
+}
+
+function getDetailsKey(side: "local" | "backup"): string {
+  return `${conflictKey(activeConflict.value)}:${side}`;
+}
+
+function isShowingDetails(side: "local" | "backup"): boolean {
+  return showDetails.value[getDetailsKey(side)] != null;
+}
+
+function toggleDetails(side: "local" | "backup") {
+  const key = getDetailsKey(side);
+  showDetails.value = { ...showDetails.value, [key]: showDetails.value[key] ? null : side };
+}
+
+function metaEntries(data: unknown): Array<{ label: string; value: string }> {
+  if (!data || typeof data !== "object" || Array.isArray(data)) return [];
+  return Object.entries(data as Record<string, unknown>)
+    .filter(([k]) => !["id", "space_id"].includes(k))
+    .slice(0, 6)
+    .map(([k, v]) => ({ label: k.replace(/_/g, " "), value: String(v ?? "") }));
+}
+
+function isDiff(label: string): boolean {
+  const c = activeConflict.value;
+  if (!c) return false;
+  const key = label.replace(/ /g, "_");
+  const localVal = (c.local as Record<string, unknown>)?.[key];
+  const backupVal = (c.backup as Record<string, unknown>)?.[key];
+  return String(localVal ?? "") !== String(backupVal ?? "");
+}
+
+function copyColumn(side: "local" | "backup") {
+  const c = activeConflict.value;
+  if (!c) return;
+  const roleLabel = side === "local" ? "Local" : "Backup";
+  const summary = side === "local" ? c.local_summary : c.backup_summary;
+  const entries = metaEntries(side === "local" ? c.local : c.backup);
+  const metaText = entries.map(({ label, value }) => `${label}: ${value}`).join("\n");
+  const text = `[${roleLabel}] ${c.title}\n${summary}${metaText ? "\n" + metaText : ""}`;
+  void navigator.clipboard?.writeText?.(text).catch(() => undefined);
+  justCopied.value = side;
+  setTimeout(() => (justCopied.value = null), 1200);
+}
+
+function applyResolutions() {
+  if (!canApply.value) return;
+  emit("apply", props.conflicts.map((c) => ({
+    entity_type: c.entity_type,
+    id: c.id,
+    resolution: choices.value[conflictKey(c)],
+  })));
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div class="fixed inset-0 z-[1250] flex items-end justify-center p-3 sm:items-center sm:p-4" data-testid="merge-conflict-dialog">
+      <button type="button" class="absolute inset-0 bg-black/45" aria-label="Close conflict dialog" @click="emit('cancel')"></button>
+      <div class="relative w-full max-w-3xl rounded-xl bg-base-100 shadow-2xl">
+
+        <!-- Header -->
+        <div class="flex items-start gap-3 p-4 pb-3">
+          <div class="flex-1">
+            <div class="mb-1 flex items-center gap-2">
+              <span
+                class="badge badge-sm"
+                :class="activeConflict?.entity_type === 'quest_series' ? 'badge-secondary' : 'badge-primary'"
+              >{{ activeConflict ? kindLabel(activeConflict.entity_type) : "" }}</span>
+            </div>
+            <h3 class="text-base font-semibold">{{ activeConflict?.title ?? "Resolve conflicts" }}</h3>
+          </div>
+          <span
+            class="rounded-full bg-base-200 px-2 py-1 text-xs font-semibold"
+            :aria-label="`${resolvedCount} of ${total} resolved`"
+            data-testid="merge-conflict-counter"
+          ><strong>{{ resolvedCount }}</strong>/{{ total }}</span>
+        </div>
+
+        <!-- Columns -->
+        <div v-if="activeConflict" class="grid grid-cols-1 gap-3 border-t border-base-200 p-4 sm:grid-cols-2">
+          <!-- Local column -->
+          <section
+            class="flex min-h-52 flex-col rounded-lg border border-base-300"
+            :class="selectedFor('local') ? 'border-primary ring-1 ring-primary' : ''"
+          >
+            <div class="flex items-center justify-between border-b border-base-200 px-3 py-2">
+              <span class="text-sm font-semibold">Local</span>
+              <span
+                v-if="selectedFor('local')"
+                class="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+              >Keeping local</span>
+            </div>
+            <div class="flex-1 px-3 py-2">
+              <p class="text-sm opacity-80">{{ activeConflict.local_summary }}</p>
+              <dl v-if="metaEntries(activeConflict.local).length" class="mt-2 grid grid-cols-[auto,1fr] gap-x-3 gap-y-0.5 text-xs">
+                <template v-for="entry in metaEntries(activeConflict.local)" :key="entry.label">
+                  <dt class="opacity-50">{{ entry.label }}</dt>
+                  <dd :class="isDiff(entry.label) ? 'font-medium text-warning' : ''">{{ entry.value }}</dd>
+                </template>
+              </dl>
+              <pre v-if="isShowingDetails('local')" class="mt-2 max-h-32 overflow-auto rounded bg-base-200 p-2 text-xs">{{ JSON.stringify(activeConflict.local, null, 2) }}</pre>
+            </div>
+            <div class="flex items-center gap-2 border-t border-base-200 px-3 py-2">
+              <button class="btn btn-ghost btn-xs" @click="copyColumn('local')">{{ justCopied === 'local' ? 'Copied' : 'Copy' }}</button>
+              <button class="btn btn-ghost btn-xs" @click="toggleDetails('local')">{{ isShowingDetails('local') ? 'Hide' : 'Show' }}</button>
+            </div>
+            <div class="border-t border-base-200 px-3 py-2">
+              <button
+                class="btn btn-sm w-full"
+                :class="selectedFor('local') ? 'btn-primary' : 'btn-outline'"
+                @click="choose('local')"
+              >Use local</button>
+            </div>
+          </section>
+
+          <!-- Backup column -->
+          <section
+            class="flex min-h-52 flex-col rounded-lg border border-base-300"
+            :class="selectedFor('backup') ? 'border-primary ring-1 ring-primary' : ''"
+          >
+            <div class="flex items-center justify-between border-b border-base-200 px-3 py-2">
+              <span class="text-sm font-semibold">Backup</span>
+              <span
+                v-if="selectedFor('backup')"
+                class="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+              >Using backup</span>
+            </div>
+            <div class="flex-1 px-3 py-2">
+              <p class="text-sm opacity-80">{{ activeConflict.backup_summary }}</p>
+              <dl v-if="metaEntries(activeConflict.backup).length" class="mt-2 grid grid-cols-[auto,1fr] gap-x-3 gap-y-0.5 text-xs">
+                <template v-for="entry in metaEntries(activeConflict.backup)" :key="entry.label">
+                  <dt class="opacity-50">{{ entry.label }}</dt>
+                  <dd :class="isDiff(entry.label) ? 'font-medium text-warning' : ''">{{ entry.value }}</dd>
+                </template>
+              </dl>
+              <pre v-if="isShowingDetails('backup')" class="mt-2 max-h-32 overflow-auto rounded bg-base-200 p-2 text-xs">{{ JSON.stringify(activeConflict.backup, null, 2) }}</pre>
+            </div>
+            <div class="flex items-center gap-2 border-t border-base-200 px-3 py-2">
+              <button class="btn btn-ghost btn-xs" @click="copyColumn('backup')">{{ justCopied === 'backup' ? 'Copied' : 'Copy' }}</button>
+              <button class="btn btn-ghost btn-xs" @click="toggleDetails('backup')">{{ isShowingDetails('backup') ? 'Hide' : 'Show' }}</button>
+            </div>
+            <div class="border-t border-base-200 px-3 py-2">
+              <button
+                class="btn btn-sm w-full"
+                :class="selectedFor('backup') ? 'btn-primary' : 'btn-outline'"
+                @click="choose('backup')"
+              >Use backup</button>
+            </div>
+          </section>
+        </div>
+
+        <!-- Footer with wizard pager -->
+        <div class="flex flex-wrap items-center gap-2 border-t border-base-200 px-4 py-3">
+          <div class="flex items-center gap-1" aria-label="Conflict pager">
+            <button
+              class="btn btn-ghost btn-sm px-2"
+              :disabled="index === 0"
+              aria-label="Previous conflict"
+              @click="index = Math.max(0, index - 1)"
+            >‹</button>
+            <span class="text-xs opacity-60">{{ index + 1 }} of {{ total }}</span>
+            <button
+              class="btn btn-ghost btn-sm px-2"
+              :disabled="index >= total - 1"
+              aria-label="Next conflict"
+              @click="index = Math.min(total - 1, index + 1)"
+            >›</button>
+          </div>
+          <span class="flex-1"></span>
+          <span v-if="!canApply" class="text-xs opacity-40">{{ remaining }} remaining</span>
+          <button class="btn btn-ghost btn-sm" @click="emit('cancel')">Cancel</button>
+          <button
+            class="btn btn-primary btn-sm"
+            :disabled="!canApply"
+            @click="applyResolutions"
+          >Apply{{ canApply ? ` ${total} resolution${total === 1 ? '' : 's'}` : "" }}</button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/src/components/ToastStack.vue
+++ b/src/components/ToastStack.vue
@@ -9,13 +9,20 @@ const { toasts } = useToast();
       <div
         v-for="t in toasts"
         :key="t.id"
-        class="rounded-xl px-4 py-3 text-sm font-medium shadow-lg pointer-events-auto"
+        class="flex items-center gap-2 rounded-xl px-4 py-3 text-sm font-medium shadow-lg pointer-events-auto"
         :class="{
           'bg-red-600 text-white':   t.type === 'error',
           'bg-zinc-800 text-white':  t.type === 'info',
           'bg-green-600 text-white': t.type === 'success',
         }"
-      >{{ t.message }}</div>
+      >
+        <span class="flex-1">{{ t.message }}</span>
+        <button
+          v-if="t.action"
+          class="ml-2 rounded px-2 py-0.5 text-xs font-semibold opacity-90 ring-1 ring-white/40 hover:opacity-100"
+          @click="t.action!.onClick()"
+        >{{ t.action.label }}</button>
+      </div>
     </transition-group>
   </div>
 </template>

--- a/src/composables/useBackupImport.ts
+++ b/src/composables/useBackupImport.ts
@@ -118,7 +118,6 @@ export function useBackupImport(onSuccess?: () => void) {
       toast.error("Backup import failed");
     } finally {
       applying.value = false;
-      showConflicts.value = false;
     }
   }
 

--- a/src/composables/useBackupImport.ts
+++ b/src/composables/useBackupImport.ts
@@ -1,0 +1,141 @@
+import { computed, onMounted, ref } from "vue";
+import { open } from "@tauri-apps/plugin-dialog";
+import { useBackupStore, type BackupConflict, type BackupConflictResolutionInput, type BackupSpaceMappingInput, type BackupSpaceMappingRequest } from "../stores/backup";
+import { useQuestStore } from "../stores/quest";
+import { useSpaceStore, isBuiltinSpace } from "../stores/space";
+import { useToast } from "./useToast";
+
+export function useBackupImport(onSuccess?: () => void) {
+  const backupStore = useBackupStore();
+  const spaceStore = useSpaceStore();
+  const questStore = useQuestStore();
+  const toast = useToast();
+
+  const path = ref<string | null>(null);
+  const mappings = ref<BackupSpaceMappingInput[]>([]);
+  const activeMapping = ref<BackupSpaceMappingRequest | null>(null);
+  const mappingIndex = ref(0);
+  const totalMappings = ref(0);
+  const conflicts = ref<BackupConflict[]>([]);
+  const showConflicts = ref(false);
+  const loading = ref(false);
+  const applying = ref(false);
+  const error = ref<string | null>(null);
+
+  const selectableSpaces = computed(() => spaceStore.spaces.filter((s) => !isBuiltinSpace(s.id)));
+
+  onMounted(() => { void spaceStore.fetchSpaces(); });
+
+  async function startImport() {
+    error.value = null;
+    let selected: string | null;
+    // E2E test hook: bypasses native OS dialog
+    const e2eHook = (window as Window & { __FINI_E2E_OPEN_PATH__?: string | null }).__FINI_E2E_OPEN_PATH__;
+    if (e2eHook !== undefined) {
+      selected = e2eHook ?? null;
+      delete (window as Window & { __FINI_E2E_OPEN_PATH__?: string | null }).__FINI_E2E_OPEN_PATH__;
+    } else {
+      const picked = await open({
+        multiple: false,
+        filters: [{ name: "Fini backup", extensions: ["zip"] }],
+      });
+      selected = Array.isArray(picked) ? null : picked;
+    }
+    if (!selected) return;
+    path.value = selected;
+    mappings.value = [];
+    mappingIndex.value = 0;
+    await runPreflight();
+  }
+
+  async function runPreflight() {
+    if (!path.value) return;
+    loading.value = true;
+    error.value = null;
+    try {
+      const result = await backupStore.preflightImport(path.value, mappings.value);
+      const pending = result.required_space_mappings;
+      totalMappings.value = pending.length;
+
+      if (pending.length > 0) {
+        activeMapping.value = pending[0];
+        conflicts.value = [];
+        showConflicts.value = false;
+      } else if (result.conflicts.length > 0) {
+        activeMapping.value = null;
+        conflicts.value = result.conflicts;
+        showConflicts.value = true;
+      } else {
+        // No mappings needed, no conflicts — apply immediately
+        activeMapping.value = null;
+        conflicts.value = [];
+        showConflicts.value = false;
+        await applyImport([]);
+      }
+    } catch (err) {
+      error.value = String(err);
+      toast.error("Backup import failed validation");
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function confirmMapping(resolution: { mode: "create_new" | "use_existing"; local_space_id?: string }) {
+    if (!activeMapping.value) return;
+    mappings.value = [
+      ...mappings.value,
+      {
+        backup_space_id: activeMapping.value.backup_space_id,
+        mode: resolution.mode,
+        local_space_id: resolution.local_space_id,
+      },
+    ];
+    mappingIndex.value++;
+    await runPreflight();
+  }
+
+  function cancelImport() {
+    path.value = null;
+    mappings.value = [];
+    activeMapping.value = null;
+    conflicts.value = [];
+    showConflicts.value = false;
+    error.value = null;
+  }
+
+  async function applyImport(resolutions: BackupConflictResolutionInput[] = []) {
+    if (!path.value) return;
+    applying.value = true;
+    error.value = null;
+    try {
+      await backupStore.applyImport(path.value, mappings.value, resolutions);
+      await Promise.all([spaceStore.fetchSpaces(), questStore.fetchQuests(), questStore.fetchActiveQuest()]);
+      toast.show("Backup imported", "success", 3000);
+      cancelImport();
+      onSuccess?.();
+    } catch (err) {
+      error.value = String(err);
+      toast.error("Backup import failed");
+    } finally {
+      applying.value = false;
+      showConflicts.value = false;
+    }
+  }
+
+  return {
+    path,
+    activeMapping,
+    mappingIndex,
+    totalMappings,
+    conflicts,
+    showConflicts,
+    loading,
+    applying,
+    error,
+    selectableSpaces,
+    startImport,
+    confirmMapping,
+    cancelImport,
+    applyImport,
+  };
+}

--- a/src/composables/useToast.ts
+++ b/src/composables/useToast.ts
@@ -2,10 +2,16 @@ import { ref } from "vue";
 
 export type ToastType = "error" | "info" | "success";
 
+export interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
 interface Toast {
   id: number;
   message: string;
   type: ToastType;
+  action?: ToastAction;
 }
 
 // Module-level singleton so all callers share the same list
@@ -13,9 +19,9 @@ const toasts = ref<Toast[]>([]);
 let nextId = 0;
 
 export function useToast() {
-  function show(message: string, type: ToastType = "info", duration = 1000) {
+  function show(message: string, type: ToastType = "info", duration = 1000, action?: ToastAction) {
     const id = nextId++;
-    toasts.value.push({ id, message, type });
+    toasts.value.push({ id, message, type, action });
     setTimeout(() => {
       toasts.value = toasts.value.filter((t) => t.id !== id);
     }, duration);

--- a/src/spec/components/ExportSpacesDialog.spec.ts
+++ b/src/spec/components/ExportSpacesDialog.spec.ts
@@ -1,0 +1,87 @@
+import { mount } from "@vue/test-utils";
+import ExportSpacesDialog from "../../components/SettingsView/ExportSpacesDialog.vue";
+import { useSpaceStore } from "../../stores/space";
+import { useQuestStore } from "../../stores/quest";
+import { useBackupStore } from "../../stores/backup";
+
+jest.mock("@tauri-apps/plugin-dialog", () => ({
+  save: jest.fn(),
+}));
+
+jest.mock("@tauri-apps/plugin-opener", () => ({
+  revealItemInDir: jest.fn(),
+}));
+
+jest.mock("../../stores/space", () => ({
+  useSpaceStore: jest.fn(),
+  SPACE_COLOR_CLASS: {},
+  BUILTIN_SPACE_IDS: ["1", "2", "3"],
+  isBuiltinSpace: (id: string) => ["1", "2", "3"].includes(id),
+}));
+
+jest.mock("../../stores/quest", () => ({
+  useQuestStore: jest.fn(),
+}));
+
+jest.mock("../../stores/backup", () => ({
+  useBackupStore: jest.fn(),
+}));
+
+jest.mock("../../composables/useToast", () => ({
+  useToast: () => ({ show: jest.fn(), error: jest.fn() }),
+}));
+
+describe("ExportSpacesDialog", () => {
+  beforeEach(() => {
+    (useSpaceStore as unknown as jest.Mock).mockReturnValue({
+      spaces: [
+        { id: "1", name: "Personal" },
+        { id: "custom", name: "Custom" },
+      ],
+      fetchSpaces: jest.fn().mockResolvedValue(undefined),
+    });
+    (useQuestStore as unknown as jest.Mock).mockReturnValue({
+      quests: [],
+      fetchQuests: jest.fn().mockResolvedValue(undefined),
+    });
+    (useBackupStore as unknown as jest.Mock).mockReturnValue({
+      exportBackup: jest.fn().mockResolvedValue({ path: "/tmp/backup.zip" }),
+    });
+  });
+
+  it("starts with no spaces selected and disables Export", async () => {
+    const wrapper = mount(ExportSpacesDialog, {
+      global: { stubs: { Teleport: true } },
+    });
+
+    const checkboxes = wrapper.findAll('input[type="checkbox"]');
+    expect(checkboxes).toHaveLength(2);
+    expect(checkboxes.every((c) => (c.element as HTMLInputElement).checked === false)).toBe(true);
+
+    const exportBtn = wrapper.findAll("button").find((b) => b.text().startsWith("Export"))!;
+    expect(exportBtn.attributes("disabled")).toBeDefined();
+  });
+
+  it("enables Export when at least one space is checked", async () => {
+    const wrapper = mount(ExportSpacesDialog, {
+      global: { stubs: { Teleport: true } },
+    });
+
+    await wrapper.findAll('input[type="checkbox"]')[0].setValue(true);
+
+    const exportBtn = wrapper.findAll("button").find((b) => b.text().startsWith("Export"))!;
+    expect(exportBtn.attributes("disabled")).toBeUndefined();
+  });
+
+  it("select-all toggles all spaces", async () => {
+    const wrapper = mount(ExportSpacesDialog, {
+      global: { stubs: { Teleport: true } },
+    });
+
+    const selectAllBtn = wrapper.findAll("button").find((b) => b.text() === "Select all")!;
+    await selectAllBtn.trigger("click");
+
+    const checkboxes = wrapper.findAll('input[type="checkbox"]');
+    expect(checkboxes.every((c) => (c.element as HTMLInputElement).checked === true)).toBe(true);
+  });
+});

--- a/src/spec/components/ImportSpaceMappingDialog.spec.ts
+++ b/src/spec/components/ImportSpaceMappingDialog.spec.ts
@@ -1,0 +1,70 @@
+import { mount } from "@vue/test-utils";
+import ImportSpaceMappingDialog from "../../components/SettingsView/ImportSpaceMappingDialog.vue";
+
+jest.mock("../../stores/space", () => ({
+  SPACE_COLOR_CLASS: {},
+  BUILTIN_SPACE_IDS: ["1", "2", "3"],
+  isBuiltinSpace: (id: string) => ["1", "2", "3"].includes(id),
+}));
+
+jest.mock("../../utils/shortUuid", () => ({
+  shortUuid: (id: string) => id.slice(0, 8),
+}));
+
+const incoming = { backup_space_id: "abc-123", backup_space_name: "Work" };
+const localSpaces = [{ id: "custom-1", name: "My Space", item_order: 0, created_at: "" }];
+
+describe("ImportSpaceMappingDialog", () => {
+  it("renders 3 footer buttons: Cancel, Map to existing, Create", () => {
+    const wrapper = mount(ImportSpaceMappingDialog, {
+      props: { incoming, localSpaces, index: 0, total: 1 },
+      global: { stubs: { Teleport: true, MapToExistingDialog: true } },
+    });
+
+    const buttons = wrapper.findAll("button");
+    const labels = buttons.map((b) => b.text());
+    expect(labels).toContain("Cancel");
+    expect(labels).toContain("Map to existing");
+    expect(labels).toContain("Create");
+  });
+
+  it("does not show counter when total is 1", () => {
+    const wrapper = mount(ImportSpaceMappingDialog, {
+      props: { incoming, localSpaces, index: 0, total: 1 },
+      global: { stubs: { Teleport: true, MapToExistingDialog: true } },
+    });
+
+    expect(wrapper.find('[data-testid="mapping-counter"]').exists()).toBe(false);
+  });
+
+  it("shows counter when total > 1", () => {
+    const wrapper = mount(ImportSpaceMappingDialog, {
+      props: { incoming, localSpaces, index: 0, total: 3 },
+      global: { stubs: { Teleport: true, MapToExistingDialog: true } },
+    });
+
+    expect(wrapper.find('[data-testid="mapping-counter"]').text()).toBe("1/3");
+  });
+
+  it("shows choice cards with Create and Map to existing descriptions", () => {
+    const wrapper = mount(ImportSpaceMappingDialog, {
+      props: { incoming, localSpaces, index: 0, total: 1 },
+      global: { stubs: { Teleport: true, MapToExistingDialog: true } },
+    });
+
+    const text = wrapper.text();
+    expect(text).toContain("Create");
+    expect(text).toContain("Map to existing");
+    expect(text).toContain("Work");
+  });
+
+  it("emits resolve with create_new when Create is clicked", async () => {
+    const wrapper = mount(ImportSpaceMappingDialog, {
+      props: { incoming, localSpaces, index: 0, total: 1 },
+      global: { stubs: { Teleport: true, MapToExistingDialog: true } },
+    });
+
+    await wrapper.findAll("button").find((b) => b.text() === "Create")!.trigger("click");
+    expect(wrapper.emitted("resolve")?.[0]).toEqual([{ mode: "create_new" }]);
+  });
+});

--- a/src/spec/components/MapToExistingDialog.spec.ts
+++ b/src/spec/components/MapToExistingDialog.spec.ts
@@ -1,0 +1,73 @@
+import { mount } from "@vue/test-utils";
+import MapToExistingDialog from "../../components/MapToExistingDialog.vue";
+
+jest.mock("../../stores/space", () => ({
+  SPACE_COLOR_CLASS: {},
+  BUILTIN_SPACE_IDS: ["1", "2", "3"],
+  isBuiltinSpace: (id: string) => ["1", "2", "3"].includes(id),
+}));
+
+jest.mock("../../utils/shortUuid", () => ({
+  shortUuid: (id: string) => id.slice(0, 8),
+}));
+
+const spaces = [
+  { id: "custom-1", name: "Work", item_order: 0, created_at: "" },
+  { id: "custom-2", name: "Personal", item_order: 1, created_at: "" },
+];
+
+describe("MapToExistingDialog", () => {
+  it("renders space list as radio rows", () => {
+    const wrapper = mount(MapToExistingDialog, {
+      props: { context: { kind: "backup-space", name: "Incoming" }, spaces },
+      global: { stubs: { Teleport: true } },
+    });
+
+    const rows = wrapper.findAll('[role="option"]');
+    expect(rows).toHaveLength(2);
+    expect(rows[0].text()).toContain("Work");
+    expect(rows[1].text()).toContain("Personal");
+  });
+
+  it("Map button is disabled until a space is selected", () => {
+    const wrapper = mount(MapToExistingDialog, {
+      props: { context: { kind: "backup-space", name: "Incoming" }, spaces },
+      global: { stubs: { Teleport: true } },
+    });
+
+    const mapBtn = wrapper.findAll("button").find((b) => b.text().startsWith("Map"))!;
+    expect(mapBtn.attributes("disabled")).toBeDefined();
+  });
+
+  it("emits confirm with selected space id when Map is clicked", async () => {
+    const wrapper = mount(MapToExistingDialog, {
+      props: { context: { kind: "backup-space", name: "Incoming" }, spaces },
+      global: { stubs: { Teleport: true } },
+    });
+
+    await wrapper.findAll('[role="option"]')[0].trigger("click");
+    const mapBtn = wrapper.findAll("button").find((b) => b.text().startsWith("Map"))!;
+    expect(mapBtn.attributes("disabled")).toBeUndefined();
+    await mapBtn.trigger("click");
+    expect(wrapper.emitted("confirm")?.[0]).toEqual(["custom-1"]);
+  });
+
+  it("uses peer-space copy when context.kind is peer-space", () => {
+    const wrapper = mount(MapToExistingDialog, {
+      props: { context: { kind: "peer-space", name: "Remote" }, spaces },
+      global: { stubs: { Teleport: true } },
+    });
+
+    expect(wrapper.text()).toContain("Remote");
+    expect(wrapper.text()).toContain("sync");
+  });
+
+  it("shows empty message when no spaces", () => {
+    const wrapper = mount(MapToExistingDialog, {
+      props: { context: { kind: "backup-space", name: "Incoming" }, spaces: [] },
+      global: { stubs: { Teleport: true } },
+    });
+
+    expect(wrapper.text()).toContain("No local custom spaces");
+  });
+});

--- a/src/spec/components/MergeConflictDialog.spec.ts
+++ b/src/spec/components/MergeConflictDialog.spec.ts
@@ -1,0 +1,71 @@
+import { mount } from "@vue/test-utils";
+import MergeConflictDialog from "../../components/SettingsView/MergeConflictDialog.vue";
+
+const conflicts = [
+  {
+    entity_type: "quest",
+    id: "quest-1",
+    title: "Quest one",
+    local_summary: "Local quest",
+    backup_summary: "Backup quest",
+    local: { title: "Local quest" },
+    backup: { title: "Backup quest" },
+  },
+  {
+    entity_type: "quest_series",
+    id: "series-1",
+    title: "Series one",
+    local_summary: "Local series",
+    backup_summary: "Backup series",
+    local: { title: "Local series" },
+    backup: { title: "Backup series" },
+  },
+];
+
+describe("MergeConflictDialog", () => {
+  it("renders short counter and requires every conflict to be resolved", async () => {
+    const wrapper = mount(MergeConflictDialog, {
+      props: { conflicts },
+      global: { stubs: { Teleport: true } },
+    });
+
+    expect(wrapper.find('[data-testid="merge-conflict-counter"]').text()).toBe("0/2");
+
+    const applyBtn = wrapper.findAll("button").find((b) => b.text().startsWith("Apply"));
+    expect(applyBtn).toBeDefined();
+    expect(applyBtn!.attributes("disabled")).toBeDefined();
+
+    // choose "Use local" for conflict 1 (btn-outline when unselected)
+    await wrapper.get("button.btn-outline").trigger("click");
+    expect(wrapper.find('[data-testid="merge-conflict-counter"]').text()).toBe("1/2");
+
+    // navigate to conflict 2 via › button
+    const nextBtn = wrapper.findAll("button").find((b) => b.attributes("aria-label") === "Next conflict");
+    expect(nextBtn).toBeDefined();
+    await nextBtn!.trigger("click");
+
+    // choose "Use backup" for conflict 2
+    await wrapper.findAll("button").find((b) => b.text() === "Use backup")!.trigger("click");
+    expect(wrapper.find('[data-testid="merge-conflict-counter"]').text()).toBe("2/2");
+
+    const apply = wrapper.findAll("button").find((b) => b.text().startsWith("Apply"))!;
+    expect(apply.attributes("disabled")).toBeUndefined();
+    await apply.trigger("click");
+
+    expect(wrapper.emitted("apply")?.[0][0]).toEqual([
+      { entity_type: "quest", id: "quest-1", resolution: "local" },
+      { entity_type: "quest_series", id: "series-1", resolution: "backup" },
+    ]);
+  });
+
+  it("shows kind-pill for quest and quest_series", () => {
+    const wrapper = mount(MergeConflictDialog, {
+      props: { conflicts },
+      global: { stubs: { Teleport: true } },
+    });
+
+    const pills = wrapper.findAll(".badge");
+    expect(pills.length).toBeGreaterThan(0);
+    expect(pills[0].text()).toBe("Quest");
+  });
+});

--- a/src/spec/composables/useBackupImport.spec.ts
+++ b/src/spec/composables/useBackupImport.spec.ts
@@ -1,0 +1,150 @@
+import { defineComponent } from "vue";
+import { mount, flushPromises } from "@vue/test-utils";
+import { useBackupImport } from "../../composables/useBackupImport";
+import { open } from "@tauri-apps/plugin-dialog";
+import { useBackupStore } from "../../stores/backup";
+import { useSpaceStore } from "../../stores/space";
+import { useQuestStore } from "../../stores/quest";
+
+const mockShow = jest.fn();
+const mockError = jest.fn();
+
+jest.mock("@tauri-apps/plugin-dialog", () => ({ open: jest.fn() }));
+jest.mock("../../stores/backup", () => ({ useBackupStore: jest.fn() }));
+jest.mock("../../stores/space", () => ({
+  useSpaceStore: jest.fn(),
+  isBuiltinSpace: (id: string) => ["1", "2", "3"].includes(id),
+  BUILTIN_SPACE_IDS: ["1", "2", "3"],
+}));
+jest.mock("../../stores/quest", () => ({ useQuestStore: jest.fn() }));
+jest.mock("../../composables/useToast", () => ({
+  useToast: () => ({ show: mockShow, error: mockError, info: jest.fn() }),
+}));
+
+function makeWrapper() {
+  return mount(
+    defineComponent({
+      setup() { return useBackupImport(); },
+      template: "<div></div>",
+    }),
+  );
+}
+
+const baseSpaceStore = {
+  spaces: [{ id: "custom-1", name: "Work", item_order: 0, created_at: "" }],
+  fetchSpaces: jest.fn().mockResolvedValue(undefined),
+};
+const baseQuestStore = {
+  quests: [],
+  fetchQuests: jest.fn().mockResolvedValue(undefined),
+  fetchActiveQuest: jest.fn().mockResolvedValue(undefined),
+};
+const FILE_PATH = "/var/tmp/test-backup.zip";
+
+describe("useBackupImport", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useSpaceStore as unknown as jest.Mock).mockReturnValue(baseSpaceStore);
+    (useQuestStore as unknown as jest.Mock).mockReturnValue(baseQuestStore);
+  });
+
+  it("does nothing when file picker is cancelled", async () => {
+    const preflightMock = jest.fn();
+    (useBackupStore as unknown as jest.Mock).mockReturnValue({ preflightImport: preflightMock, applyImport: jest.fn() });
+    (open as unknown as jest.Mock).mockResolvedValue(null);
+
+    const wrapper = makeWrapper();
+    await flushPromises();
+
+    await wrapper.vm.startImport();
+    await flushPromises();
+
+    expect(preflightMock).not.toHaveBeenCalled();
+    expect(wrapper.vm.activeMapping).toBeNull();
+    expect(wrapper.vm.showConflicts).toBe(false);
+  });
+
+  it("auto-applies and shows toast when preflight has no mappings and no conflicts", async () => {
+    const applyMock = jest.fn().mockResolvedValue(undefined);
+    const preflightMock = jest.fn().mockResolvedValue({ required_space_mappings: [], conflicts: [] });
+    (useBackupStore as unknown as jest.Mock).mockReturnValue({ preflightImport: preflightMock, applyImport: applyMock });
+    (open as unknown as jest.Mock).mockResolvedValue(FILE_PATH);
+
+    const wrapper = makeWrapper();
+    await flushPromises();
+
+    await wrapper.vm.startImport();
+    await flushPromises();
+
+    expect(preflightMock).toHaveBeenCalledWith(FILE_PATH, []);
+    expect(applyMock).toHaveBeenCalledWith(FILE_PATH, [], []);
+    expect(mockShow).toHaveBeenCalledWith("Backup imported", "success", 3000);
+    // state is cleaned up after apply
+    expect(wrapper.vm.activeMapping).toBeNull();
+    expect(wrapper.vm.showConflicts).toBe(false);
+  });
+
+  it("sets activeMapping when preflight requires space mapping", async () => {
+    const pending = [{ backup_space_id: "abc", backup_space_name: "Work" }];
+    const preflightMock = jest.fn().mockResolvedValue({ required_space_mappings: pending, conflicts: [] });
+    (useBackupStore as unknown as jest.Mock).mockReturnValue({ preflightImport: preflightMock, applyImport: jest.fn() });
+    (open as unknown as jest.Mock).mockResolvedValue(FILE_PATH);
+
+    const wrapper = makeWrapper();
+    await flushPromises();
+
+    await wrapper.vm.startImport();
+    await flushPromises();
+
+    expect(wrapper.vm.activeMapping).toEqual({ backup_space_id: "abc", backup_space_name: "Work" });
+    expect(wrapper.vm.showConflicts).toBe(false);
+    expect(wrapper.vm.totalMappings).toBe(1);
+  });
+
+  it("shows conflicts when preflight has no pending mappings but has conflicts", async () => {
+    const conflicts = [
+      { entity_type: "quest", id: "q-1", title: "Q", local_summary: "L", backup_summary: "B", local: {}, backup: {} },
+    ];
+    const preflightMock = jest.fn().mockResolvedValue({ required_space_mappings: [], conflicts });
+    (useBackupStore as unknown as jest.Mock).mockReturnValue({ preflightImport: preflightMock, applyImport: jest.fn() });
+    (open as unknown as jest.Mock).mockResolvedValue(FILE_PATH);
+
+    const wrapper = makeWrapper();
+    await flushPromises();
+
+    await wrapper.vm.startImport();
+    await flushPromises();
+
+    expect(wrapper.vm.showConflicts).toBe(true);
+    expect(wrapper.vm.conflicts).toHaveLength(1);
+    expect(wrapper.vm.activeMapping).toBeNull();
+  });
+
+  it("accumulates mapping and re-runs preflight after confirmMapping", async () => {
+    // First preflight: 1 mapping required. Second: none, no conflicts → auto-apply.
+    const applyMock = jest.fn().mockResolvedValue(undefined);
+    const preflightMock = jest.fn()
+      .mockResolvedValueOnce({ required_space_mappings: [{ backup_space_id: "abc", backup_space_name: "Work" }], conflicts: [] })
+      .mockResolvedValueOnce({ required_space_mappings: [], conflicts: [] });
+    (useBackupStore as unknown as jest.Mock).mockReturnValue({ preflightImport: preflightMock, applyImport: applyMock });
+    (open as unknown as jest.Mock).mockResolvedValue(FILE_PATH);
+
+    const wrapper = makeWrapper();
+    await flushPromises();
+
+    await wrapper.vm.startImport();
+    await flushPromises();
+    expect(wrapper.vm.activeMapping).toEqual({ backup_space_id: "abc", backup_space_name: "Work" });
+
+    await wrapper.vm.confirmMapping({ mode: "create_new" });
+    await flushPromises();
+
+    // Second preflight had no conflicts → auto-apply ran
+    expect(applyMock).toHaveBeenCalledWith(
+      FILE_PATH,
+      [{ backup_space_id: "abc", mode: "create_new", local_space_id: undefined }],
+      [],
+    );
+    expect(mockShow).toHaveBeenCalledWith("Backup imported", "success", 3000);
+  });
+});

--- a/src/stores/backup.ts
+++ b/src/stores/backup.ts
@@ -1,0 +1,77 @@
+import { defineStore } from "pinia";
+import { invoke } from "@tauri-apps/api/core";
+
+export interface BackupManifest {
+  format: string;
+  version: number;
+  app_version: string;
+  exported_at: string;
+  domains: string[];
+  spaces: Array<{ id: string; name: string }>;
+  counts: { spaces: number; quest_series: number; quests: number };
+}
+
+export interface BackupExportResult {
+  path: string;
+  manifest: BackupManifest;
+}
+
+export interface BackupSpaceMappingRequest {
+  backup_space_id: string;
+  backup_space_name: string;
+}
+
+export interface BackupConflict {
+  entity_type: string;
+  id: string;
+  title: string;
+  local_summary: string;
+  backup_summary: string;
+  local: unknown;
+  backup: unknown;
+}
+
+export interface BackupImportPreflight {
+  manifest: BackupManifest;
+  required_space_mappings: BackupSpaceMappingRequest[];
+  conflicts: BackupConflict[];
+}
+
+export interface BackupSpaceMappingInput {
+  backup_space_id: string;
+  mode: "create_new" | "use_existing";
+  local_space_id?: string;
+}
+
+export interface BackupConflictResolutionInput {
+  entity_type: string;
+  id: string;
+  resolution: "local" | "backup";
+}
+
+export interface BackupImportResult {
+  imported: boolean;
+  spaces: number;
+  quest_series: number;
+  quests: number;
+}
+
+export const useBackupStore = defineStore("backup", () => {
+  function exportBackup(path: string, spaceIds: string[]): Promise<BackupExportResult> {
+    return invoke<BackupExportResult>("backup_export", { path, spaceIds });
+  }
+
+  function preflightImport(path: string, mappings: BackupSpaceMappingInput[]): Promise<BackupImportPreflight> {
+    return invoke<BackupImportPreflight>("backup_preflight_import", { path, mappings });
+  }
+
+  function applyImport(
+    path: string,
+    mappings: BackupSpaceMappingInput[],
+    resolutions: BackupConflictResolutionInput[],
+  ): Promise<BackupImportResult> {
+    return invoke<BackupImportResult>("backup_apply_import", { path, mappings, resolutions });
+  }
+
+  return { exportBackup, preflightImport, applyImport };
+});

--- a/src/style.css
+++ b/src/style.css
@@ -1,5 +1,7 @@
-@import "tailwindcss";
+@import "tailwindcss" source(none);
 @plugin "daisyui";
+@source "../index.html";
+@source "./**/*.{vue,ts}";
 
 /* Built-in space colors — keep in sync with SPACE_COLOR_CLASS in space.ts */
 :root {

--- a/src/views/SettingsView.md
+++ b/src/views/SettingsView.md
@@ -35,6 +35,16 @@ Device connection entry point. See `specs/device-connect/README.md` and `specs/s
 - Device rows show display name plus `Online`/`Offline`; UUIDs stay out of visible Settings list rows
 - Device detail view owns mapped-space configuration and visible sync status per paired device
 
+### Backup
+
+Portable backup import/export. See `specs/backup/README.md`.
+
+- Rendered inline on `/settings` using [[SettingsListGroup]] and [[SettingsListItem]]
+- `Export backup` opens a selected-space checklist dialog with no spaces checked by default
+- `Import backup` opens a native `.zip` picker and validates before applying changes
+- Import uses one-space-at-a-time custom space mapping, then [[MergeConflictDialog]] for item conflicts
+- Backup files contain quest data; UI copy must say this before export
+
 ### About
 
 App metadata and project link.
@@ -68,6 +78,7 @@ Progress label format: `Downloading <filename> (<file_index+1>/<file_count>) <pc
 |---|---|
 | [[useModelDownload]] | Download state, progress, error, start/check |
 | [[space.ts]] | `fetchSpaces`, `createSpace`, `updateSpace`, `deleteSpace` |
+| [[backup.ts]] | backup export, import preflight, import apply |
 | `device_connection` runtime adapter | Paired devices list, presence state, and pairing actions |
 | `space_sync` runtime adapter | Mapping state, bootstrap sync, and sync status |
 

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -2,18 +2,24 @@
 import { ref, onMounted } from "vue";
 import packageJson from "../../package.json";
 import AboutCard from "../components/SettingsView/AboutCard.vue";
+import ExportSpacesDialog from "../components/SettingsView/ExportSpacesDialog.vue";
+import ImportSpaceMappingDialog from "../components/SettingsView/ImportSpaceMappingDialog.vue";
+import MergeConflictDialog from "../components/SettingsView/MergeConflictDialog.vue";
 import SettingsListGroup from "../components/SettingsView/SettingsListGroup.vue";
 import SettingsListItem from "../components/SettingsView/SettingsListItem.vue";
 import ThemeSelector from "../components/SettingsView/ThemeSelector.vue";
 import { useSpaceStore, isBuiltinSpace } from "../stores/space";
 import { useDeviceStore, type PairedDevice } from "../stores/device";
 import { useContextMenu, type MenuItem } from "../composables/useContextMenu";
+import { useBackupImport } from "../composables/useBackupImport";
 import ActionsBtn from "../components/ActionsBtn.vue";
 import { PencilIcon, TrashIcon } from "@heroicons/vue/24/outline";
 
 const spaceStore = useSpaceStore();
 const deviceStore = useDeviceStore();
 const contextMenu = useContextMenu();
+
+const backupImport = useBackupImport();
 
 function openSpaceMenu(e: MouseEvent, spaceId: string, spaceName: string) {
   const items: MenuItem[] = [{ label: "Edit", icon: PencilIcon, action: () => startEdit(spaceId, spaceName) }];
@@ -27,6 +33,7 @@ function openSpaceMenu(e: MouseEvent, spaceId: string, spaceName: string) {
 const newSpaceName = ref("");
 const editingId = ref<string | null>(null);
 const editingName = ref("");
+const showBackupExport = ref(false);
 const appVersion = packageJson.version;
 const sourceUrl = "https://github.com/VRuzhentsov/fini";
 
@@ -163,6 +170,61 @@ function devicePresenceLabel(device: PairedDevice) {
 
     <ThemeSelector />
 
+    <section class="rounded-xl bg-base-200 p-3" data-testid="settings-backup">
+      <h2 class="mb-3 text-sm font-semibold uppercase tracking-wide opacity-70">Backup</h2>
+      <p class="mb-2 text-xs opacity-60">Save your spaces and quests to a portable file, or restore from one.</p>
+      <SettingsListGroup>
+        <SettingsListItem button data-testid="backup-export-row" @click="showBackupExport = true">
+          <template #leading>
+            <svg class="h-5 w-5 flex-shrink-0 opacity-60" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M12 3v12"/><path d="M7 10l5 5 5-5"/><path d="M5 21h14"/>
+            </svg>
+          </template>
+          <div>
+            <span class="block font-medium">Export backup</span>
+            <span class="block text-xs opacity-60">Saves a <code class="font-mono">.zip</code> with quests and quest series for the spaces you pick.</span>
+          </div>
+          <template #trailing>
+            <span class="text-sm opacity-50">›</span>
+          </template>
+        </SettingsListItem>
+        <SettingsListItem button data-testid="backup-import-row" @click="void backupImport.startImport()">
+          <template #leading>
+            <svg class="h-5 w-5 flex-shrink-0 opacity-60" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M12 21V9"/><path d="M7 14l5-5 5 5"/><path d="M5 3h14"/>
+            </svg>
+          </template>
+          <div>
+            <span class="block font-medium">Import backup</span>
+            <span class="block text-xs opacity-60">Restore from a <code class="font-mono">.zip</code>. Conflicts will ask before overwriting.</span>
+          </div>
+          <template #trailing>
+            <span class="text-sm opacity-50">›</span>
+          </template>
+        </SettingsListItem>
+      </SettingsListGroup>
+      <div v-if="backupImport.error.value" class="mt-2 text-xs text-error">{{ backupImport.error.value }}</div>
+    </section>
+
     <AboutCard :version="appVersion" :source-url="sourceUrl" />
+
+    <ExportSpacesDialog v-if="showBackupExport" @close="showBackupExport = false" />
+
+    <ImportSpaceMappingDialog
+      v-if="backupImport.activeMapping.value"
+      :incoming="backupImport.activeMapping.value"
+      :local-spaces="backupImport.selectableSpaces.value"
+      :index="backupImport.mappingIndex.value"
+      :total="backupImport.totalMappings.value"
+      @cancel="backupImport.cancelImport()"
+      @resolve="(r) => void backupImport.confirmMapping(r)"
+    />
+
+    <MergeConflictDialog
+      v-if="backupImport.showConflicts.value"
+      :conflicts="backupImport.conflicts.value"
+      @cancel="backupImport.cancelImport()"
+      @apply="(r) => void backupImport.applyImport(r)"
+    />
   </div>
 </template>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,12 @@ const host = process.env.TAURI_DEV_HOST;
 // https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [vue(), tailwindcss()],
+  optimizeDeps: {
+    // Vite's dep crawler can CPU-spin on the Tauri plugin graph and leave the
+    // dev server accepting connections without responding, which whitescreens
+    // the Tauri webview. Transform deps on demand instead.
+    noDiscovery: true,
+  },
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //


### PR DESCRIPTION
## Summary

- **Backend**: new `backup` service (SQLite snapshot → zip), three Tauri commands (`backup_export`, `backup_preflight_import`, `backup_apply_import`), and `fini backup export/import` CLI subcommands
- **Frontend**: `ExportSpacesDialog` (space checklist + quest counts), `ImportSpaceMappingDialog` + `MapToExistingDialog` (space-remapping wizard), `MergeConflictDialog` (side-by-side diff, auto-advance, pager); `useBackupImport` composable drives the full preflight → mapping → conflict → apply flow; toast action support ("Open location")
- **Reuse**: `MapToExistingDialog` also replaces the inline select in `IncomingSpaceResolutionDialog` for device-sync space mapping
- **E2E testability**: window-global hooks (`window.__FINI_E2E_OPEN/SAVE_PATH__`) bypass the native OS file dialogs in headless tests (Tauri's `__TAURI_INTERNALS__.invoke` is non-writable, so patching it directly isn't possible)

## Test plan

- [x] 48 unit tests passing (`npm run test:unit`)
- [x] 3 E2E tests passing headed: settings section renders, full export flow with "Backup exported + Open location" toast, full import flow with auto-apply and "Backup imported" toast
- [ ] Visual smoke: Settings → Export (pick spaces, native save dialog, toast) → Import (native open dialog, auto-apply or mapping/conflict dialogs)
- [ ] Device-sync: incoming space resolution still works with the refactored `MapToExistingDialog`