### PR TITLE
feat(ci): Android emulator E2E gate

### DIFF
--- a/.agents/skills/fini-dev-agent-install/SKILL.md
+++ b/.agents/skills/fini-dev-agent-install/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: fini-dev-agent-install
+description: "Use this to install, repair, or verify the Fini autonomous dev agent daily schedule. Trigger when asked to set up fini-dev-agent, local autonomous agent scheduling, daily 8 AM triage, Daily topic reports, OpenClaw cron for Fini, or rerunnable/idempotent install of the Fini dev agent. This skill ensures a stable daily 8 AM local-time job runs `fini-daily`, uses `triage`, and reports to the Fini Dev `Daily` Telegram topic."
+metadata:
+  openclaw:
+    envVars:
+      - name: FINI_DEV_TG_CHANNEL_ID
+        required: false
+        description: Telegram group chat ID for Fini Dev.
+      - name: FINI_DAILY_TG_TARGET
+        required: true
+        description: Preferred Telegram target for Daily topic reports, usually <group-id>:topic:<thread-id>.
+      - name: FINI_PROGRESS_TG_TARGET
+        required: false
+        description: Preferred Telegram target for delegated implementation progress updates.
+      - name: FINI_DAILY_TZ
+        required: false
+        description: Optional timezone override for the 8 AM daily schedule.
+---
+
+# Fini Dev Agent Install
+
+Use this skill to install or repair the daily autonomous Fini dev-agent schedule. The workflow is intentionally idempotent: repeated runs should converge on the same cron job without duplicating schedules or changing unrelated jobs.
+
+## Outcome
+
+Ensure the local agent has one daily schedule:
+
+- Job ID: `fini-daily-issue-report`
+- Schedule: `0 8 * * *`
+- Timezone: local timezone, or `FINI_DAILY_TZ` when configured
+- Session: isolated
+- Prompt: load `fini-daily`, run from `~/projects/fini`, use `triage`, query open `VRuzhentsov/fini` GitHub issues, and send the final report to `FINI_DAILY_TG_TARGET`
+- Delivery: Telegram `Daily` topic parsed from `FINI_DAILY_TG_TARGET`
+
+## Prerequisites
+
+Before writing schedule state, verify:
+
+1. OpenClaw is installed and the local gateway or cron store path is available.
+2. `fini-daily` is installed for the local agent.
+3. `triage` is installed for the local agent.
+4. `FINI_DAILY_TG_TARGET` is set to the Daily topic target in `<group-id>:topic:<thread-id>` form.
+5. GitHub access for `VRuzhentsov/fini` works without printing tokens.
+
+If a prerequisite is missing, stop and report the exact blocker. Do not create a partial schedule that cannot deliver to `Daily`.
+
+## Helper Script
+
+Use the bundled helper to upsert the cron job safely:
+
+```bash
+node .agents/skills/fini-dev-agent-install/scripts/upsert-fini-daily-cron.mjs --dry-run
+node .agents/skills/fini-dev-agent-install/scripts/upsert-fini-daily-cron.mjs --write
+```
+
+The helper:
+
+- Reads `~/.openclaw/cron/jobs.json` by default.
+- Preserves unrelated cron jobs.
+- Replaces only the job with ID `fini-daily-issue-report`.
+- Defaults to dry-run and requires `--write` to modify the store.
+- Uses `FINI_DAILY_TG_TARGET` for Telegram delivery.
+- Uses `FINI_DAILY_TZ` or the local system timezone for the 8 AM schedule.
+
+Use `--store <path>` only for tests or non-standard OpenClaw stores.
+
+## Verification
+
+After `--write`, verify with the local agent tools when available:
+
+```bash
+openclaw cron list --json
+openclaw skills info fini-daily
+openclaw skills info triage
+openclaw channels status --probe
+```
+
+Expected evidence:
+
+- Exactly one enabled job with ID `fini-daily-issue-report`.
+- The job schedule is `0 8 * * *` in the selected timezone.
+- Delivery points to the `Daily` topic thread from `FINI_DAILY_TG_TARGET`.
+- `fini-daily` and `triage` are available.
+- Telegram is configured and can send to the Daily topic, or the blocker is explicitly reported.
+
+If OpenClaw CLI cron commands are blocked by device-scope approval, verify by reading the cron list through any available read-only status path and report the approval blocker. Do not keep retrying approval loops.
+
+## Daily Prompt Contract
+
+The scheduled prompt must preserve this intent:
+
+```text
+Use the fini-daily skill. Run from ~/projects/fini. Use FINI_DAILY_TG_TARGET and FINI_PROGRESS_TG_TARGET from the local agent environment. Query current open GitHub issues for VRuzhentsov/fini using configured GitHub access without printing secrets. Run or load triage before choosing the recommendation. Produce the daily report format addressed to Vitalii. Deliver the final report to FINI_DAILY_TG_TARGET.
+```
+
+Keep this prompt focused on read-only triage and reporting. Do not edit issues, labels, code, docs, or branches from the daily job unless the user explicitly delegates implementation.
+
+## Idempotency Rules
+
+- Treat `fini-daily-issue-report` as the only managed cron job.
+- Do not create timestamped duplicate daily jobs.
+- Do not remove unrelated jobs.
+- Do not overwrite a different job unless it has the managed ID.
+- Prefer dry-run output before write output when reporting changes.
+- If the existing job already matches, report `changed: false`.
+
+## Report Format
+
+When finished, report:
+
+```text
+Status: <installed | already current | blocked>
+Job: fini-daily-issue-report
+Schedule: 0 8 * * * @ <timezone>
+Delivery: <group-id>:topic:<thread-id>
+Evidence: <commands and outcomes>
+Blocker: <only if blocked>
+```

