### PR TITLE
Guard database schema compatibility

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,7 +7,7 @@ mod services;
 #[cfg(feature = "ui-plane")]
 use services::backup::{backup_apply_import, backup_export, backup_preflight_import};
 #[cfg(feature = "ui-plane")]
-use services::db::{app_data_dir, open_db, AppDbConnection};
+use services::db::{app_data_dir, try_open_db, AppDbConnection};
 #[cfg(feature = "ui-plane")]
 use services::device_connection::{
     device_connection_consume_space_mapping_updates, device_connection_debug_status,
@@ -157,7 +157,7 @@ pub fn run() {
         .setup(|app| {
             let app_handle = app.handle();
 
-            let conn = open_db(&app_handle);
+            let conn = try_open_db(&app_handle).map_err(std::io::Error::other)?;
             app.manage(AppDbConnection(std::sync::Mutex::new(conn)));
             app.manage(SchedulerState::new());
             #[cfg(feature = "devtools")]
@@ -190,7 +190,7 @@ pub fn run() {
             resume_watcher::spawn(&app_handle);
 
             let data_dir = app_data_dir(&app_handle);
-            let dc_state = DeviceConnectionState::new(&data_dir);
+            let dc_state = DeviceConnectionState::from_app_data_dir(&data_dir);
             tauri::async_runtime::spawn(run_ws_server(dc_state.clone(), dc_state.db_path.clone()));
             app.manage(dc_state);
             Ok(())

--- a/src-tauri/src/services/cli.rs
+++ b/src-tauri/src/services/cli.rs
@@ -455,16 +455,21 @@ impl CliContext {
             .parent()
             .map(std::path::Path::to_path_buf)
             .unwrap_or_else(|| std::path::PathBuf::from("."));
-        let device_state = DeviceConnectionState::new_with_db_path(&app_data_dir, db_path.clone());
+        let device_state = DeviceConnectionState::try_from_db_path(&app_data_dir, db_path.clone())
+            .map_err(CliError::runtime)?;
         Ok(Self {
             db_path,
             device_state,
         })
     }
+
+    fn open_db(&self) -> CliResult<SqliteConnection> {
+        open_cli_db_at_path(&self.db_path)
+    }
 }
 
-fn open_cli_db(ctx: &CliContext) -> CliResult<SqliteConnection> {
-    try_open_db_at_path(&ctx.db_path).map_err(CliError::runtime)
+fn open_cli_db_at_path(path: &std::path::Path) -> CliResult<SqliteConnection> {
+    try_open_db_at_path(path).map_err(CliError::runtime)
 }
 
 pub fn run(args: Vec<String>) -> i32 {
@@ -543,7 +548,7 @@ fn emit_series_sync(
 }
 
 fn handle_focus(ctx: &CliContext, command: FocusCommand) -> CliResult<Value> {
-    let mut conn = open_cli_db(ctx)?;
+    let mut conn = ctx.open_db()?;
     match command {
         FocusCommand::Get => {
             let quest = resolve_active_quest(&mut conn)
@@ -588,7 +593,7 @@ fn handle_focus(ctx: &CliContext, command: FocusCommand) -> CliResult<Value> {
 }
 
 fn handle_quest(ctx: &CliContext, command: QuestCommand) -> CliResult<Value> {
-    let mut conn = open_cli_db(ctx)?;
+    let mut conn = ctx.open_db()?;
     match command {
         QuestCommand::List(args) => {
             let status = args.status.unwrap_or_else(|| "active".to_string());
@@ -738,7 +743,7 @@ fn sync_reminder_rows(conn: &mut diesel::sqlite::SqliteConnection, quest: &crate
 }
 
 fn handle_space(ctx: &CliContext, command: SpaceCommand) -> CliResult<Value> {
-    let mut conn = open_cli_db(ctx)?;
+    let mut conn = ctx.open_db()?;
     match command {
         SpaceCommand::List => Ok(json!({
             "spaces": SpaceRepository::new(&mut conn).list().map_err(CliError::from_string)?
@@ -780,7 +785,7 @@ fn handle_space(ctx: &CliContext, command: SpaceCommand) -> CliResult<Value> {
 }
 
 fn handle_backup(ctx: &CliContext, command: BackupCommand) -> CliResult<Value> {
-    let mut conn = open_cli_db(ctx)?;
+    let mut conn = ctx.open_db()?;
     let value = match command {
         BackupCommand::Export(args) => {
             if args.all_spaces && !args.space_id.is_empty() {
@@ -816,7 +821,7 @@ fn handle_backup(ctx: &CliContext, command: BackupCommand) -> CliResult<Value> {
 }
 
 fn handle_reminder(ctx: &CliContext, command: ReminderCommand) -> CliResult<Value> {
-    let mut conn = open_cli_db(ctx)?;
+    let mut conn = ctx.open_db()?;
     match command {
         ReminderCommand::List(args) => serde_json::to_value(
             ReminderRepository::new(&mut conn)
@@ -845,7 +850,7 @@ fn handle_reminder(ctx: &CliContext, command: ReminderCommand) -> CliResult<Valu
 }
 
 fn handle_device(ctx: &CliContext, command: DeviceCommand) -> CliResult<Value> {
-    let mut conn = open_cli_db(ctx)?;
+    let mut conn = ctx.open_db()?;
     let value = match command {
         DeviceCommand::Identity => serde_json::to_value(
             device_connection_get_identity_impl(&ctx.device_state)
@@ -988,7 +993,7 @@ fn handle_device_pair(ctx: &CliContext, command: DevicePairCommand) -> CliResult
 }
 
 fn handle_sync(ctx: &CliContext, command: SyncCommand) -> CliResult<Value> {
-    let mut conn = open_cli_db(ctx)?;
+    let mut conn = ctx.open_db()?;
     let value = match command {
         SyncCommand::Mappings { command } => match command {
             SyncMappingsCommand::List(args) => serde_json::to_value(
@@ -1071,7 +1076,7 @@ fn parse_space_resolution_mode(value: &str) -> CliResult<SpaceResolutionMode> {
 }
 
 fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> CliResult<Value> {
-    let mut conn = open_cli_db(ctx)?;
+    let mut conn = ctx.open_db()?;
     let value = match command {
         SettingsCommand::ThemeGet => {
             let mode = settings::theme_mode(&mut conn).map_err(CliError::from_string)?;
@@ -1157,4 +1162,68 @@ fn print_output(value: &Value, json: bool) -> Result<(), String> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::db::temp_db_path;
+    use std::path::Path;
+
+    fn seed_unknown_schema_migration_db(db_path: &Path) {
+        let mut conn = SqliteConnection::establish(db_path.to_str().expect("valid temp db path"))
+            .expect("open db path");
+
+        diesel::sql_query(
+            "CREATE TABLE IF NOT EXISTS __diesel_schema_migrations (
+                version VARCHAR(50) PRIMARY KEY NOT NULL,
+                run_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )",
+        )
+        .execute(&mut conn)
+        .expect("create migrations metadata table");
+        diesel::sql_query(
+            "INSERT INTO __diesel_schema_migrations (version) VALUES ('99999999999999')",
+        )
+        .execute(&mut conn)
+        .expect("seed unknown future migration version");
+    }
+
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn cli_execute_rejects_unknown_schema_migration_before_device_state_creation() {
+        let _guard = ENV_LOCK.lock().expect("lock env");
+        let db_path = temp_db_path("cli-db-open-rejects-unknown-schema-migration");
+        seed_unknown_schema_migration_db(&db_path);
+        std::env::set_var("FINI_DB_PATH", &db_path);
+
+        let result = execute(Cli {
+            json: true,
+            command: Some(Command::Space {
+                command: SpaceCommand::List,
+            }),
+        });
+        std::env::remove_var("FINI_DB_PATH");
+
+        let err = match result {
+            Ok(_) => panic!("CLI execute must reject database with unknown migration"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.code, EXIT_RUNTIME);
+        assert!(
+            err.message
+                .contains("database schema is not supported by this Fini binary"),
+            "error should explain unsupported schema, got: {}",
+            err.message
+        );
+        assert!(
+            err.message.contains("Upgrade Fini"),
+            "error should include next step, got: {}",
+            err.message
+        );
+
+        let _ = std::fs::remove_file(db_path);
+    }
 }

--- a/src-tauri/src/services/cli.rs
+++ b/src-tauri/src/services/cli.rs
@@ -1,5 +1,6 @@
 use clap::{ArgAction, Args, Parser, Subcommand};
 use diesel::prelude::*;
+use diesel::sqlite::SqliteConnection;
 use serde_json::{json, Value};
 
 use crate::models::{
@@ -7,7 +8,7 @@ use crate::models::{
 };
 use crate::schema::quests;
 use crate::services::backup;
-use crate::services::db::{db_default_path, open_db_at_path, utc_now};
+use crate::services::db::{db_default_path, try_open_db_at_path, utc_now};
 use crate::services::device_connection::types::{
     DevicePairRequestAckInput, DevicePairRequestInput,
 };
@@ -462,6 +463,10 @@ impl CliContext {
     }
 }
 
+fn open_cli_db(ctx: &CliContext) -> CliResult<SqliteConnection> {
+    try_open_db_at_path(&ctx.db_path).map_err(CliError::runtime)
+}
+
 pub fn run(args: Vec<String>) -> i32 {
     let cli = match Cli::try_parse_from(args) {
         Ok(cli) => cli,
@@ -538,7 +543,7 @@ fn emit_series_sync(
 }
 
 fn handle_focus(ctx: &CliContext, command: FocusCommand) -> CliResult<Value> {
-    let mut conn = open_db_at_path(&ctx.db_path);
+    let mut conn = open_cli_db(ctx)?;
     match command {
         FocusCommand::Get => {
             let quest = resolve_active_quest(&mut conn)
@@ -583,7 +588,7 @@ fn handle_focus(ctx: &CliContext, command: FocusCommand) -> CliResult<Value> {
 }
 
 fn handle_quest(ctx: &CliContext, command: QuestCommand) -> CliResult<Value> {
-    let mut conn = open_db_at_path(&ctx.db_path);
+    let mut conn = open_cli_db(ctx)?;
     match command {
         QuestCommand::List(args) => {
             let status = args.status.unwrap_or_else(|| "active".to_string());
@@ -733,7 +738,7 @@ fn sync_reminder_rows(conn: &mut diesel::sqlite::SqliteConnection, quest: &crate
 }
 
 fn handle_space(ctx: &CliContext, command: SpaceCommand) -> CliResult<Value> {
-    let mut conn = open_db_at_path(&ctx.db_path);
+    let mut conn = open_cli_db(ctx)?;
     match command {
         SpaceCommand::List => Ok(json!({
             "spaces": SpaceRepository::new(&mut conn).list().map_err(CliError::from_string)?
@@ -775,7 +780,7 @@ fn handle_space(ctx: &CliContext, command: SpaceCommand) -> CliResult<Value> {
 }
 
 fn handle_backup(ctx: &CliContext, command: BackupCommand) -> CliResult<Value> {
-    let mut conn = open_db_at_path(&ctx.db_path);
+    let mut conn = open_cli_db(ctx)?;
     let value = match command {
         BackupCommand::Export(args) => {
             if args.all_spaces && !args.space_id.is_empty() {
@@ -811,7 +816,7 @@ fn handle_backup(ctx: &CliContext, command: BackupCommand) -> CliResult<Value> {
 }
 
 fn handle_reminder(ctx: &CliContext, command: ReminderCommand) -> CliResult<Value> {
-    let mut conn = open_db_at_path(&ctx.db_path);
+    let mut conn = open_cli_db(ctx)?;
     match command {
         ReminderCommand::List(args) => serde_json::to_value(
             ReminderRepository::new(&mut conn)
@@ -840,7 +845,7 @@ fn handle_reminder(ctx: &CliContext, command: ReminderCommand) -> CliResult<Valu
 }
 
 fn handle_device(ctx: &CliContext, command: DeviceCommand) -> CliResult<Value> {
-    let mut conn = open_db_at_path(&ctx.db_path);
+    let mut conn = open_cli_db(ctx)?;
     let value = match command {
         DeviceCommand::Identity => serde_json::to_value(
             device_connection_get_identity_impl(&ctx.device_state)
@@ -983,7 +988,7 @@ fn handle_device_pair(ctx: &CliContext, command: DevicePairCommand) -> CliResult
 }
 
 fn handle_sync(ctx: &CliContext, command: SyncCommand) -> CliResult<Value> {
-    let mut conn = open_db_at_path(&ctx.db_path);
+    let mut conn = open_cli_db(ctx)?;
     let value = match command {
         SyncCommand::Mappings { command } => match command {
             SyncMappingsCommand::List(args) => serde_json::to_value(
@@ -1066,7 +1071,7 @@ fn parse_space_resolution_mode(value: &str) -> CliResult<SpaceResolutionMode> {
 }
 
 fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> CliResult<Value> {
-    let mut conn = open_db_at_path(&ctx.db_path);
+    let mut conn = open_cli_db(ctx)?;
     let value = match command {
         SettingsCommand::ThemeGet => {
             let mode = settings::theme_mode(&mut conn).map_err(CliError::from_string)?;

--- a/src-tauri/src/services/db.rs
+++ b/src-tauri/src/services/db.rs
@@ -1,7 +1,9 @@
+use diesel::migration::MigrationSource;
 use diesel::prelude::*;
-use diesel::sql_types::Text;
+use diesel::sqlite::Sqlite;
 use diesel::sqlite::SqliteConnection;
 use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 #[cfg(any(feature = "ui-plane", test))]
 use std::sync::Mutex;
@@ -14,12 +16,6 @@ pub const APP_DATA_DIR_NAME: &str = "fini";
 
 #[cfg(any(feature = "ui-plane", test))]
 pub struct AppDbConnection(pub Mutex<SqliteConnection>);
-
-#[derive(QueryableByName)]
-struct MigrationTableRow {
-    #[diesel(sql_type = Text)]
-    _name: String,
-}
 
 pub fn utc_now() -> String {
     chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
@@ -57,27 +53,52 @@ pub fn app_data_dir(app: &tauri::AppHandle) -> PathBuf {
 }
 
 pub fn open_db_at_path(path: &Path) -> SqliteConnection {
-    let mut conn =
-        SqliteConnection::establish(path.to_str().unwrap()).expect("failed to open database");
+    try_open_db_at_path(path).expect("failed to open compatible Fini database")
+}
+
+pub fn try_open_db_at_path(path: &Path) -> Result<SqliteConnection, String> {
+    let mut conn = SqliteConnection::establish(path.to_str().ok_or("database path is not UTF-8")?)
+        .map_err(|err| format!("failed to open database: {err}"))?;
     diesel::sql_query(
         "PRAGMA foreign_keys = ON; PRAGMA journal_mode = WAL; PRAGMA busy_timeout = 5000;",
     )
     .execute(&mut conn)
-    .expect("failed to set PRAGMAs");
-    if should_run_migrations(&mut conn) {
-        conn.run_pending_migrations(MIGRATIONS)
-            .expect("failed to run migrations");
-    }
-    conn
+    .map_err(|err| format!("failed to set database PRAGMAs: {err}"))?;
+    ensure_database_schema_is_supported(&mut conn)?;
+    conn.run_pending_migrations(MIGRATIONS)
+        .map_err(|err| format!("failed to run database migrations: {err}"))?;
+    Ok(conn)
 }
 
-fn should_run_migrations(conn: &mut SqliteConnection) -> bool {
-    diesel::sql_query(
-        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = '__diesel_schema_migrations' LIMIT 1;",
-    )
-    .load::<MigrationTableRow>(conn)
-    .map(|rows| rows.is_empty())
-    .unwrap_or(true)
+fn ensure_database_schema_is_supported(conn: &mut SqliteConnection) -> Result<(), String> {
+    let known_versions = embedded_migration_versions()?;
+    let applied_versions = conn
+        .applied_migrations()
+        .map_err(|err| format!("failed to read database migration state: {err}"))?;
+
+    if let Some(version) = applied_versions
+        .iter()
+        .map(ToString::to_string)
+        .find(|version| !known_versions.contains(version))
+    {
+        return Err(format!(
+            "database schema is newer than this Fini binary. App/CLI version: {}; unknown database migration: {version}. Upgrade Fini before opening this database.",
+            env!("CARGO_PKG_VERSION")
+        ));
+    }
+
+    Ok(())
+}
+
+fn embedded_migration_versions() -> Result<BTreeSet<String>, String> {
+    <EmbeddedMigrations as MigrationSource<Sqlite>>::migrations(&MIGRATIONS)
+        .map_err(|err| format!("failed to read embedded database migrations: {err}"))
+        .map(|migrations| {
+            migrations
+                .into_iter()
+                .map(|migration| migration.name().version().to_string())
+                .collect()
+        })
 }
 
 #[cfg(any(feature = "ui-plane", test))]
@@ -196,6 +217,49 @@ mod tests {
     }
 
     #[test]
+    fn database_with_newer_migration_is_rejected() {
+        let db_path = temp_db_path("database-with-newer-migration-is-rejected");
+
+        let mut conn = SqliteConnection::establish(db_path.to_str().expect("valid temp db path"))
+            .expect("open db path");
+
+        diesel::sql_query(
+            "CREATE TABLE IF NOT EXISTS __diesel_schema_migrations (
+                version VARCHAR(50) PRIMARY KEY NOT NULL,
+                run_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )",
+        )
+        .execute(&mut conn)
+        .expect("create migrations metadata table");
+        diesel::sql_query(
+            "INSERT INTO __diesel_schema_migrations (version) VALUES ('99999999999999')",
+        )
+        .execute(&mut conn)
+        .expect("seed unknown future migration version");
+        drop(conn);
+
+        let err = match try_open_db_at_path(&db_path) {
+            Ok(_) => panic!("newer-schema database must be rejected"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.contains("database schema is newer than this Fini binary"),
+            "error should explain newer schema, got: {err}"
+        );
+        assert!(
+            err.contains("App/CLI version:"),
+            "error should include app/CLI version, got: {err}"
+        );
+        assert!(
+            err.contains("99999999999999"),
+            "error should include unknown migration version, got: {err}"
+        );
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
     fn legacy_v2_db_migrates_to_text_ids_without_data_loss() {
         let db_path = temp_db_path("legacy-v2-db-migrates-to-text-ids");
 
@@ -242,9 +306,9 @@ mod tests {
         )
         .execute(&mut conn)
         .expect("insert legacy quest row");
+        drop(conn);
 
-        conn.run_pending_migrations(MIGRATIONS)
-            .expect("run pending migrations from legacy to latest");
+        let mut conn = open_db_at_path(&db_path);
 
         let legacy_space_id: String = spaces::table
             .filter(spaces::name.eq("Legacy Custom"))

--- a/src-tauri/src/services/db.rs
+++ b/src-tauri/src/services/db.rs
@@ -82,7 +82,7 @@ fn ensure_database_schema_is_supported(conn: &mut SqliteConnection) -> Result<()
         .find(|version| !known_versions.contains(version))
     {
         return Err(format!(
-            "database schema is newer than this Fini binary. App/CLI version: {}; unknown database migration: {version}. Upgrade Fini before opening this database.",
+            "database schema is not supported by this Fini binary. Fini version: {}; unknown database migration: {version}. Upgrade Fini before opening this database.",
             env!("CARGO_PKG_VERSION")
         ));
     }
@@ -102,19 +102,21 @@ fn embedded_migration_versions() -> Result<BTreeSet<String>, String> {
 }
 
 #[cfg(any(feature = "ui-plane", test))]
-pub fn open_db(app: &tauri::AppHandle) -> SqliteConnection {
+pub fn try_open_db(app: &tauri::AppHandle) -> Result<SqliteConnection, String> {
     if std::env::var_os("FINI_DB_PATH").is_some() {
         let db_path = db_default_path();
         if let Some(parent) = db_path.parent() {
-            std::fs::create_dir_all(parent).expect("failed to create app data dir");
+            std::fs::create_dir_all(parent)
+                .map_err(|err| format!("failed to create app data dir: {err}"))?;
         }
-        return open_db_at_path(&db_path);
+        return try_open_db_at_path(&db_path);
     }
 
     let data_dir = app_data_dir(app);
-    std::fs::create_dir_all(&data_dir).expect("failed to create app data dir");
+    std::fs::create_dir_all(&data_dir)
+        .map_err(|err| format!("failed to create app data dir: {err}"))?;
     let db_path = data_dir.join("fini.db");
-    open_db_at_path(&db_path)
+    try_open_db_at_path(&db_path)
 }
 
 #[cfg(test)]
@@ -217,8 +219,8 @@ mod tests {
     }
 
     #[test]
-    fn database_with_newer_migration_is_rejected() {
-        let db_path = temp_db_path("database-with-newer-migration-is-rejected");
+    fn database_with_unknown_migration_is_rejected() {
+        let db_path = temp_db_path("database-with-unknown-migration-is-rejected");
 
         let mut conn = SqliteConnection::establish(db_path.to_str().expect("valid temp db path"))
             .expect("open db path");
@@ -239,17 +241,17 @@ mod tests {
         drop(conn);
 
         let err = match try_open_db_at_path(&db_path) {
-            Ok(_) => panic!("newer-schema database must be rejected"),
+            Ok(_) => panic!("database with unknown migration must be rejected"),
             Err(err) => err,
         };
 
         assert!(
-            err.contains("database schema is newer than this Fini binary"),
-            "error should explain newer schema, got: {err}"
+            err.contains("database schema is not supported by this Fini binary"),
+            "error should explain unsupported schema, got: {err}"
         );
         assert!(
-            err.contains("App/CLI version:"),
-            "error should include app/CLI version, got: {err}"
+            err.contains("Fini version:"),
+            "error should include Fini version, got: {err}"
         );
         assert!(
             err.contains("99999999999999"),
@@ -260,15 +262,15 @@ mod tests {
     }
 
     #[test]
-    fn legacy_v2_db_migrates_to_text_ids_without_data_loss() {
-        let db_path = temp_db_path("legacy-v2-db-migrates-to-text-ids");
+    fn v2_numeric_id_db_migrates_to_text_ids_without_data_loss() {
+        let db_path = temp_db_path("v2-numeric-id-db-migrates-to-text-ids");
 
         let mut conn = SqliteConnection::establish(db_path.to_str().expect("valid temp db path"))
-            .expect("open legacy db path");
+            .expect("open v2 db path");
 
         diesel::sql_query("PRAGMA foreign_keys = ON")
             .execute(&mut conn)
-            .expect("enable foreign keys on legacy db");
+            .expect("enable foreign keys on v2 db");
 
         execute_sql_script(
             &mut conn,
@@ -293,72 +295,70 @@ mod tests {
                 ('00000000000002')",
         )
         .execute(&mut conn)
-        .expect("seed applied legacy migration versions");
+        .expect("seed applied v2 migration versions");
 
-        diesel::sql_query(
-            "INSERT INTO spaces (id, name, item_order) VALUES (7, 'Legacy Custom', 7)",
-        )
-        .execute(&mut conn)
-        .expect("insert legacy custom space");
+        diesel::sql_query("INSERT INTO spaces (id, name, item_order) VALUES (7, 'V2 Custom', 7)")
+            .execute(&mut conn)
+            .expect("insert v2 custom space");
         diesel::sql_query(
             "INSERT INTO quests (id, space_id, title, description, status, energy, priority, pinned, created_at, updated_at)
-             VALUES (55, 7, 'Legacy Quest', 'before migration', 'active', 'medium', 1, 0, datetime('now'), datetime('now'))",
+             VALUES (55, 7, 'V2 Quest', 'before migration', 'active', 'medium', 1, 0, datetime('now'), datetime('now'))",
         )
         .execute(&mut conn)
-        .expect("insert legacy quest row");
+        .expect("insert v2 quest row");
         drop(conn);
 
         let mut conn = open_db_at_path(&db_path);
 
-        let legacy_space_id: String = spaces::table
-            .filter(spaces::name.eq("Legacy Custom"))
+        let migrated_space_id: String = spaces::table
+            .filter(spaces::name.eq("V2 Custom"))
             .select(spaces::id)
             .first(&mut conn)
-            .expect("load migrated legacy space id");
-        assert_ne!(legacy_space_id, "1");
-        assert_ne!(legacy_space_id, "2");
-        assert_ne!(legacy_space_id, "3");
+            .expect("load migrated v2 space id");
+        assert_ne!(migrated_space_id, "1");
+        assert_ne!(migrated_space_id, "2");
+        assert_ne!(migrated_space_id, "3");
         assert!(
-            is_uuid_like(&legacy_space_id),
-            "legacy custom space id must become UUID"
+            is_uuid_like(&migrated_space_id),
+            "v2 custom space id must become UUID"
         );
 
         let migrated_rows: Vec<(String, String, Option<String>)> = quests::table
-            .filter(quests::title.eq("Legacy Quest"))
+            .filter(quests::title.eq("V2 Quest"))
             .select((quests::id, quests::space_id, quests::description))
             .load(&mut conn)
-            .expect("load migrated legacy quest");
+            .expect("load migrated v2 quest");
 
         assert_eq!(
             migrated_rows.len(),
             1,
-            "legacy quest must still exist after migration"
+            "v2 quest must still exist after migration"
         );
         let (quest_id, quest_space_id, description) = &migrated_rows[0];
-        assert!(is_uuid_like(quest_id), "legacy quest id must become UUID");
+        assert!(is_uuid_like(quest_id), "v2 quest id must become UUID");
         assert_eq!(
-            quest_space_id, &legacy_space_id,
-            "legacy quest must keep space membership"
+            quest_space_id, &migrated_space_id,
+            "v2 quest must keep space membership"
         );
         assert_eq!(
             description.as_deref(),
             Some("before migration"),
-            "legacy quest payload must be preserved"
+            "v2 quest payload must be preserved"
         );
 
         let _ = std::fs::remove_file(db_path);
     }
 
     #[test]
-    fn legacy_v2_custom_work_space_migrates_without_duplicate_work() {
-        let db_path = temp_db_path("legacy-v2-custom-work-space-migrates-without-duplicate-work");
+    fn v2_custom_work_space_migrates_without_duplicate_work() {
+        let db_path = temp_db_path("v2-custom-work-space-migrates-without-duplicate-work");
 
         let mut conn = SqliteConnection::establish(db_path.to_str().expect("valid temp db path"))
-            .expect("open legacy db path");
+            .expect("open v2 db path");
 
         diesel::sql_query("PRAGMA foreign_keys = ON")
             .execute(&mut conn)
-            .expect("enable foreign keys on legacy db");
+            .expect("enable foreign keys on v2 db");
 
         execute_sql_script(
             &mut conn,
@@ -383,20 +383,20 @@ mod tests {
                 ('00000000000002')",
         )
         .execute(&mut conn)
-        .expect("seed applied legacy migration versions");
+        .expect("seed applied v2 migration versions");
 
         diesel::sql_query("INSERT INTO spaces (id, name, item_order) VALUES (2, 'Work', 2)")
             .execute(&mut conn)
-            .expect("insert legacy custom work space");
+            .expect("insert v2 custom work space");
         diesel::sql_query(
             "INSERT INTO quests (id, space_id, title, status, energy, priority, pinned, created_at, updated_at)
-             VALUES (77, 2, 'Legacy Work Quest', 'active', 'medium', 1, 0, datetime('now'), datetime('now'))",
+             VALUES (77, 2, 'V2 Work Quest', 'active', 'medium', 1, 0, datetime('now'), datetime('now'))",
         )
         .execute(&mut conn)
-        .expect("insert quest in legacy custom work space");
+        .expect("insert quest in v2 custom work space");
 
         conn.run_pending_migrations(MIGRATIONS)
-            .expect("run pending migrations from legacy to latest");
+            .expect("run pending migrations from v2 state");
 
         let work_count = spaces::table
             .filter(spaces::name.eq("Work"))
@@ -416,13 +416,13 @@ mod tests {
         assert_eq!(family_count, 1, "migration must produce one Family space");
 
         let quest_space_id: String = quests::table
-            .filter(quests::title.eq("Legacy Work Quest"))
+            .filter(quests::title.eq("V2 Work Quest"))
             .select(quests::space_id)
             .first(&mut conn)
             .expect("load migrated work quest space id");
         assert_eq!(
             quest_space_id, "3",
-            "legacy Work-named custom space should map to built-in Work id=3"
+            "v2 Work-named custom space should map to built-in Work id=3"
         );
 
         let _ = std::fs::remove_file(db_path);

--- a/src-tauri/src/services/device_connection/mod.rs
+++ b/src-tauri/src/services/device_connection/mod.rs
@@ -33,7 +33,7 @@ pub use commands::{
     device_connection_send_pair_request_impl, device_connection_unpair_impl,
     device_connection_update_last_seen_impl,
 };
-use runtime::{load_or_create_identity, spawn_discovery_worker};
+use runtime::{spawn_discovery_worker, try_load_or_create_identity};
 use types::DiscoveryRuntime;
 pub use types::{
     CustomSpaceDescriptor, DeviceIdentity, IncomingSpaceMappingUpdate, IncomingSpaceSyncEnd,
@@ -94,12 +94,17 @@ fn env_port_list(name: &str, fallback: u16) -> Vec<u16> {
 
 impl DeviceConnectionState {
     #[cfg(any(feature = "ui-plane", test))]
-    pub fn new(app_data_dir: &Path) -> Self {
-        Self::new_with_db_path(app_data_dir, app_data_dir.join("fini.db"))
+    pub fn from_app_data_dir(app_data_dir: &Path) -> Self {
+        Self::from_db_path(app_data_dir, app_data_dir.join("fini.db"))
     }
 
-    pub fn new_with_db_path(app_data_dir: &Path, db_path: PathBuf) -> Self {
-        let identity = load_or_create_identity(app_data_dir);
+    pub fn from_db_path(app_data_dir: &Path, db_path: PathBuf) -> Self {
+        Self::try_from_db_path(app_data_dir, db_path)
+            .expect("failed to create device connection state")
+    }
+
+    pub fn try_from_db_path(app_data_dir: &Path, db_path: PathBuf) -> Result<Self, String> {
+        let identity = try_load_or_create_identity(app_data_dir, &db_path)?;
         let runtime = Arc::new(Mutex::new(DiscoveryRuntime::default()));
         let discovery_port = env_port("FINI_DISCOVERY_PORT", DISCOVERY_PORT);
         let space_sync_ws_port = env_port("FINI_SPACE_SYNC_WS_PORT", SPACE_SYNC_WS_PORT);
@@ -113,13 +118,13 @@ impl DeviceConnectionState {
             space_sync_ws_port,
         );
 
-        Self {
+        Ok(Self {
             identity,
             db_path,
             discovery_port,
             space_sync_ws_port,
             runtime,
-        }
+        })
     }
 
     pub fn take_incoming_sync_events(&self) -> Vec<SyncEventEnvelope> {

--- a/src-tauri/src/services/device_connection/runtime.rs
+++ b/src-tauri/src/services/device_connection/runtime.rs
@@ -27,17 +27,26 @@ pub(super) fn utc_now() -> String {
     Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
 }
 
+#[cfg(test)]
 pub(super) fn load_or_create_identity(app_data_dir: &Path) -> DeviceIdentity {
-    let legacy_path = app_data_dir.join("device_identity.json");
     let db_path = app_data_dir.join("fini.db");
-    let mut conn = db::open_db_at_path(&db_path);
+    try_load_or_create_identity(app_data_dir, &db_path)
+        .expect("failed to load or create device identity")
+}
+
+pub(super) fn try_load_or_create_identity(
+    app_data_dir: &Path,
+    db_path: &Path,
+) -> Result<DeviceIdentity, String> {
+    let file_identity_path = app_data_dir.join("device_identity.json");
+    let mut conn = db::try_open_db_at_path(db_path)?;
 
     let settings_device_id = settings::load_setting(&mut conn, DEVICE_ID_KEY)
         .ok()
         .flatten()
         .filter(|value| !value.trim().is_empty());
-    let legacy_device_id = || {
-        std::fs::read_to_string(&legacy_path)
+    let file_device_id = || {
+        std::fs::read_to_string(&file_identity_path)
             .ok()
             .and_then(|raw| serde_json::from_str::<DeviceIdentity>(&raw).ok())
             .map(|identity| identity.device_id)
@@ -45,7 +54,7 @@ pub(super) fn load_or_create_identity(app_data_dir: &Path) -> DeviceIdentity {
     };
 
     let device_id = settings_device_id
-        .or_else(legacy_device_id)
+        .or_else(file_device_id)
         .unwrap_or_else(|| Uuid::new_v4().to_string());
     let existing_name = settings::load_setting(&mut conn, DEVICE_NAME_KEY)
         .ok()
@@ -55,12 +64,12 @@ pub(super) fn load_or_create_identity(app_data_dir: &Path) -> DeviceIdentity {
 
     let _ = settings::upsert_setting(&mut conn, DEVICE_ID_KEY, &device_id);
     let _ = settings::upsert_setting(&mut conn, DEVICE_NAME_KEY, &hostname);
-    let _ = std::fs::remove_file(legacy_path);
+    let _ = std::fs::remove_file(file_identity_path);
 
-    DeviceIdentity {
+    Ok(DeviceIdentity {
         device_id,
         hostname,
-    }
+    })
 }
 
 fn current_device_name(device_id: &str, existing_name: Option<&str>) -> String {
@@ -890,19 +899,20 @@ mod tests {
     }
 
     #[test]
-    fn load_or_create_identity_imports_legacy_id_and_deletes_file() {
+    fn load_or_create_identity_imports_file_id_and_deletes_file() {
         let dir = unique_temp_dir("identity-import");
-        let legacy = DeviceIdentity {
+        let file_identity = DeviceIdentity {
             device_id: "existing-device-id".to_string(),
-            hostname: "legacy-host".to_string(),
+            hostname: "file-host".to_string(),
         };
 
-        let payload = serde_json::to_string_pretty(&legacy).expect("serialize fixture identity");
+        let payload =
+            serde_json::to_string_pretty(&file_identity).expect("serialize fixture identity");
         std::fs::write(dir.join("device_identity.json"), payload)
             .expect("failed to write fixture identity file");
 
         let loaded = load_or_create_identity(&dir);
-        assert_eq!(loaded.device_id, legacy.device_id);
+        assert_eq!(loaded.device_id, file_identity.device_id);
         assert!(!loaded.hostname.trim().is_empty());
         assert!(
             !dir.join("device_identity.json").exists(),
@@ -911,18 +921,19 @@ mod tests {
     }
 
     #[test]
-    fn load_or_create_identity_prefers_settings_over_legacy_file() {
+    fn load_or_create_identity_prefers_settings_over_file_identity() {
         let dir = unique_temp_dir("identity-settings-win");
         let mut conn = db::open_db_at_path(&dir.join("fini.db"));
         settings::upsert_setting(&mut conn, DEVICE_ID_KEY, "settings-device-id")
             .expect("seed device id setting");
         settings::upsert_setting(&mut conn, DEVICE_NAME_KEY, "settings-device-name")
             .expect("seed device name setting");
-        let legacy = DeviceIdentity {
-            device_id: "legacy-device-id".to_string(),
-            hostname: "legacy-host".to_string(),
+        let file_identity = DeviceIdentity {
+            device_id: "file-device-id".to_string(),
+            hostname: "file-host".to_string(),
         };
-        let payload = serde_json::to_string_pretty(&legacy).expect("serialize fixture identity");
+        let payload =
+            serde_json::to_string_pretty(&file_identity).expect("serialize fixture identity");
         std::fs::write(dir.join("device_identity.json"), payload)
             .expect("failed to write fixture identity file");
 

--- a/src-tauri/src/services/space_sync/commands.rs
+++ b/src-tauri/src/services/space_sync/commands.rs
@@ -1731,7 +1731,7 @@ mod tests {
             .execute(&mut conn)
             .unwrap();
 
-        let device_connection = DeviceConnectionState::new(&app_dir);
+        let device_connection = DeviceConnectionState::from_app_data_dir(&app_dir);
         let quest = test_quest("q-gated", "Blocked Until Approval", "2026-04-11T20:00:00Z");
         let event = test_envelope(
             "evt-gated",
@@ -1810,7 +1810,7 @@ mod tests {
             .execute(&mut conn)
             .unwrap();
 
-        let device_connection = DeviceConnectionState::new(&app_dir);
+        let device_connection = DeviceConnectionState::from_app_data_dir(&app_dir);
         let (tx, mut rx) = mpsc::channel(4);
         device_connection.register_session("peer-a".to_string(), tx);
 

--- a/src-tauri/src/services/space_sync/ws_server.rs
+++ b/src-tauri/src/services/space_sync/ws_server.rs
@@ -179,7 +179,7 @@ mod tests {
 
             let data_dir = db_path.with_extension("data");
             std::fs::create_dir_all(&data_dir).unwrap();
-            let state = DeviceConnectionState::new(&data_dir);
+            let state = DeviceConnectionState::from_app_data_dir(&data_dir);
             let state_clone = state.clone();
             let db_clone = db_path.clone();
 


### PR DESCRIPTION
## Summary
- run embedded Diesel pending migrations on every Fini database open, including existing databases with `__diesel_schema_migrations`
- reject databases that contain migration versions unknown to the running binary with a clear Fini-versioned compatibility error
- route CLI database opens and CLI context/device-state startup through the same fallible guard so schema incompatibility is reported as a normal CLI runtime error
- return GUI startup database-open failures through the Tauri setup error path instead of panicking before the app is managed

Closes #51.

## Verification
- `cargo test --manifest-path src-tauri/Cargo.toml --features cli-plane,ui-plane -- --nocapture`
  - 66 passed, 0 failed

## Notes
- GUI startup still uses the existing Tauri startup failure surface; the underlying error now identifies the unsupported database schema state and the running Fini version.
- CLI guard coverage is covered by `services::cli::tests::cli_execute_rejects_unknown_schema_migration_before_device_state_creation`; migration compatibility is covered by `services::db::tests::*`.
