### PR TITLE
fix(release): publish standalone CLI artifacts

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -198,6 +198,9 @@ jobs:
       - name: Build Linux bundles
         run: npm run tauri build -- --features ui-plane,cli-plane --target ${{ matrix.rust_target }} --bundles appimage,deb,rpm
 
+      - name: Build Linux CLI
+        run: cargo build --manifest-path src-tauri/Cargo.toml --locked --release --bin fini --features cli-plane --target ${{ matrix.rust_target }}
+
       - name: Collect Linux release files
         run: |
           set -euo pipefail
@@ -234,6 +237,13 @@ jobs:
             echo "Expected Linux artifacts (.deb, .rpm, .AppImage) were not all produced" >&2
             exit 1
           fi
+
+          cli_binary="src-tauri/target/${{ matrix.rust_target }}/release/fini"
+          if [ ! -f "$cli_binary" ]; then
+            echo "Expected Linux CLI binary was not produced: $cli_binary" >&2
+            exit 1
+          fi
+          tar -C "$(dirname "$cli_binary")" -czf "prep/linux/fini-prep-${short_sha}-linux-${{ matrix.arch }}-cli.tar.gz" fini
 
       - name: Upload Linux bundle artifact
         uses: actions/upload-artifact@v4
@@ -286,25 +296,31 @@ jobs:
       - name: Build Windows bundles
         run: npm run tauri build -- --features ui-plane,cli-plane --target ${{ matrix.rust_target }} --bundles nsis
 
+      - name: Build Windows CLI
+        run: cargo build --manifest-path src-tauri/Cargo.toml --locked --release --bin fini --features cli-plane --target ${{ matrix.rust_target }}
+
       - name: Collect Windows release files
-        shell: bash
+        shell: pwsh
         run: |
-          set -euo pipefail
-          bundle_root="src-tauri/target/${{ matrix.rust_target }}/release/bundle"
-          mkdir -p prep/windows
-          short_sha="${GITHUB_SHA::7}"
+          $ErrorActionPreference = "Stop"
+          $bundleRoot = "src-tauri/target/${{ matrix.rust_target }}/release/bundle"
+          $shortSha = $env:GITHUB_SHA.Substring(0, 7)
+          New-Item -ItemType Directory -Force prep/windows | Out-Null
 
-          found_exe="false"
-          while IFS= read -r file; do
-            output_path="prep/windows/fini-prep-${short_sha}-windows-${{ matrix.arch }}-setup.exe"
-            cp "$file" "$output_path"
-            found_exe="true"
-          done < <(find "$bundle_root" -type f -name '*-setup.exe')
+          $setupFiles = Get-ChildItem -Path $bundleRoot -Recurse -Filter "*-setup.exe"
+          if ($setupFiles.Count -eq 0) {
+            throw "Expected Windows .exe artifacts were not produced"
+          }
+          foreach ($file in $setupFiles) {
+            $outputPath = "prep/windows/fini-prep-$shortSha-windows-${{ matrix.arch }}-setup.exe"
+            Copy-Item -LiteralPath $file.FullName -Destination $outputPath -Force
+          }
 
-          if [ "$found_exe" != "true" ]; then
-            echo "Expected Windows .exe artifacts were not produced" >&2
-            exit 1
-          fi
+          $cliBinary = "src-tauri/target/${{ matrix.rust_target }}/release/fini.exe"
+          if (!(Test-Path -LiteralPath $cliBinary)) {
+            throw "Expected Windows CLI binary was not produced: $cliBinary"
+          }
+          Compress-Archive -LiteralPath $cliBinary -DestinationPath "prep/windows/fini-prep-$shortSha-windows-${{ matrix.arch }}-cli.zip" -Force
 
       - name: Upload Windows bundle artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -301,6 +301,9 @@ jobs:
       - name: Build Linux bundles
         run: npm run tauri build -- --features ui-plane,cli-plane --target ${{ matrix.rust_target }} --bundles appimage,deb,rpm
 
+      - name: Build Linux CLI
+        run: cargo build --manifest-path src-tauri/Cargo.toml --locked --release --bin fini --features cli-plane --target ${{ matrix.rust_target }}
+
       - name: Collect Linux release files
         run: |
           set -euo pipefail
@@ -341,6 +344,13 @@ jobs:
             echo "Expected Linux artifacts (.deb, .rpm, .AppImage) were not all produced" >&2
             exit 1
           fi
+
+          cli_binary="src-tauri/target/${{ matrix.rust_target }}/release/fini"
+          if [ ! -f "$cli_binary" ]; then
+            echo "Expected Linux CLI binary was not produced: $cli_binary" >&2
+            exit 1
+          fi
+          tar -C "$(dirname "$cli_binary")" -czf "release/linux/fini-${GITHUB_REF_NAME}-linux-${{ matrix.arch }}-cli.tar.gz" fini
 
       - name: Upload Linux artifact
         uses: actions/upload-artifact@v4
@@ -406,28 +416,34 @@ jobs:
       - name: Build Windows bundles
         run: npm run tauri build -- --features ui-plane,cli-plane --target ${{ matrix.rust_target }} --bundles nsis
 
+      - name: Build Windows CLI
+        run: cargo build --manifest-path src-tauri/Cargo.toml --locked --release --bin fini --features cli-plane --target ${{ matrix.rust_target }}
+
       - name: Collect Windows release files
