### PR TITLE
Add Fini setup skill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect App Changes
+    runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Detect changed app inputs
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            app:
+              - '.github/workflows/ci.yml'
+              - 'Dockerfile'
+              - 'Makefile'
+              - 'com.fini.app.yml'
+              - 'index.html'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig*.json'
+              - 'vite.config.ts'
+              - 'scripts/**'
+              - 'specs/**'
+              - 'src/**'
+              - 'src-tauri/**'
+              - 'xtask/**'
+
   snyk:
     name: Snyk Vulnerability Scan
     runs-on: ubuntu-latest
@@ -38,6 +68,8 @@ jobs:
 
   fe-unit-tests:
     name: FE Unit Tests
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -48,6 +80,8 @@ jobs:
 
   be-unit-tests:
     name: BE Unit Tests
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -85,6 +119,8 @@ jobs:
 
   be-compile:
     name: BE Compile
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -122,6 +158,8 @@ jobs:
 
   e2e-ci:
     name: E2E Tests
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -171,6 +209,8 @@ jobs:
 
   android-emulator-e2e:
     name: Android Emulator E2E
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/skills/fini-install/SKILL.md
+++ b/skills/fini-install/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: fini-install
+description: "Install or upgrade Fini for agent CLI use by selecting the correct GitHub release CLI executable for the current platform."
+---
+
+# Fini Install
+
+Use when the user asks to install, update, repair, or make Fini available in a terminal for agent use.
+
+This skill installs the CLI entrypoint needed by the public `fini` skill. After installation succeeds, use `fini` for quest, space, reminder, and Focus operations.
+
+## Outcome
+
+Make a working `fini` command available:
+
+- choose the correct release asset for the current OS and architecture
+- download the CLI executable package, not only the GUI installer
+- verify the executable runs with `fini --help`
+- leave the user with the exact installed path and version evidence
+
+## Asset Selection
+
+Use the latest stable GitHub release unless the user asks for a specific version.
+
+Repository:
+
+```text
+https://github.com/VRuzhentsov/fini
+```
+
+Prefer CLI assets for agent use:
+
+- Linux x64: `fini-v<VERSION>-linux-x64-cli.tar.gz`
+- Linux arm64: `fini-v<VERSION>-linux-arm64-cli.tar.gz`
+- Windows x64: `fini-v<VERSION>-windows-x64-cli.zip`
+- Windows arm64: `fini-v<VERSION>-windows-arm64-cli.zip`
+
+The Linux CLI archives contain an executable named `fini`.
+The Windows CLI archives contain `fini.exe`.
+
+Use GUI/package assets only when the user explicitly asks for the desktop app installer:
+
+- Linux: `.AppImage`, `.deb`, or `.rpm`
+- Windows: `setup.exe`
+- Android: `.apk` or `.aab`
+
+## Platform Detection
+
+Detect platform before download:
+
+```bash
+uname -s
+uname -m
+```
+
+Map architecture names:
+
+- `x86_64` or `amd64` -> `x64`
+- `aarch64` or `arm64` -> `arm64`
+
+If the platform has no matching CLI release asset, stop and say which platform was detected and which assets are available.
+
+## Install Workflow
+
+1. Check whether `fini` already exists:
+
+   ```bash
+   command -v fini
+   fini --help
+   ```
+
+2. Resolve the release version:
+
+   - use the user-requested `vX.Y.Z`, or
+   - query the latest stable GitHub release
+
+3. Download the matching CLI asset and its `.sig` when available.
+4. Extract the archive into a temporary directory.
+5. Verify the extracted executable:
+
+   ```bash
+   ./fini --help
+   ```
+
+6. Install it to a directory already on `PATH`, or to `~/.local/bin` when that is acceptable for the user environment.
+7. Ensure the installed binary is executable on Unix-like systems:
+
+   ```bash
+   chmod 0755 <installed-fini-path>
+   ```
+
+8. Verify the final command:
+
+   ```bash
+   command -v fini
+   fini --help
+   ```
+
+Do not run quest, space, reminder, or Focus commands until installation verification succeeds.
+
+## Download Commands
+
+When GitHub CLI is available, prefer:
+
+```bash
+gh release download <VERSION> --repo VRuzhentsov/fini --pattern '<ASSET_NAME>' --pattern '<ASSET_NAME>.sig' --dir <DOWNLOAD_DIR>
+```
+
+When GitHub CLI is unavailable, use the release download URL:
+
+```text
+https://github.com/VRuzhentsov/fini/releases/download/<VERSION>/<ASSET_NAME>
+```
+
+Always download into a temporary working directory first. Do not extract archives directly into the final install directory.
+
+## Safety
+
+- Do not overwrite an existing `fini` binary until the replacement executable has passed `--help`.
+- If replacing an existing binary, keep a rollback copy unless the user asks for a clean reinstall.
+- Do not install GUI packages when the user only needs CLI agent access.
+- Do not assume package-manager availability; release assets are the source of truth.
+- Do not write machine-specific absolute paths into project files or reusable instructions.
+
+## Handoff
+
+Report:
+
+- selected release version and asset name
+- installed command path
+- verification command and result
+- whether a previous binary was replaced or left untouched