--- a/.agents/skills/fini-dev-agent-install/SKILL.md
+++ b/.agents/skills/fini-dev-agent-install/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fini-dev-agent-install
-description: "Use this to install, repair, or verify the Fini autonomous dev agent daily schedule. Trigger when asked to set up fini-dev-agent, local autonomous agent scheduling, daily 8 AM triage, Daily topic reports, OpenClaw cron for Fini, or rerunnable/idempotent install of the Fini dev agent. This skill ensures a stable daily 8 AM local-time job runs `fini-daily`, uses `triage`, and reports to the Fini Dev `Daily` Telegram topic."
+description: "Use this to install, repair, or verify the Fini autonomous dev agent schedules. Trigger when asked to set up fini-dev-agent, local autonomous agent scheduling, daily 8 AM triage, every-5-minutes branch fetch, Daily topic reports, OpenClaw cron for Fini, or rerunnable/idempotent install of the Fini dev agent. This skill ensures a stable daily 8 AM local-time job runs `fini-daily`, uses `triage`, reports to the Fini Dev `Daily` Telegram topic, and keeps all Git branches fetched every 5 minutes."
 metadata:
   openclaw:
     envVars:
@@ -20,11 +20,13 @@ metadata:
 
 # Fini Dev Agent Install
 
-Use this skill to install or repair the daily autonomous Fini dev-agent schedule. The workflow is intentionally idempotent: repeated runs should converge on the same cron job without duplicating schedules or changing unrelated jobs.
+Use this skill to install or repair autonomous Fini dev-agent schedules. The workflow is intentionally idempotent: repeated runs should converge on the same managed cron jobs without duplicating schedules or changing unrelated jobs.
 
 ## Outcome
 
-Ensure the local agent has one daily schedule:
+Ensure the local agent has these schedules:
+
+Daily triage report:
 
 - Job ID: `fini-daily-issue-report`
 - Schedule: `0 8 * * *`
@@ -32,6 +34,14 @@ Ensure the local agent has one daily schedule:
 - Session: isolated
 - Prompt: load `fini-daily`, run from `~/projects/fini`, use `triage`, query open `VRuzhentsov/fini` GitHub issues, and send the final report to `FINI_DAILY_TG_TARGET`
 - Delivery: Telegram `Daily` topic parsed from `FINI_DAILY_TG_TARGET`
+
+Branch fetch:
+
+- Job ID: `fini-fetch-all-branches`
+- Schedule: every `5m`
+- Session: isolated, light context
+- Prompt: run `git fetch --all --prune` from `~/projects/fini` and report only failures
+- Delivery: none
 
 ## Prerequisites
 
@@ -58,7 +68,7 @@ The helper:
 
 - Reads `~/.openclaw/cron/jobs.json` by default.
 - Preserves unrelated cron jobs.
-- Replaces only the job with ID `fini-daily-issue-report`.
+- Replaces only the managed jobs with IDs `fini-daily-issue-report` and `fini-fetch-all-branches`.
 - Defaults to dry-run and requires `--write` to modify the store.
 - Uses `FINI_DAILY_TG_TARGET` for Telegram delivery.
 - Uses `FINI_DAILY_TZ` or the local system timezone for the 8 AM schedule.
@@ -79,14 +89,16 @@ openclaw channels status --probe
 Expected evidence:
 
 - Exactly one enabled job with ID `fini-daily-issue-report`.
+- Exactly one enabled job with ID `fini-fetch-all-branches`.
 - The job schedule is `0 8 * * *` in the selected timezone.
+- The fetch job schedule is every `5m`.
 - Delivery points to the `Daily` topic thread from `FINI_DAILY_TG_TARGET`.
 - `fini-daily` and `triage` are available.
 - Telegram is configured and can send to the Daily topic, or the blocker is explicitly reported.
 
 If OpenClaw CLI cron commands are blocked by device-scope approval, verify by reading the cron list through any available read-only status path and report the approval blocker. Do not keep retrying approval loops.
 
-## Daily Prompt Contract
+## Prompt Contracts
 
 The scheduled prompt must preserve this intent:
 
@@ -96,9 +108,15 @@ Use the fini-daily skill. Run from ~/projects/fini. Use FINI_DAILY_TG_TARGET and
 
 Keep this prompt focused on read-only triage and reporting. Do not edit issues, labels, code, docs, or branches from the daily job unless the user explicitly delegates implementation.
 
+The fetch prompt must preserve this intent:
+
+```text
+From ~/projects/fini, run git fetch --all --prune to update every remote branch reference. Do not switch branches, merge, rebase, reset, clean, edit files, or push. Report only if the fetch fails, including the command and error summary.
+```
+
 ## Idempotency Rules
 
-- Treat `fini-daily-issue-report` as the only managed cron job.
+- Treat `fini-daily-issue-report` and `fini-fetch-all-branches` as the only managed cron jobs.
 - Do not create timestamped duplicate daily jobs.
 - Do not remove unrelated jobs.
 - Do not overwrite a different job unless it has the managed ID.