-        shell: bash
+        shell: pwsh
         run: |
-          set -euo pipefail
-          bundle_root="src-tauri/target/${{ matrix.rust_target }}/release/bundle"
-          mkdir -p release/windows
+          $ErrorActionPreference = "Stop"
+          $bundleRoot = "src-tauri/target/${{ matrix.rust_target }}/release/bundle"
+          New-Item -ItemType Directory -Force release/windows | Out-Null
 
-          found_exe="false"
-          while IFS= read -r file; do
-            output_path="release/windows/fini-${GITHUB_REF_NAME}-windows-${{ matrix.arch }}-setup.exe"
-            cp "$file" "$output_path"
-            if [ -f "${file}.sig" ]; then
-              cp "${file}.sig" "${output_path}.sig"
-            fi
-            found_exe="true"
-          done < <(find "$bundle_root" -type f \
-            -name '*-setup.exe')
+          $setupFiles = Get-ChildItem -Path $bundleRoot -Recurse -Filter "*-setup.exe"
+          if ($setupFiles.Count -eq 0) {
+            throw "Expected Windows .exe artifacts were not produced"
+          }
+          foreach ($file in $setupFiles) {
+            $outputPath = "release/windows/fini-${env:GITHUB_REF_NAME}-windows-${{ matrix.arch }}-setup.exe"
+            Copy-Item -LiteralPath $file.FullName -Destination $outputPath -Force
+            $signaturePath = "$($file.FullName).sig"
+            if (Test-Path -LiteralPath $signaturePath) {
+              Copy-Item -LiteralPath $signaturePath -Destination "$outputPath.sig" -Force
+            }
+          }
 
-          if [ "$found_exe" != "true" ]; then
-            echo "Expected Windows .exe artifacts were not produced" >&2
-            exit 1
-          fi
+          $cliBinary = "src-tauri/target/${{ matrix.rust_target }}/release/fini.exe"
+          if (!(Test-Path -LiteralPath $cliBinary)) {
+            throw "Expected Windows CLI binary was not produced: $cliBinary"
+          }
+          Compress-Archive -LiteralPath $cliBinary -DestinationPath "release/windows/fini-${env:GITHUB_REF_NAME}-windows-${{ matrix.arch }}-cli.zip" -Force
 
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Build planes are explicit:
 - Desktop GUI builds use `ui-plane`.
 - Mobile builds use `ui-plane` only; CLI code is not compiled into mobile bundles.
 - Docker/runtime builds use `cli-plane` only and expose `/usr/local/bin/fini`.
+- Release artifacts keep GUI and CLI distribution separate. Linux and Windows releases publish standalone CLI archives alongside GUI installers.
 
 The CLI binary is built separately from the desktop app binary:
 
@@ -111,6 +112,15 @@ The CLI binary is built separately from the desktop app binary:
 cargo build --manifest-path src-tauri/Cargo.toml --bin fini --features cli-plane
 npm run tauri build -- --features ui-plane
 ```
+
+CLI release artifacts are named by platform and architecture:
+
+| Platform | CLI artifact |
+|---|---|
+| Linux x64 | `fini-vX.Y.Z-linux-x64-cli.tar.gz` |
+| Linux arm64 | `fini-vX.Y.Z-linux-arm64-cli.tar.gz` |
+| Windows x64 | `fini-vX.Y.Z-windows-x64-cli.zip` |
+| Windows arm64 | `fini-vX.Y.Z-windows-arm64-cli.zip` |
 
 ## Tech Stack
 

--- a/specs/cli/README.md
+++ b/specs/cli/README.md
@@ -20,6 +20,20 @@ Fini exposes a CLI-only binary named `fini` for synchronous automation.
 - Docker runtime builds enable only `cli-plane` and expose the CLI binary by default.
 - Mobile builds enable only `ui-plane`; adding `cli-plane` to mobile builds violates this contract.
 
+## Release Artifacts
+
+GUI and CLI distribution are separate release surfaces.
+
+| Surface | Artifact shape |
+|---|---|
+| Linux GUI | `.deb`, `.rpm`, `.AppImage` |
+| Windows GUI | NSIS setup `.exe` |
+| Linux CLI | `fini-vX.Y.Z-linux-ARCH-cli.tar.gz` containing `fini` |
+| Windows CLI | `fini-vX.Y.Z-windows-ARCH-cli.zip` containing `fini.exe` |
+| Docker runtime | Image entrypoint `/usr/local/bin/fini` |
+
+Desktop installers must not be required to expose the CLI on `PATH`. Users who want CLI-only automation should install the standalone CLI artifact or use the Docker runtime image.
+
 ## Verification
 
 Use these checks when changing the binary contract:


### PR DESCRIPTION
## Summary
- build the standalone Rust CLI in Linux and Windows release matrix jobs
- publish CLI archives alongside GUI release artifacts
- document separate GUI/CLI release surfaces and artifact names

## Verification
- cargo build --manifest-path src-tauri/Cargo.toml --locked --bin fini --features cli-plane
- git diff --check

## Notes
- actionlint is not installed in the local environment, so workflow lint was not run locally.
- macOS CLI artifacts remain out of scope for this PR.