--- a/skills/fini-setup/SKILL.md
+++ b/skills/fini-setup/SKILL.md
@@ -35,7 +35,7 @@ Let the current system decide the exact detection method: `uname`, PowerShell, e
 3. Open the latest release/API above, or the user-requested release.
 4. Select the matching standalone CLI asset and download URL.
 5. Download into `/var/tmp` or the platform's normal temporary directory.
-6. If a matching `.sig` is present, verify it when a verifier is available.
+6. Do not treat `.sig` as verified unless the release also provides public verification material or instructions.
 7. Extract the archive and locate the actual executable path.
 8. Smoke-test the extracted executable with `--help`.
 9. Install to a location on `PATH`, or ask if multiple locations are plausible.

--- a/skills/fini-setup/SKILL.md
+++ b/skills/fini-setup/SKILL.md
@@ -1,132 +1,50 @@
 ---
 name: fini-setup
-description: "Install or upgrade Fini for agent CLI use by selecting the correct GitHub release CLI executable for the current platform."
+description: "Install or upgrade Fini CLI from the matching GitHub release executable archive."
 ---
 
 # Fini Setup
 
-Use when the user asks to install, update, repair, or make Fini available in a terminal for agent use.
+Use when `fini` is missing, broken, outdated, or needed for agent terminal use.
 
-This skill installs the CLI entrypoint needed by the public `fini` skill. After installation succeeds, use `fini` for quest, space, reminder, and Focus operations.
-
-## Outcome
+## Goal
 
 Make a working `fini` command available:
 
 - choose the correct release asset for the current OS and architecture
-- download the CLI executable package, not only the GUI installer
-- verify the executable runs with `fini --help`
-- leave the user with the exact installed path and version evidence
+- download the standalone CLI package, not a GUI installer
+- verify the executable with `fini --help`
+- report version, install path, and replacement status
 
-## Asset Selection
+## Assets
 
-Use the latest stable GitHub release unless the user asks for a specific version.
+Use the requested `vX.Y.Z`, or the latest stable release from `VRuzhentsov/fini`.
 
-Repository:
-
-```text
-https://github.com/VRuzhentsov/fini
-```
-
-Prefer CLI assets for agent use:
+CLI asset patterns:
 
 - Linux x64: `fini-v<VERSION>-linux-x64-cli.tar.gz`
 - Linux arm64: `fini-v<VERSION>-linux-arm64-cli.tar.gz`
 - Windows x64: `fini-v<VERSION>-windows-x64-cli.zip`
 - Windows arm64: `fini-v<VERSION>-windows-arm64-cli.zip`
 
-The Linux CLI archives contain an executable named `fini`.
-The Windows CLI archives contain `fini.exe`.
+Map `x86_64`/`amd64` to `x64`; map `aarch64`/`arm64` to `arm64`.
+Linux archives contain `fini`; Windows archives contain `fini.exe`.
+Use GUI/package assets only when the user explicitly asks for the desktop app.
 
-Use GUI/package assets only when the user explicitly asks for the desktop app installer:
+## Workflow
 