@@ -114,6 +132,9 @@ Status: <installed | already current | blocked>
 Job: fini-daily-issue-report
 Schedule: 0 8 * * * @ <timezone>
 Delivery: <group-id>:topic:<thread-id>
+Job: fini-fetch-all-branches
+Schedule: every 5m
+Delivery: none
 Evidence: <commands and outcomes>
 Blocker: <only if blocked>
 ```

--- a/.agents/skills/fini-dev-agent-install/scripts/upsert-fini-daily-cron.mjs
+++ b/.agents/skills/fini-dev-agent-install/scripts/upsert-fini-daily-cron.mjs
@@ -3,11 +3,16 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-const JOB_ID = 'fini-daily-issue-report';
-const JOB_NAME = 'Fini daily issue report';
-const JOB_DESCRIPTION = 'Daily Fini issue report for Vitalii';
+const DAILY_JOB_ID = 'fini-daily-issue-report';
+const FETCH_JOB_ID = 'fini-fetch-all-branches';
+const DAILY_JOB_NAME = 'Fini daily issue report';
+const FETCH_JOB_NAME = 'Fini fetch all branches';
+const DAILY_JOB_DESCRIPTION = 'Daily Fini issue report for Vitalii';
+const FETCH_JOB_DESCRIPTION = 'Fetch all Fini remote branches every five minutes';
 const CRON_EXPR = '0 8 * * *';
-const MESSAGE = 'Use the fini-daily skill. Run from ~/projects/fini. Use FINI_DAILY_TG_TARGET and FINI_PROGRESS_TG_TARGET from the local agent environment. Query current open GitHub issues for VRuzhentsov/fini using configured GitHub access without printing secrets. Run or load triage before choosing the recommendation. Produce the daily report format addressed to Vitalii. Deliver the final report to FINI_DAILY_TG_TARGET.';
+const FETCH_EVERY_MS = 5 * 60 * 1000;
+const DAILY_MESSAGE = 'Use the fini-daily skill. Run from ~/projects/fini. Use FINI_DAILY_TG_TARGET and FINI_PROGRESS_TG_TARGET from the local agent environment. Query current open GitHub issues for VRuzhentsov/fini using configured GitHub access without printing secrets. Run or load triage before choosing the recommendation. Produce the daily report format addressed to Vitalii. Deliver the final report to FINI_DAILY_TG_TARGET.';
+const FETCH_MESSAGE = 'From ~/projects/fini, run git fetch --all --prune to update every remote branch reference. Do not switch branches, merge, rebase, reset, clean, edit files, or push. Report only if the fetch fails, including the command and error summary.';
 
 function usage() {
   return `Usage: node upsert-fini-daily-cron.mjs [--dry-run|--write] [--store <path>]\n\nDefaults to --dry-run and ~/.openclaw/cron/jobs.json.`;
@@ -118,11 +123,11 @@ function readStore(storePath) {
   throw new Error(`Unsupported cron store shape at ${storePath}`);
 }
 
-function buildJob(target, timezone, nowMs) {
+function buildDailyJob(target, timezone, nowMs) {
   return {
-    id: JOB_ID,
-    name: JOB_NAME,
-    description: JOB_DESCRIPTION,
+    id: DAILY_JOB_ID,
+    name: DAILY_JOB_NAME,
+    description: DAILY_JOB_DESCRIPTION,
     enabled: true,
     createdAtMs: nowMs,
     schedule: {
@@ -135,7 +140,7 @@ function buildJob(target, timezone, nowMs) {
     wakeMode: 'now',
     payload: {
       kind: 'agentTurn',
-      message: MESSAGE,
+      message: DAILY_MESSAGE,
       timeoutSeconds: 900,
     },
     delivery: {
@@ -151,6 +156,36 @@ function buildJob(target, timezone, nowMs) {
   };
 }
 
+function buildFetchJob(nowMs) {
+  return {
+    id: FETCH_JOB_ID,
+    name: FETCH_JOB_NAME,
+    description: FETCH_JOB_DESCRIPTION,
+    enabled: true,
+    createdAtMs: nowMs,
+    schedule: {
+      kind: 'every',
+      everyMs: FETCH_EVERY_MS,
+    },
+    sessionTarget: 'isolated',
+    wakeMode: 'now',
+    payload: {
+      kind: 'agentTurn',
+      message: FETCH_MESSAGE,
+      timeoutSeconds: 120,
+      lightContext: true,
+      tools: ['exec'],
+    },
+    delivery: {
+      mode: 'none',
+    },
+    state: {
+      nextRunAtMs: nowMs + FETCH_EVERY_MS,
+    },
+    updatedAtMs: nowMs,
+  };
+}
+
 function comparable(job) {
   const copy = JSON.parse(JSON.stringify(job));
   delete copy.createdAtMs;
@@ -161,7 +196,7 @@ function comparable(job) {
 
 function upsert(store, desired) {
   const jobs = Array.isArray(store.jobs) ? store.jobs : [];
-  const index = jobs.findIndex((job) => job && job.id === JOB_ID);
+  const index = jobs.findIndex((job) => job && job.id === desired.id);
   const existing = index >= 0 ? jobs[index] : null;
   const finalJob = existing
     ? { ...desired, createdAtMs: existing.createdAtMs || desired.createdAtMs }
@@ -194,22 +229,34 @@ function main() {
   const timezone = localTimezone();
   const store = readStore(options.store);
   const nowMs = Date.now();
-  const desired = buildJob(target, timezone, nowMs);
-  const result = upsert(store, desired);
+  const dailyResult = upsert(store, buildDailyJob(target, timezone, nowMs));
+  const fetchResult = upsert(dailyResult.store, buildFetchJob(nowMs));
 
-  if (!options.dryRun && result.changed) {
-    writeStore(options.store, result.store);
+  if (!options.dryRun && (dailyResult.changed || fetchResult.changed)) {
+    writeStore(options.store, fetchResult.store);
   }
 
   console.log(JSON.stringify({
     dryRun: options.dryRun,
-    changed: result.changed,
-    existing: result.existing,
-    written: !options.dryRun && result.changed,
+    changed: dailyResult.changed || fetchResult.changed,
+    written: !options.dryRun && (dailyResult.changed || fetchResult.changed),
     store: options.store,
-    jobId: JOB_ID,
-    schedule: `${CRON_EXPR} @ ${timezone}`,
-    delivery: `${target.chatId}:topic:${target.threadId}`,
+    jobs: [
+      {
+        jobId: DAILY_JOB_ID,
+        changed: dailyResult.changed,
+        existing: dailyResult.existing,
+        schedule: `${CRON_EXPR} @ ${timezone}`,
+        delivery: `${target.chatId}:topic:${target.threadId}`,
+      },
+      {
+        jobId: FETCH_JOB_ID,
+        changed: fetchResult.changed,
+        existing: fetchResult.existing,
+        schedule: 'every 5m',
+        delivery: 'none',
+      },
+    ],
   }, null, 2));
 }
 

--- a/.agents/skills/fini-dev-agent-install/scripts/upsert-fini-daily-cron.mjs
+++ b/.agents/skills/fini-dev-agent-install/scripts/upsert-fini-daily-cron.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const JOB_ID = 'fini-daily-issue-report';
+const JOB_NAME = 'Fini daily issue report';
+const JOB_DESCRIPTION = 'Daily Fini issue report for Vitalii';
+const CRON_EXPR = '0 8 * * *';
+const MESSAGE = 'Use the fini-daily skill. Run from ~/projects/fini. Use FINI_DAILY_TG_TARGET and FINI_PROGRESS_TG_TARGET from the local agent environment. Query current open GitHub issues for VRuzhentsov/fini using configured GitHub access without printing secrets. Run or load triage before choosing the recommendation. Produce the daily report format addressed to Vitalii. Deliver the final report to FINI_DAILY_TG_TARGET.';
+
+function usage() {
+  return `Usage: node upsert-fini-daily-cron.mjs [--dry-run|--write] [--store <path>]\n\nDefaults to --dry-run and ~/.openclaw/cron/jobs.json.`;
+}
+
+function parseArgs(argv) {
+  const options = {
+    dryRun: true,
+    store: path.join(os.homedir(), '.openclaw', 'cron', 'jobs.json'),
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--dry-run') {
+      options.dryRun = true;
+    } else if (arg === '--write') {
+      options.dryRun = false;
+    } else if (arg === '--store') {
+      const value = argv[i + 1];
+      if (!value) throw new Error('--store requires a path');
+      options.store = value.startsWith('~') ? path.join(os.homedir(), value.slice(1)) : value;
+      i += 1;
+    } else if (arg === '--help' || arg === '-h') {
+      console.log(usage());
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function parseDailyTarget(value) {
+  if (!value) {
+    throw new Error('FINI_DAILY_TG_TARGET is required and should look like <group-id>:topic:<thread-id>');
+  }
+
+  const match = value.match(/^(-?\d+):topic:(\d+)$/);
+  if (!match) {
+    throw new Error('FINI_DAILY_TG_TARGET should look like <group-id>:topic:<thread-id>');
+  }
+
+  return {
+    chatId: match[1],
+    threadId: Number.parseInt(match[2], 10),
+  };
+}
+
+function localTimezone() {
+  return process.env.FINI_DAILY_TZ || Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+}
+
+function partsInTimezone(date, timezone) {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+  const entries = formatter.formatToParts(date)
+    .filter((part) => part.type !== 'literal')
+    .map((part) => [part.type, Number.parseInt(part.value, 10)]);
+  const parts = Object.fromEntries(entries);
+  if (parts.hour === 24) parts.hour = 0;
+  return parts;
+}
+
+function zonedTimeToUtcMs(parts, timezone) {
+  let guess = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second || 0);
+  for (let i = 0; i < 4; i += 1) {
+    const actual = partsInTimezone(new Date(guess), timezone);
+    const desiredLocalMs = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second || 0);
+    const actualLocalMs = Date.UTC(actual.year, actual.month - 1, actual.day, actual.hour, actual.minute, actual.second || 0);
+    const delta = desiredLocalMs - actualLocalMs;
+    if (delta === 0) break;
+    guess += delta;
+  }
+  return guess;
+}
+
+function nextDailyRunAtMs(timezone, nowMs) {
+  const now = partsInTimezone(new Date(nowMs), timezone);
+  const useToday = now.hour < 8 || (now.hour === 8 && now.minute === 0 && now.second === 0);
+  const baseMs = Date.UTC(now.year, now.month - 1, now.day + (useToday ? 0 : 1), 8, 0, 0);
+  const base = new Date(baseMs);
+  return zonedTimeToUtcMs({
+    year: base.getUTCFullYear(),
+    month: base.getUTCMonth() + 1,
+    day: base.getUTCDate(),
+    hour: 8,
+    minute: 0,
+    second: 0,
+  }, timezone);
+}
+
+function readStore(storePath) {
+  if (!fs.existsSync(storePath)) return { jobs: [] };
+  const text = fs.readFileSync(storePath, 'utf8');
+  if (!text.trim()) return { jobs: [] };
+  const parsed = JSON.parse(text);
+  if (Array.isArray(parsed)) return { jobs: parsed };
+  if (parsed && Array.isArray(parsed.jobs)) return parsed;
+  throw new Error(`Unsupported cron store shape at ${storePath}`);
+}
+
+function buildJob(target, timezone, nowMs) {
+  return {
+    id: JOB_ID,
+    name: JOB_NAME,
+    description: JOB_DESCRIPTION,
+    enabled: true,
+    createdAtMs: nowMs,
+    schedule: {
+      kind: 'cron',
+      expr: CRON_EXPR,
+      tz: timezone,
+      staggerMs: 0,
+    },
+    sessionTarget: 'isolated',
+    wakeMode: 'now',
+    payload: {
+      kind: 'agentTurn',
+      message: MESSAGE,
+      timeoutSeconds: 900,
+    },
+    delivery: {
+      mode: 'announce',
+      channel: 'telegram',
+      to: target.chatId,
+      threadId: target.threadId,
+    },
+    state: {
+      nextRunAtMs: nextDailyRunAtMs(timezone, nowMs),
+    },
+    updatedAtMs: nowMs,
+  };
+}
+
+function comparable(job) {
+  const copy = JSON.parse(JSON.stringify(job));
+  delete copy.createdAtMs;
+  delete copy.updatedAtMs;
+  delete copy.state;
+  return copy;
+}
+
+function upsert(store, desired) {
+  const jobs = Array.isArray(store.jobs) ? store.jobs : [];
+  const index = jobs.findIndex((job) => job && job.id === JOB_ID);
+  const existing = index >= 0 ? jobs[index] : null;
+  const finalJob = existing
+    ? { ...desired, createdAtMs: existing.createdAtMs || desired.createdAtMs }
+    : desired;
+
+  const stateNeedsRepair = existing && (!existing.state || typeof existing.state.nextRunAtMs !== 'number');
+  const changed = !existing || stateNeedsRepair || JSON.stringify(comparable(existing)) !== JSON.stringify(comparable(finalJob));
+  const nextJobs = [...jobs];
+  if (index >= 0) nextJobs[index] = finalJob;
+  else nextJobs.push(finalJob);
+
+  return {
+    changed,
+    existing: Boolean(existing),
+    store: { ...store, jobs: nextJobs },
+    job: finalJob,
+  };
+}
+
+function writeStore(storePath, store) {
+  fs.mkdirSync(path.dirname(storePath), { recursive: true });
+  const tempPath = `${storePath}.${process.pid}.tmp`;
+  fs.writeFileSync(tempPath, `${JSON.stringify(store, null, 2)}\n`, 'utf8');
+  fs.renameSync(tempPath, storePath);
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const target = parseDailyTarget(process.env.FINI_DAILY_TG_TARGET);
+  const timezone = localTimezone();
+  const store = readStore(options.store);
+  const nowMs = Date.now();
+  const desired = buildJob(target, timezone, nowMs);
+  const result = upsert(store, desired);
+
+  if (!options.dryRun && result.changed) {
+    writeStore(options.store, result.store);
+  }
+
+  console.log(JSON.stringify({
+    dryRun: options.dryRun,
+    changed: result.changed,
+    existing: result.existing,
+    written: !options.dryRun && result.changed,
+    store: options.store,
+    jobId: JOB_ID,
+    schedule: `${CRON_EXPR} @ ${timezone}`,
+    delivery: `${target.chatId}:topic:${target.threadId}`,
+  }, null, 2));
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/.agents/skills/fini-dev-agent/SKILL.md
+++ b/.agents/skills/fini-dev-agent/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: fini-dev-agent
+description: "Use this when an autonomous-coding-agent, autonomous coding agent, remote agent, Will Claw/Milo, or other delegated agent is asked to implement, debug, verify, or report progress on Fini repository work. This is a behavior overlay for agents: load `fini-dev` for Fini development mechanics, then use this skill to organize scope, autonomy, Telegram topic coordination, progress updates, blockers, verification evidence, and handoff discipline."
+metadata:
+  openclaw:
+    envVars:
+      - name: FINI_DEV_TG_CHANNEL_ID
+        required: false
+        description: Telegram group chat ID for Fini Dev.
+      - name: FINI_DAILY_TG_TARGET
+        required: false
+        description: Preferred Telegram target for Daily topic reports, usually <group-id>:topic:<thread-id>.
+      - name: FINI_CREATE_TG_TARGET
+        required: false
+        description: Preferred Telegram target for Create topic work intake and ticket creation updates.
+      - name: FINI_PROGRESS_TG_TARGET
+        required: false
+        description: Preferred Telegram target for In Progress topic implementation updates.
+---
+
+# Fini Autonomous Dev Agent
+
+Use this skill as a behavior overlay for autonomous coding agents working on Fini. It does not replace `fini-dev`; it adds delegation, progress, and handoff discipline around it.
+
+## First Step
+
+Load `fini-dev` before changing Fini code, tests, docs, automation, release files, or designs.
+
+Then apply this skill for autonomous-agent behavior:
+
+- Keep the scope locked to the delegated issue, ticket, prompt, or user request.
+- Work end-to-end within that scope when feasible.
+- Preserve user and other-agent changes in the worktree.
+- Send progress only at meaningful phase transitions.
+- Report verifiable evidence before claiming success.
+
+## Agent Operating Contract
+
+Start each delegated task by establishing:
+
+- target outcome in the user's words
+- in-scope files, behavior, or issue
+- out-of-scope work that should not be touched
+- success checks and smallest useful verification command
+- expected progress channel, if Telegram is available
+
+If the task comes from a GitHub issue, follow `fini-dev` branch guidance before editing. If the issue is ambiguous, inspect the issue body, labels, linked design/spec/wiki context, and source code before asking the user.
+
+## Telegram Topic Coordination
+
+Use Fini Dev Telegram topics as coordination surfaces when the channel is available. Do not let Telegram delivery failures block local implementation; continue the work and report the delivery blocker in the final handoff.
+
+Preferred targets:
+
+| Topic | Use For | Preferred Env Var |
+|---|---|---|
+| `Daily` | Daily issue reports, triage summaries, next-delegation recommendations | `FINI_DAILY_TG_TARGET` |
+| `Create` | New ticket intake, issue drafting, scope capture, task creation status | `FINI_CREATE_TG_TARGET` |
+| `In Progress` | Implementation progress, blockers, verification updates, PR-ready notices | `FINI_PROGRESS_TG_TARGET` |
+
+Fallback:
+
+- Use `FINI_DEV_TG_CHANNEL_ID` only when a topic-specific target is not configured.
+- Prefer topic targets in the `<group-id>:topic:<thread-id>` form when available.
+- Never print or expose bot tokens, GitHub tokens, or secret file contents.
+
+Progress messages should be short and phase-based:
+
+```text
+Fini #<issue-or-task>: <phase>
+- Working on: <one sentence>
+- Evidence: <file, command, log, or current finding>
+- Next: <next concrete step>
+- Blocker: <only if blocked>
+```
+
+Send progress when entering these phases:
+
+- accepted / starting
+- investigating
+- implementing
+- verifying
+- blocked
+- PR ready / handoff ready
+
+Do not send progress after every command or minor edit.
+
+## Autonomous Work Loop
+
+Use this loop after `fini-dev` routing chooses the domain skill:
+
+1. Build the evidence chain before editing: trigger path, current behavior, relevant spec/wiki/source, and expected behavior.
+2. Create or update a concise todo list for tasks with three or more meaningful steps.
+3. Read only the files needed for the delegated scope.
+4. Search for existing utilities, constants, commands, and patterns before adding new ones.
+5. Make the smallest correct change.
+6. Update companion specs/docs when behavior or architecture changes.
+7. Verify with the smallest useful command, escalating only when the result demands it.
+8. Summarize evidence, changed files, skipped checks, and remaining risks.
+
+When data behavior is involved, verify all three hops before claiming success:
+
+- write path
+- persisted data or durable side effect
+- read/render/report path
+
+## Decision Discipline
+
+Prefer action over asking when evidence can answer the question. Ask the user only when a decision changes product intent, scope, data semantics, release policy, or risk acceptance.
+
+When blocked:
+
+- State the exact blocker.
+- Include the evidence that proves the blocker.
+- Offer the shortest safe manual step if user action is faster than automation.
+- Keep unrelated work untouched.
+
+Do not expand scope to opportunistic refactors, cleanup, dependency upgrades, or broad test rewrites unless they are required for the delegated task.
+
+## Worktree Safety
+
+Assume the Fini worktree may contain user or other-agent changes.
+
+- Inspect status before edits when implementation is requested.
+- Do not revert, overwrite, or restage unrelated changes.
+- If existing changes are in files you need to edit, read them carefully and layer your change around them.
+- If unrelated changes conflict directly with the delegated task, stop and ask for the desired resolution.
+- Do not commit implementation changes until the user has verified they work, following the repo `AGENTS.md` rule.
+
+## Handoff Format
+
+Use this concise final or Telegram handoff format:
+
+```text
+Status: <done | blocked | partial>
+Scope: <issue/task>
+Changed: <files or none>
+Evidence: <commands/logs/code refs that verify the claim>
+Skipped: <checks not run and why>
+Risks: <remaining risks or none>
+Next: <one concrete next step, if any>
+```
+
+For PR-ready work, include:
+
+- branch name
+- issue number or task source
+- verification commands and outcomes
+- manual checks still needed
+- whether Telegram progress delivery succeeded or failed
+
+## Non-Goals
+
+This skill does not define Fini product semantics, test commands, release rules, design bundle protocol, Android workflow, or CLI behavior. Load the specialized Fini skill for those areas through `fini-dev`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,3 +180,112 @@ jobs:
       - name: Cleanup E2E containers
         if: always()
         run: make pr-gate-e2e-cleanup
+
+  android-emulator-e2e:
+    name: Android Emulator E2E
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Add x86_64 Android Rust target
+        run: rustup target add x86_64-linux-android
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            src-tauri -> target
+          shared-key: android-emulator-e2e-rust
+
+      - name: Restore Android project cache
+        uses: actions/cache@v4
+        with:
+          path: src-tauri/gen/android/.gradle
+          key: android-emulator-e2e-${{ runner.os }}-${{ hashFiles('src-tauri/gen/android/gradle.properties', 'src-tauri/gen/android/settings.gradle', 'src-tauri/gen/android/build.gradle.kts', 'src-tauri/gen/android/app/build.gradle.kts', 'src-tauri/gen/android/gradle/wrapper/gradle-wrapper.properties', 'src-tauri/Cargo.lock', 'package-lock.json') }}
+          restore-keys: |
+            android-emulator-e2e-${{ runner.os }}-
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build x86_64 debug APK
+        run: make android-build-emulator-e2e
+
+      - name: Locate debug APK
+        shell: bash
+        run: |
+          set -euo pipefail
+          apk=$(find src-tauri/gen/android/app/build/outputs/apk -name '*.apk' | head -n 1)
+          if [ -z "$apk" ]; then
+            echo "APK not found after build" >&2
+            exit 1
+          fi
+          echo "ANDROID_E2E_APK=$apk" >> "$GITHUB_ENV"
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run smoke and notification channel assertions
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          emulator-options: -no-window -no-audio -gpu swiftshader_indirect -no-snapshot -no-metrics
+          disable-animations: true
+          script: |
+            set -euo pipefail
+
+            adb install "$ANDROID_E2E_APK"
+            adb shell pm grant com.fini.app android.permission.POST_NOTIFICATIONS
+            adb shell am start -n com.fini.app/.MainActivity
+
+            echo "Waiting for app process..."
+            for i in $(seq 1 30); do
+              pid=$(adb shell pidof com.fini.app 2>/dev/null || true)
+              if [ -n "$pid" ]; then echo "App process alive: $pid"; break; fi
+              if [ "$i" -eq 30 ]; then
+                echo "App process did not start" >&2
+                adb logcat -d -s AndroidRuntime:E >&2
+                exit 1
+              fi
+              sleep 1
+            done
+
+            echo "Waiting for notification channel fini.reminders..."
+            for i in $(seq 1 20); do
+              if adb shell dumpsys notification 2>/dev/null | grep -q "fini.reminders"; then
+                echo "Notification channel fini.reminders confirmed"
+                break
+              fi
+              if [ "$i" -eq 20 ]; then
+                echo "Notification channel fini.reminders not found" >&2
+                adb shell dumpsys notification | grep -A3 "com.fini.app" >&2 || true
+                exit 1
+              fi
+              sleep 1
+            done
+
+            echo "Android smoke + notification channel assertions passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          apk=$(find src-tauri/gen/android/app/build/outputs/apk -name '*.apk' | head -n 1)
+          apk=$(find src-tauri/gen/android/app/build/outputs/apk -name '*debug*.apk' | head -n 1)
           if [ -z "$apk" ]; then
             echo "APK not found after build" >&2
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
           emulator-options: -no-window -no-audio -gpu swiftshader_indirect -no-snapshot -no-metrics
           disable-animations: true
           script: |
-            set -euo pipefail
+            set -eu
 
             adb install "$ANDROID_E2E_APK"
             adb shell pm grant com.fini.app android.permission.POST_NOTIFICATIONS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,11 +235,17 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          apk=$(find src-tauri/gen/android/app/build/outputs/apk -name '*debug*.apk' | head -n 1)
+          echo "=== APK outputs ==="
+          find src-tauri/gen/android/app/build/outputs/apk -name '*.apk' | sort
+          apk=$(find src-tauri/gen/android/app/build/outputs/apk -name '*debug*.apk' | grep -v arm | head -n 1)
+          if [ -z "$apk" ]; then
+            apk=$(find src-tauri/gen/android/app/build/outputs/apk -name '*debug*.apk' | head -n 1)
+          fi
           if [ -z "$apk" ]; then
             echo "APK not found after build" >&2
             exit 1
           fi
+          echo "Using APK: $apk"
           echo "ANDROID_E2E_APK=$apk" >> "$GITHUB_ENV"
 
       - name: Enable KVM
@@ -255,37 +261,4 @@ jobs:
           arch: x86_64
           emulator-options: -no-window -no-audio -gpu swiftshader_indirect -no-snapshot -no-metrics
           disable-animations: true
-          script: |
-            set -eu
-
-            adb install "$ANDROID_E2E_APK"
-            adb shell pm grant com.fini.app android.permission.POST_NOTIFICATIONS
-            adb shell am start -n com.fini.app/.MainActivity
-
-            echo "Waiting for app process..."
-            for i in $(seq 1 30); do
-              pid=$(adb shell pidof com.fini.app 2>/dev/null || true)
-              if [ -n "$pid" ]; then echo "App process alive: $pid"; break; fi
-              if [ "$i" -eq 30 ]; then
-                echo "App process did not start" >&2
-                adb logcat -d -s AndroidRuntime:E >&2
-                exit 1
-              fi
-              sleep 1
-            done
-
-            echo "Waiting for notification channel fini.reminders..."
-            for i in $(seq 1 20); do
-              if adb shell dumpsys notification 2>/dev/null | grep -q "fini.reminders"; then
-                echo "Notification channel fini.reminders confirmed"
-                break
-              fi
-              if [ "$i" -eq 20 ]; then
-                echo "Notification channel fini.reminders not found" >&2
-                adb shell dumpsys notification | grep -A3 "com.fini.app" >&2 || true
-                exit 1
-              fi
-              sleep 1
-            done
-
-            echo "Android smoke + notification channel assertions passed"
+          script: bash scripts/android-e2e-assert.sh

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ FINI_E2E_CACHE_IMAGE_PREFIX ?=
 FINI_E2E_CACHE_PUSH ?= 0
 RELEASE_BUNDLES ?= deb,rpm
 
-.PHONY: help dev build mcp play-store-screenshots pr-gate-fe-unit pr-gate-be-cache-key pr-gate-be-compile pr-gate-be-unit pr-gate-e2e pr-gate-e2e-cache-key pr-gate-e2e-build-actor pr-gate-e2e-build-runner pr-gate-e2e-network pr-gate-e2e-start-actors pr-gate-e2e-wait-actors pr-gate-e2e-run pr-gate-e2e-logs pr-gate-e2e-cleanup e2e e2e-ci e2e-image e2e-build e2e-headed e2e-actors-image e2e-actors runtime-image runtime-smoke release android-connect android-dev android-build android-sign-debug android-sign-release-local android-install-debug android-install-release-local android-launch android-devices android-debug-deploy android-release-deploy-local flatpak-install-local
+.PHONY: help dev build mcp play-store-screenshots pr-gate-fe-unit pr-gate-be-cache-key pr-gate-be-compile pr-gate-be-unit pr-gate-e2e pr-gate-e2e-cache-key pr-gate-e2e-build-actor pr-gate-e2e-build-runner pr-gate-e2e-network pr-gate-e2e-start-actors pr-gate-e2e-wait-actors pr-gate-e2e-run pr-gate-e2e-logs pr-gate-e2e-cleanup e2e e2e-ci e2e-image e2e-build e2e-headed e2e-actors-image e2e-actors runtime-image runtime-smoke release android-connect android-dev android-build android-build-emulator-e2e android-sign-debug android-sign-release-local android-install-debug android-install-release-local android-launch android-devices android-debug-deploy android-release-deploy-local flatpak-install-local
 
 help:
 	@echo ""
@@ -50,6 +50,7 @@ help:
 	@echo "  make android-connect  Auto-discover and connect to device via adb mdns"
 	@echo "  make android-dev      Hot-reload on device via Wi-Fi (auto-connects)"
 	@echo "  make android-build    Build Android APK"
+	@echo "  make android-build-emulator-e2e  Build x86_64 debug APK for emulator E2E gate"
 	@echo "  make android-sign-debug   Sign APK to bin/fini.apk using debug keystore"
 	@echo "  make android-sign-release-local  Sign APK with local release keystore env vars"
 	@echo "  make android-install-debug  Install bin/fini.apk on connected device"
@@ -657,6 +658,9 @@ android-dev: android-connect
 
 android-build:
 	npm run tauri android build -- --target "$(ANDROID_TARGET)"
+
+android-build-emulator-e2e:
+	npm run tauri android build -- --ci --debug --apk --target x86_64
 
 android-sign-debug:
 	@test -n "$(ANDROID_HOME)" || (echo "ANDROID_HOME is not set" && exit 1)

--- a/scripts/android-e2e-assert.sh
+++ b/scripts/android-e2e-assert.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+adb install "$ANDROID_E2E_APK"
+adb shell pm grant com.fini.app android.permission.POST_NOTIFICATIONS
+adb shell am start -n com.fini.app/.MainActivity
+
+echo "Waiting for app process..."
+for i in $(seq 1 30); do
+  pid=$(adb shell pidof com.fini.app 2>/dev/null || true)
+  if [ -n "$pid" ]; then echo "App process alive: $pid"; break; fi
+  if [ "$i" -eq 30 ]; then
+    echo "App process did not start" >&2
+    adb logcat -d -s AndroidRuntime:E >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "Waiting for notification channel fini.reminders..."
+for i in $(seq 1 20); do
+  if adb shell dumpsys notification 2>/dev/null | grep -q "fini.reminders"; then
+    echo "Notification channel fini.reminders confirmed"
+    break
+  fi
+  if [ "$i" -eq 20 ]; then
+    echo "Notification channel fini.reminders not found" >&2
+    adb shell dumpsys notification | grep -A3 "com.fini.app" >&2 || true
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "Android smoke + notification channel assertions passed"


### PR DESCRIPTION
## Summary

- Adds `android-emulator-e2e` job to `ci.yml` as a blocking PR gate
- Builds a debug x86_64 APK, boots an Android 34 emulator, installs the APK, and asserts two things: (1) the app process is alive and (2) the `fini.reminders` notification channel is registered
- Adds `android-build-emulator-e2e` Makefile target for local builds
- Fixes APK locate pattern to match `*debug*.apk` (avoid picking up stale release APK)

## What it catches

- Android build breakage (Rust cross-compile, Gradle, NDK)
- App launch failures (blank webview, init crash, missing permissions)
- Notification channel regressions (`fini.reminders` missing → reminders silently broken on mobile)

## Local validation

Assertions were run locally against an x86_64 emulator (API 34, `google_apis`):

```
App process alive: 6015
Notification channel fini.reminders confirmed
```

**Note for local use on Bazzite:** use `-gpu angle_indirect` instead of `-gpu swiftshader_indirect` — swiftshader crashes on Bazzite kernel 6.19 (QEMU JIT callback bug, Bazzite-specific). CI runs ubuntu-latest where swiftshader works correctly.

## Test plan

- [ ] CI `android-emulator-e2e` job passes green
- [ ] Verify job blocks the PR merge when it fails (branch protection)