### PR TITLE
Fix release button protected main push

### DIFF
--- a/.github/workflows/release-button.yml
+++ b/.github/workflows/release-button.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: write
   contents: write
   issues: write
 
@@ -20,6 +19,7 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_AUTOMATION_TOKEN || github.token }}
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -70,13 +70,14 @@ jobs:
           set -euo pipefail
           test "$(git ls-remote origin refs/heads/main | cut -f1)" = "${{ steps.plan.outputs.main_sha }}"
           test -z "$(git ls-remote --tags origin "refs/tags/${{ steps.plan.outputs.tag }}")"
+          test -z "$(git ls-remote --heads origin "refs/heads/${{ steps.plan.outputs.branch }}")"
           cargo run --manifest-path xtask/Cargo.toml -- release-version "${{ steps.plan.outputs.version }}"
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
           git add package.json package-lock.json src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json
           git commit -m "chore: release ${{ steps.plan.outputs.tag }}"
-          git push origin "HEAD:refs/heads/${{ steps.plan.outputs.branch }}"
           git push origin "HEAD:refs/heads/main"
+          git push origin "HEAD:refs/heads/${{ steps.plan.outputs.branch }}"
 
       - name: Import GPG key
         if: steps.plan.outputs.should_release == 'true'
@@ -87,10 +88,10 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: false
 
-      - name: Tag, issue, and dispatch release
+      - name: Tag and create issue
         if: steps.plan.outputs.should_release == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN || github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -99,5 +100,4 @@ jobs:
           git tag -v "$tag"
           git push origin "$tag"
           issue_url="$(gh issue create --title "Release $tag" --body "Release button created $tag from ${{ steps.plan.outputs.latest_tag }}. Triggered by: @${{ github.actor }}. Branch: ${{ steps.plan.outputs.branch }}. Workflow: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID")"
-          gh workflow run release-tag.yml --ref "$tag"
-          printf '\n## Release started\n\n- Tag: %s\n- Issue: %s\n- Release workflow: release-tag.yml\n' "$tag" "$issue_url" >> "$GITHUB_STEP_SUMMARY"
+          printf '\n## Release started\n\n- Tag: %s\n- Issue: %s\n- Release workflow: release-tag.yml starts from the tag push\n' "$tag" "$issue_url" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - "v*"
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -53,16 +52,11 @@ jobs:
           echo "tag_name=$tag" >> "$GITHUB_OUTPUT"
           echo "is_prerelease=$is_prerelease" >> "$GITHUB_OUTPUT"
 
-      - name: Verify release actor has maintain/admin access
+      - name: Verify tag actor has maintain/admin access
         uses: actions/github-script@v8
         with:
           script: |
             const actor = context.actor;
-            if (context.eventName === "workflow_dispatch" && actor === "github-actions[bot]") {
-              core.info("Release workflow was dispatched by GitHub Actions automation.");
-              return;
-            }
-
             const { owner, repo } = context.repo;
             const result = await github.rest.repos.getCollaboratorPermissionLevel({
               owner,
@@ -71,9 +65,9 @@ jobs:
             });
             const allowed = new Set(["maintain", "admin"]);
             const permission = result.data.permission;
-            core.info(`Release actor ${actor} has permission: ${permission}`);
+            core.info(`Tag actor ${actor} has permission: ${permission}`);
             if (!allowed.has(permission)) {
-              core.setFailed(`Release actor ${actor} must have maintain/admin permission.`);
+              core.setFailed(`Tag actor ${actor} must have maintain/admin permission.`);
             }
 
       - name: Resolve tag commit and compare with origin/main

--- a/README.md
+++ b/README.md
@@ -168,9 +168,15 @@ make build
 
 Release workflow is GitOps: pushing a signed annotated `v*` tag starts CI. The release command first commits the npm, Rust, and Tauri version metadata on `main`, then tags and pushes that exact commit. CI owns tests, builds, signing checks, packaging, and artifacts.
 
-The one-click release path is the `Release Button` GitHub Actions workflow. It compares the latest `v*` tag with `origin/main`, chooses the next version from Conventional Commit subjects, creates one `chore: release vX.Y.Z` metadata commit, pushes a `release/vX.Y.Z` trace branch and `main`, creates a signed annotated tag, opens a release issue, and dispatches the tag release pipeline. If there are no commits since the latest release tag, it exits successfully as a skipped no-op and does not create an issue, commit, tag, or release pipeline run.
+The one-click release path is the `Release Button` GitHub Actions workflow. It compares the latest `v*` tag with `origin/main`, chooses the next version from Conventional Commit subjects, creates one `chore: release vX.Y.Z` metadata commit, pushes `main` and a `release/vX.Y.Z` trace branch, creates a signed annotated tag, and opens a release issue. The tag push starts the release pipeline. If there are no commits since the latest release tag, it exits successfully as a skipped no-op and does not create an issue, commit, tag, or release pipeline run.
 
-Before using the button, add the release signing key secrets once:
+Because `main` is protected, the button needs an automation token that can update protected branches for the repository:
+
+```bash
+gh auth token | gh secret set RELEASE_AUTOMATION_TOKEN --repo VRuzhentsov/fini
+```
+
+Before using the button, also add the release signing key secrets once:
 
 ```bash
 release_key_id="$(git config user.signingkey)"


### PR DESCRIPTION
## Summary
- use RELEASE_AUTOMATION_TOKEN for release button checkout, pushes, issue creation, and tag push so protected main can be updated by the release automation identity
- push main before the trace branch to avoid leftover release branches if main push fails
- keep release-tag.yml tag-push-only now that the tag push uses a real automation token
- document the required RELEASE_AUTOMATION_TOKEN secret

## Validation
- inspected failed run 26928719435: main push rejected by branch protection
- deleted stray origin release/v0.1.31 branch left by the failed run
- verified no v0.1.31 tag exists
- verified RELEASE_AUTOMATION_TOKEN, RELEASE_TAG_GPG_PRIVATE_KEY, and RELEASE_TAG_GPG_PUBLIC_KEY secrets exist
- cargo fmt --manifest-path xtask/Cargo.toml --check && cargo check --manifest-path xtask/Cargo.toml