-- Linux: `.AppImage`, `.deb`, or `.rpm`
-- Windows: `setup.exe`
-- Android: `.apk` or `.aab`
-
-## Platform Detection
-
-Detect platform before download:
-
-```bash
-uname -s
-uname -m
-```
-
-Map architecture names:
-
-- `x86_64` or `amd64` -> `x64`
-- `aarch64` or `arm64` -> `arm64`
-
-If the platform has no matching CLI release asset, stop and say which platform was detected and which assets are available.
-
-## Install Workflow
-
-1. Check whether `fini` already exists:
-
-   ```bash
-   command -v fini
-   fini --help
-   ```
-
-2. Resolve the release version:
-
-   - use the user-requested `vX.Y.Z`, or
-   - query the latest stable GitHub release
-
-3. Download the matching CLI asset and its `.sig` when available.
-4. Extract the archive into a temporary directory.
-5. Verify the extracted executable:
-
-   ```bash
-   ./fini --help
-   ```
-
-6. Install it to a directory already on `PATH`, or to `~/.local/bin` when that is acceptable for the user environment.
-7. Ensure the installed binary is executable on Unix-like systems:
-
-   ```bash
-   chmod 0755 <installed-fini-path>
-   ```
-
-8. Verify the final command:
-
-   ```bash
-   command -v fini
-   fini --help
-   ```
-
-Do not run quest, space, reminder, or Focus commands until installation verification succeeds.
-
-## Download Commands
-
-When GitHub CLI is available, prefer:
-
-```bash
-gh release download <VERSION> --repo VRuzhentsov/fini --pattern '<ASSET_NAME>' --pattern '<ASSET_NAME>.sig' --dir <DOWNLOAD_DIR>
-```
-
-When GitHub CLI is unavailable, use the release download URL:
-
-```text
-https://github.com/VRuzhentsov/fini/releases/download/<VERSION>/<ASSET_NAME>
-```
-
-Always download into a temporary working directory first. Do not extract archives directly into the final install directory.
+1. Check existing binary: `command -v fini` and `fini --help`.
+2. Detect platform with `uname -s` and `uname -m`.
+3. Resolve the release version and matching CLI asset.
+4. Download with `gh release download --repo VRuzhentsov/fini` or the release asset URL.
+5. Extract under `/var/tmp`; never extract directly into the install directory.
+6. Verify the extracted binary with `--help`.
+7. Install to a directory already on `PATH`, or `~/.local/bin` when acceptable.
+8. On Unix, set executable mode with `chmod 0755 <installed-fini-path>`.
+9. Verify final state with `command -v fini` and `fini --help`.
 
 ## Safety
 
-- Do not overwrite an existing `fini` binary until the replacement executable has passed `--help`.
-- If replacing an existing binary, keep a rollback copy unless the user asks for a clean reinstall.
-- Do not install GUI packages when the user only needs CLI agent access.
-- Do not assume package-manager availability; release assets are the source of truth.
-- Do not write machine-specific absolute paths into project files or reusable instructions.
-
-## Handoff
-
-Report:
-
-- selected release version and asset name
-- installed command path
-- verification command and result
-- whether a previous binary was replaced or left untouched
+- Stop if no matching CLI asset exists; say which platform was detected.
+- Do not overwrite an existing binary until the replacement passes `--help`.
+- Do not run quest, space, reminder, or Focus commands until setup succeeds.

--- a/skills/fini-setup/SKILL.md
+++ b/skills/fini-setup/SKILL.md
@@ -1,50 +1,49 @@
 ---
 name: fini-setup
-description: "Install or upgrade Fini CLI from the matching GitHub release executable archive."
+description: "Install or upgrade Fini CLI from the latest GitHub release assets."
 ---
 
 # Fini Setup
 
 Use when `fini` is missing, broken, outdated, or needed for agent terminal use.
 
-## Goal
+## Release Sources
 
-Make a working `fini` command available:
+Use these before doing a general web search:
 
-- choose the correct release asset for the current OS and architecture
-- download the standalone CLI package, not a GUI installer
-- verify the executable with `fini --help`
-- report version, install path, and replacement status
+- Latest release page: `https://github.com/VRuzhentsov/fini/releases/latest`
+- Latest release API: `https://api.github.com/repos/VRuzhentsov/fini/releases/latest`
 
-## Assets
+For a requested version, use the matching release page instead of latest.
 
-Use the requested `vX.Y.Z`, or the latest stable release from `VRuzhentsov/fini`.
+## Selection
 
