### PR TITLE
Fix Linux AppImage GUI launch packaging

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -196,7 +196,29 @@ jobs:
         run: npm ci
 
       - name: Build Linux bundles
-        run: npm run tauri build -- --features ui-plane,cli-plane --target ${{ matrix.rust_target }} --bundles appimage,deb,rpm
+        run: npm run tauri build -- --features ui-plane --target ${{ matrix.rust_target }} --bundles appimage,deb,rpm -- --bin fini-app
+
+      - name: Verify Linux desktop binary
+        run: |
+          set -euo pipefail
+          desktop_binary="src-tauri/target/${{ matrix.rust_target }}/release/fini-app"
+          symbols_file="/var/tmp/fini-app-${{ matrix.arch }}-symbols.txt"
+
+          if [ ! -f "$desktop_binary" ]; then
+            echo "Expected Linux desktop binary was not produced: $desktop_binary" >&2
+            exit 1
+          fi
+
+          nm -C "$desktop_binary" > "$symbols_file"
+          if ! grep -Eq '(^|[[:space:]])fini_lib::run$' "$symbols_file"; then
+            echo "Linux desktop binary is missing the GUI entrypoint fini_lib::run" >&2
+            exit 1
+          fi
+
+          if grep -Fq 'fini_lib::run_cli' "$symbols_file" || grep -Fq 'fini_lib::services::cli::run' "$symbols_file"; then
+            echo "Linux desktop binary contains CLI symbols and may launch the CLI instead of the GUI" >&2
+            exit 1
+          fi
 
       - name: Build Linux CLI
         run: cargo build --manifest-path src-tauri/Cargo.toml --locked --release --bin fini --features cli-plane --target ${{ matrix.rust_target }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -299,7 +299,29 @@ jobs:
         run: npm ci
 
       - name: Build Linux bundles
-        run: npm run tauri build -- --features ui-plane,cli-plane --target ${{ matrix.rust_target }} --bundles appimage,deb,rpm
+        run: npm run tauri build -- --features ui-plane --target ${{ matrix.rust_target }} --bundles appimage,deb,rpm -- --bin fini-app
+
+      - name: Verify Linux desktop binary
+        run: |
+          set -euo pipefail
+          desktop_binary="src-tauri/target/${{ matrix.rust_target }}/release/fini-app"
+          symbols_file="/var/tmp/fini-app-${{ matrix.arch }}-symbols.txt"
+
+          if [ ! -f "$desktop_binary" ]; then
+            echo "Expected Linux desktop binary was not produced: $desktop_binary" >&2
+            exit 1
+          fi
+
+          nm -C "$desktop_binary" > "$symbols_file"
+          if ! grep -Eq '(^|[[:space:]])fini_lib::run$' "$symbols_file"; then
+            echo "Linux desktop binary is missing the GUI entrypoint fini_lib::run" >&2
+            exit 1
+          fi
+
+          if grep -Fq 'fini_lib::run_cli' "$symbols_file" || grep -Fq 'fini_lib::services::cli::run' "$symbols_file"; then
+            echo "Linux desktop binary contains CLI symbols and may launch the CLI instead of the GUI" >&2
+            exit 1
+          fi
 
       - name: Build Linux CLI
         run: cargo build --manifest-path src-tauri/Cargo.toml --locked --release --bin fini --features cli-plane --target ${{ matrix.rust_target }}


### PR DESCRIPTION
## Outcome

- Build Linux desktop bundles with the GUI-only `fini-app` binary.
- Keep the standalone Linux CLI as a separate `fini` artifact.
- Add release checks that verify the GUI binary contains the app entrypoint and excludes CLI entrypoints.

## Why

Fixes #50. Linux desktop packages must launch the GUI rather than the standalone command-line interface.

## Verification

- `cargo build --manifest-path src-tauri/Cargo.toml --locked --release --bin fini-app --features ui-plane` passed.
- Symbol inspection found `fini_lib::run` and no CLI entrypoints in `fini-app`.
- `cargo build --manifest-path src-tauri/Cargo.toml --locked --release --bin fini --features cli-plane` passed.
- The Tauri no-bundle build for `fini-app` passed.
- `git diff --check` passed.

## Review focus

- Confirm packaged desktop artifacts select `fini-app` and standalone CLI artifacts select `fini`.
- Confirm release symbol checks fail when the entrypoints are mixed.

## Follow-up

- Full local AppImage extraction was not completed; release CI provides the desktop integration dependency required by the bundler.

Fixes #50
