### PR TITLE
Add release button workflow

### DIFF
--- a/.github/workflows/release-button.yml
+++ b/.github/workflows/release-button.yml
@@ -1,0 +1,103 @@
+name: Release Button
+
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: write
+  issues: write
+
+concurrency:
+  group: release-button-main
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Plan release
+        id: plan
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin main --tags --force
+          latest_tag="$(git describe --tags --abbrev=0 --match 'v[0-9]*' origin/main)"
+          main_sha="$(git rev-parse origin/main)"
+          subjects="$(git log --format=%s "${latest_tag}..origin/main")"
+
+          if [ -z "$subjects" ]; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            printf '## Release skipped\n\n- Latest tag: %s\n- origin/main: %s\n- Reason: no commits since latest release tag\n' "$latest_tag" "$main_sha" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          bump=none
+          if printf '%s\n' "$subjects" | grep -Eq '^[a-z]+(\([^)]+\))?!:'; then bump=major;
+          elif printf '%s\n' "$subjects" | grep -Eq '^feat(\([^)]+\))?:'; then bump=minor;
+          elif printf '%s\n' "$subjects" | grep -Eq '^(fix|perf|refactor|build|release)(\([^)]+\))?:'; then bump=patch; fi
+
+          if [ "$bump" = none ]; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            printf '## Release skipped\n\n- Latest tag: %s\n- origin/main: %s\n- Reason: no releasable commits since latest release tag\n' "$latest_tag" "$main_sha" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          IFS=. read -r major minor patch <<< "${latest_tag#v}"
+          case "$bump" in
+            major) major=$((major + 1)); minor=0; patch=0 ;;
+            minor) minor=$((minor + 1)); patch=0 ;;
+            patch) patch=$((patch + 1)) ;;
+          esac
+          version="$major.$minor.$patch"
+          tag="v$version"
+          branch="release/$tag"
+
+          { echo "should_release=true"; echo "latest_tag=$latest_tag"; echo "main_sha=$main_sha"; echo "bump=$bump"; echo "version=$version"; echo "tag=$tag"; echo "branch=$branch"; } >> "$GITHUB_OUTPUT"
+          printf '## Release planned\n\n- Latest tag: %s\n- Next tag: %s\n- Bump: %s\n- origin/main: %s\n\n### Commits\n%s\n' "$latest_tag" "$tag" "$bump" "$main_sha" "$(git log --oneline "${latest_tag}..origin/main")" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Commit version bump
+        if: steps.plan.outputs.should_release == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git ls-remote origin refs/heads/main | cut -f1)" = "${{ steps.plan.outputs.main_sha }}"
+          test -z "$(git ls-remote --tags origin "refs/tags/${{ steps.plan.outputs.tag }}")"
+          cargo run --manifest-path xtask/Cargo.toml -- release-version "${{ steps.plan.outputs.version }}"
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git add package.json package-lock.json src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json
+          git commit -m "chore: release ${{ steps.plan.outputs.tag }}"
+          git push origin "HEAD:refs/heads/${{ steps.plan.outputs.branch }}"
+          git push origin "HEAD:refs/heads/main"
+
+      - name: Import GPG key
+        if: steps.plan.outputs.should_release == 'true'
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.RELEASE_TAG_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.RELEASE_TAG_GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: false
+
+      - name: Tag, issue, and dispatch release
+        if: steps.plan.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ steps.plan.outputs.tag }}"
+          git tag -s -a "$tag" -m "$tag"
+          git tag -v "$tag"
+          git push origin "$tag"
+          issue_url="$(gh issue create --title "Release $tag" --body "Release button created $tag from ${{ steps.plan.outputs.latest_tag }}. Triggered by: @${{ github.actor }}. Branch: ${{ steps.plan.outputs.branch }}. Workflow: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID")"
+          gh workflow run release-tag.yml --ref "$tag"
+          printf '\n## Release started\n\n- Tag: %s\n- Issue: %s\n- Release workflow: release-tag.yml\n' "$tag" "$issue_url" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -52,11 +53,16 @@ jobs:
           echo "tag_name=$tag" >> "$GITHUB_OUTPUT"
           echo "is_prerelease=$is_prerelease" >> "$GITHUB_OUTPUT"
 
-      - name: Verify tag actor has maintain/admin access
+      - name: Verify release actor has maintain/admin access
         uses: actions/github-script@v8
         with:
           script: |
             const actor = context.actor;
+            if (context.eventName === "workflow_dispatch" && actor === "github-actions[bot]") {
+              core.info("Release workflow was dispatched by GitHub Actions automation.");
+              return;
+            }
+
             const { owner, repo } = context.repo;
             const result = await github.rest.repos.getCollaboratorPermissionLevel({
               owner,
@@ -65,9 +71,9 @@ jobs:
             });
             const allowed = new Set(["maintain", "admin"]);
             const permission = result.data.permission;
-            core.info(`Tag actor ${actor} has permission: ${permission}`);
+            core.info(`Release actor ${actor} has permission: ${permission}`);
             if (!allowed.has(permission)) {
-              core.setFailed(`Tag actor ${actor} must have maintain/admin permission.`);
+              core.setFailed(`Release actor ${actor} must have maintain/admin permission.`);
             }
 
       - name: Resolve tag commit and compare with origin/main

--- a/README.md
+++ b/README.md
@@ -168,6 +168,26 @@ make build
 
 Release workflow is GitOps: pushing a signed annotated `v*` tag starts CI. The release command first commits the npm, Rust, and Tauri version metadata on `main`, then tags and pushes that exact commit. CI owns tests, builds, signing checks, packaging, and artifacts.
 
+The one-click release path is the `Release Button` GitHub Actions workflow. It compares the latest `v*` tag with `origin/main`, chooses the next version from Conventional Commit subjects, creates one `chore: release vX.Y.Z` metadata commit, pushes a `release/vX.Y.Z` trace branch and `main`, creates a signed annotated tag, opens a release issue, and dispatches the tag release pipeline. If there are no commits since the latest release tag, it exits successfully as a skipped no-op and does not create an issue, commit, tag, or release pipeline run.
+
+Before using the button, add the release signing key secrets once:
+
+```bash
+release_key_id="$(git config user.signingkey)"
+gpg --armor --export-secret-keys "$release_key_id" | gh secret set RELEASE_TAG_GPG_PRIVATE_KEY
+gpg --armor --export "$release_key_id" | gh secret set RELEASE_TAG_GPG_PUBLIC_KEY
+```
+
+If the release key has a passphrase, also add it:
+
+```bash
+read -rsp 'GPG passphrase: ' RELEASE_TAG_GPG_PASSPHRASE; printf '\n'
+gh secret set RELEASE_TAG_GPG_PASSPHRASE --body "$RELEASE_TAG_GPG_PASSPHRASE"
+unset RELEASE_TAG_GPG_PASSPHRASE
+```
+
+The local release path remains available:
+
 ```bash
 make release VERSION=0.1.12
 ```


### PR DESCRIPTION
## Summary
- add a manual Release Button workflow that computes the next release from Conventional Commit subjects
- create one version-bump commit, push a trace branch and main, sign and push the release tag, open a release issue, and dispatch release-tag.yml
- allow release-tag.yml to be dispatched explicitly after the button pushes a signed tag

## Validation
- cargo fmt --manifest-path xtask/Cargo.toml --check
- cargo check --manifest-path xtask/Cargo.toml

## Notes
- RELEASE_TAG_GPG_PRIVATE_KEY and RELEASE_TAG_GPG_PUBLIC_KEY are configured on VRuzhentsov/fini
- the new workflow should appear after this PR is merged to main