-CLI asset patterns:
+Choose a standalone CLI asset from the release assets for the current system.
+The asset should match OS and CPU architecture and should be a CLI archive, not a GUI installer.
 
-- Linux x64: `fini-v<VERSION>-linux-x64-cli.tar.gz`
-- Linux arm64: `fini-v<VERSION>-linux-arm64-cli.tar.gz`
-- Windows x64: `fini-v<VERSION>-windows-x64-cli.zip`
-- Windows arm64: `fini-v<VERSION>-windows-arm64-cli.zip`
+Common release families:
 
-Map `x86_64`/`amd64` to `x64`; map `aarch64`/`arm64` to `arm64`.
-Linux archives contain `fini`; Windows archives contain `fini.exe`.
-Use GUI/package assets only when the user explicitly asks for the desktop app.
+- Linux CLI archives contain `fini`
+- Windows CLI archives contain `fini.exe`
+
+Let the current system decide the exact detection method: `uname`, PowerShell, environment variables, package metadata, or another reliable local signal.
 
 ## Workflow
 
-1. Check existing binary: `command -v fini` and `fini --help`.
-2. Detect platform with `uname -s` and `uname -m`.
-3. Resolve the release version and matching CLI asset.
-4. Download with `gh release download --repo VRuzhentsov/fini` or the release asset URL.
-5. Extract under `/var/tmp`; never extract directly into the install directory.
-6. Verify the extracted binary with `--help`.
-7. Install to a directory already on `PATH`, or `~/.local/bin` when acceptable.
-8. On Unix, set executable mode with `chmod 0755 <installed-fini-path>`.
-9. Verify final state with `command -v fini` and `fini --help`.
+1. Check whether `fini` already works: `command -v fini` and `fini --help`.
+2. Resolve the target OS and architecture from the current environment.
+3. Open the latest release/API above, or the user-requested release.
+4. Select the matching standalone CLI asset and download URL.
+5. Download into `/var/tmp` or the platform's normal temporary directory.
+6. If a matching `.sig` is present, verify it when a verifier is available.
+7. Extract the archive and locate the actual executable path.
+8. Smoke-test the extracted executable with `--help`.
+9. Install to a location on `PATH`, or ask if multiple locations are plausible.
+10. Verify the final `fini --help` command.
 
 ## Safety
 
 - Stop if no matching CLI asset exists; say which platform was detected.
 - Do not overwrite an existing binary until the replacement passes `--help`.
 - Do not run quest, space, reminder, or Focus commands until setup succeeds.
+- Report the release, asset, install path, and verification result.

--- a/skills/fini-setup/SKILL.md
+++ b/skills/fini-setup/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: fini-install
+name: fini-setup
 description: "Install or upgrade Fini for agent CLI use by selecting the correct GitHub release CLI executable for the current platform."
 ---
 
-# Fini Install
+# Fini Setup
 
 Use when the user asks to install, update, repair, or make Fini available in a terminal for agent use.
 

--- a/skills/fini/SKILL.md
+++ b/skills/fini/SKILL.md
@@ -7,6 +7,16 @@ description: "TRIGGER when user asks to create, update, list, or manage quests, 
 
 You manage quests, spaces, reminders, and Focus state in the Fini app through the `fini` binary.
 
+## Binary Preflight
+
+At the start of every `fini` skill run, verify the global CLI command exists:
+
+```bash
+command -v fini
+```
+
+If `fini` is missing, broken, or not globally available, use `fini-setup` first. Do not run quest, space, reminder, or Focus commands until the installed binary passes `fini --help`.
+
 ## Shared CLI Foundation
 
 Use `fini-cli` for shared mechanics before any operation:


### PR DESCRIPTION
## Outcome

- Add setup guidance for selecting the correct standalone Fini CLI release artifact.
- Cover download, verification, and safe installation of the selected executable.
- Route a missing or unusable global `fini` command through the setup guidance.

## Why

Contributors need a repeatable way to install the published CLI artifact before using repository automation guidance.

## Verification

- Reviewed the setup flow against the repository’s published release asset naming and CLI entrypoint.

## Review focus

- Confirm the guidance selects the correct operating-system and architecture artifact.
- Confirm verification happens before the installed executable is replaced.

## Follow-up

None.
