### PR TITLE
Document Fini issue-to-PR contribution contract

### DIFF
--- a/.agents/skills/fini-daily/SKILL.md
+++ b/.agents/skills/fini-daily/SKILL.md
@@ -98,31 +98,31 @@ Use open PRs as first-class daily report inputs:
 
 ## Project Support Contract
 
-Use this skill as Fini's project-local support layer for daily triage and ticket pickup decisions. Keep the guidance Fini-facing: define what the project expects from issues, pull requests, verification, and review. Do not document private agent internals, credential handling, or host-specific trust mechanics here.
+Use this skill as Fini's project-local support layer for daily triage and ticket pickup decisions. Keep the guidance Fini-facing: define what the project expects from tickets, review artifacts, verification, and review. Do not document private agent internals, credential handling, channel routing, or host-specific trust mechanics here.
 
-Treat GitHub issues as the authoritative source for auto-starting implementation work. When daily triage recommends a `ready-to-start` issue for delegated implementation, the expected loop is:
+Treat the configured issue tracker as the authoritative source for auto-starting implementation work. The current Fini instance uses GitHub issues and pull requests, but the project contract should stay compatible with other tracker or channel adapters owned by the agent environment. When daily triage recommends a `ready-to-start` ticket for delegated implementation, the expected loop is:
 
-1. start from the issue body, labels, linked context, and current comments
-2. create or reuse an issue-numbered branch
+1. start from the ticket body, labels, linked context, and current comments
+2. create or reuse a ticket-numbered branch when the tracker has stable ticket numbers
 3. implement and verify the smallest useful slice
 4. for implementation changes, wait for the user-verification gate required by `AGENTS.md` before committing, pushing, or opening the PR
 5. for docs, specs, process guidance, or implementation work after required user verification, push the branch
-6. create or update the linked pull request as the review artifact
+6. create or update the linked review artifact, such as a pull request for a GitHub-backed project
 
-The daily recommendation should make this PR expectation explicit in the suggested assignment prompt. A delegated issue is not fully handed off when only a branch exists; it should have a PR URL, or a stated blocker explaining why the PR could not be created.
+The daily recommendation should make the review-artifact expectation explicit in the suggested assignment prompt. A delegated ticket is not fully handed off when only a branch exists; it should have a review URL, or a stated blocker explaining why the review artifact could not be created.
 
-Classify candidate issues with these readiness states:
+Classify candidate tickets with these readiness states:
 
-- `ready-to-start`: the issue has a clear goal, bounded scope, expected behavior, and a practical verification path. It may be recommended for delegated implementation when it has no exclusion label and no stronger PR should be finished first.
-- `needs-clarification`: the issue is potentially useful, but scope, product intent, expected behavior, or verification is ambiguous. Recommend one concise clarification question instead of implementation.
-- `needs-human-review`: the issue touches security, privacy, data migration, release behavior, broad architecture, user-visible product direction, or another high-risk area. Include it for visibility, but do not recommend autonomous pickup without explicit maintainer direction.
+- `ready-to-start`: the ticket has a clear goal, bounded scope, expected behavior, and a practical verification path. It may be recommended for delegated implementation when it has no exclusion label and no stronger review artifact should be finished first.
+- `needs-clarification`: the ticket is potentially useful, but scope, product intent, expected behavior, or verification is ambiguous. Recommend one concise clarification question instead of implementation.
+- `needs-human-review`: the ticket touches security, privacy, data migration, release behavior, broad architecture, user-visible product direction, or another high-risk area. Include it for visibility, but do not recommend autonomous pickup without explicit maintainer direction.
 
 Treat these Fini signals as project-specific triage inputs:
 
-- `no-auto` always excludes an issue or linked PR from autonomous pickup.
+- `no-auto` always excludes a ticket or linked review artifact from autonomous pickup.
 - Stale or near-ready PRs usually outrank starting a fresh issue.
-- Issues that lack acceptance criteria, reproduction steps for bugs, or verification expectations should be marked `needs-clarification`.
-- Tickets involving release, credentials, privacy, destructive data behavior, database migrations, or external service behavior should be marked `needs-human-review` unless the issue explicitly narrows the work to documentation or dry-run planning.
+- Tickets that lack acceptance criteria, reproduction steps for bugs, or verification expectations should be marked `needs-clarification`.
+- Tickets involving release, credentials, privacy, destructive data behavior, database migrations, or external service behavior should be marked `needs-human-review` unless the ticket explicitly narrows the work to documentation or dry-run planning.
 - Prefer a small, verifiable implementation slice over broad exploratory work.
 
 When recommending a next delegation, include the readiness state and the reason it is safe or unsafe to start. If no issue is ready, recommend the highest-value clarification or review action instead of forcing a pickup.

--- a/.agents/skills/fini-daily/SKILL.md
+++ b/.agents/skills/fini-daily/SKILL.md
@@ -96,6 +96,36 @@ Use open PRs as first-class daily report inputs:
 - Prefer recommending "finish PR #<number>" over "start issue #<number>" when the PR is close to merge, has been hanging, or just needs verification/review/fixes.
 - Draft PRs should be reported separately as in-progress, not as ready-to-finish unless the next step is clearly to undraft or complete review fixes.
 
+## Project Support Contract
+
+Use this skill as Fini's project-local support layer for daily triage and ticket pickup decisions. Keep the guidance Fini-facing: define what the project expects from issues, pull requests, verification, and review. Do not document private agent internals, credential handling, or host-specific trust mechanics here.
+
+Treat GitHub issues as the authoritative source for auto-starting implementation work. When daily triage recommends a `ready-to-start` issue for delegated implementation, the expected loop is:
+
+1. start from the issue body, labels, linked context, and current comments
+2. create or reuse an issue-numbered branch
+3. implement and verify the smallest useful slice
+4. push the branch
+5. create or update the linked pull request as the review artifact
+
+The daily recommendation should make this PR expectation explicit in the suggested assignment prompt. A delegated issue is not fully handed off when only a branch exists; it should have a PR URL, or a stated blocker explaining why the PR could not be created.
+
+Classify candidate issues with these readiness states:
+
+- `ready-to-start`: the issue has a clear goal, bounded scope, expected behavior, and a practical verification path. It may be recommended for delegated implementation when it has no exclusion label and no stronger PR should be finished first.
+- `needs-clarification`: the issue is potentially useful, but scope, product intent, expected behavior, or verification is ambiguous. Recommend one concise clarification question instead of implementation.
+- `needs-human-review`: the issue touches security, privacy, data migration, release behavior, broad architecture, user-visible product direction, or another high-risk area. Include it for visibility, but do not recommend autonomous pickup without explicit maintainer direction.
+
+Treat these Fini signals as project-specific triage inputs:
+
+- `no-auto` always excludes an issue or linked PR from autonomous pickup.
+- Stale or near-ready PRs usually outrank starting a fresh issue.
+- Issues that lack acceptance criteria, reproduction steps for bugs, or verification expectations should be marked `needs-clarification`.
+- Tickets involving release, credentials, privacy, destructive data behavior, database migrations, or external service behavior should be marked `needs-human-review` unless the issue explicitly narrows the work to documentation or dry-run planning.
+- Prefer a small, verifiable implementation slice over broad exploratory work.
+
+When recommending a next delegation, include the readiness state and the reason it is safe or unsafe to start. If no issue is ready, recommend the highest-value clarification or review action instead of forcing a pickup.
+
 ## Daily Report Format
 
 Write a concise report for the configured recipient. If `FINI_DAILY_RECIPIENT` is unset, omit the personal salutation.

--- a/.agents/skills/fini-daily/SKILL.md
+++ b/.agents/skills/fini-daily/SKILL.md
@@ -105,8 +105,9 @@ Treat GitHub issues as the authoritative source for auto-starting implementation
 1. start from the issue body, labels, linked context, and current comments
 2. create or reuse an issue-numbered branch
 3. implement and verify the smallest useful slice
-4. push the branch
-5. create or update the linked pull request as the review artifact
+4. for implementation changes, wait for the user-verification gate required by `AGENTS.md` before committing, pushing, or opening the PR
+5. for docs, specs, process guidance, or implementation work after required user verification, push the branch
+6. create or update the linked pull request as the review artifact
 
 The daily recommendation should make this PR expectation explicit in the suggested assignment prompt. A delegated issue is not fully handed off when only a branch exists; it should have a PR URL, or a stated blocker explaining why the PR could not be created.
 

--- a/.agents/skills/fini-dev-agent/SKILL.md
+++ b/.agents/skills/fini-dev-agent/SKILL.md
@@ -54,6 +54,38 @@ Start each delegated task by establishing:
 
 If the task comes from a GitHub issue, follow `fini-dev` branch guidance before editing. If the issue is ambiguous, inspect the issue body, labels, linked design/spec/wiki context, and source code before asking the user.
 
+## Issue Readiness And Review Contract
+
+Treat the GitHub issue as the authoritative work source for delegated Fini implementation. Before implementation, classify the delegated issue in Fini-facing terms:
+
+- `ready-to-start`: the issue has a clear goal, bounded scope, expected behavior, and a practical verification path.
+- `needs-clarification`: the issue is actionable only after a missing scope, product, behavior, or verification decision is answered.
+- `needs-human-review`: the issue touches security, privacy, data migration, release behavior, broad architecture, user-visible product direction, or another high-risk area that should not proceed without explicit maintainer direction.
+
+Do not expose private agent internals, credential handling, or host-specific trust mechanics in GitHub issues, pull requests, or Telegram progress. Report only the Fini-facing contract: scope, assumptions, evidence, risk, and review needs.
+
+When an issue is `needs-clarification`, ask the smallest useful question and include the recommended answer. When it is `needs-human-review`, explain the Fini project risk and stop before implementation unless the maintainer explicitly delegates the next step.
+
+When an issue is `ready-to-start` and not excluded by labels or maintainer direction, the agent loop should move from authoritative issue source to branch to pull request without waiting for a separate "create PR" prompt:
+
+1. Create or reuse an issue-numbered branch before editing.
+2. Implement the smallest verified slice described by the issue.
+3. Push the branch to the configured remote when local verification is complete.
+4. Create or update the linked pull request as the review surface for the issue.
+5. Report the PR URL, readiness state, verification evidence, and remaining risks in the issue topic or handoff.
+
+If a host or policy prevents creating a public PR automatically, stop at the pushed branch and report that the missing PR is a delivery blocker, not a completed handoff.
+
+For agent-assisted pull requests, include a review payload in the PR body or handoff:
+
+- linked issue
+- readiness state used at start
+- assumptions made
+- files or Fini areas changed
+- verification commands and outcomes
+- remaining risks
+- whether human review is required before merge
+
 ## Telegram Topic Coordination
 
 Use Fini Dev Telegram topics as coordination surfaces when the channel is available. Do not let Telegram delivery failures block local implementation; continue the work and report the delivery blocker in the final handoff.
@@ -220,7 +252,11 @@ For PR-ready work, include:
 
 - branch name
 - issue number or task source
+- readiness state used at start
+- assumptions made
 - verification commands and outcomes
+- remaining risks
+- whether human review is required before merge
 - manual checks still needed
 - whether Telegram progress delivery succeeded or failed
 

--- a/.agents/skills/fini-dev-agent/SKILL.md
+++ b/.agents/skills/fini-dev-agent/SKILL.md
@@ -56,33 +56,33 @@ If the task comes from a GitHub issue, follow `fini-dev` branch guidance before 
 
 ## Issue Readiness And Review Contract
 
-Treat the GitHub issue as the authoritative work source for delegated Fini implementation. Before implementation, classify the delegated issue in Fini-facing terms:
+Treat the configured tracker ticket as the authoritative work source for delegated Fini implementation. The current Fini instance uses GitHub issues and pull requests, but tracker providers and communication channels belong to the agent environment. Before implementation, classify the delegated ticket in Fini-facing terms:
 
-- `ready-to-start`: the issue has a clear goal, bounded scope, expected behavior, and a practical verification path.
-- `needs-clarification`: the issue is actionable only after a missing scope, product, behavior, or verification decision is answered.
-- `needs-human-review`: the issue touches security, privacy, data migration, release behavior, broad architecture, user-visible product direction, or another high-risk area that should not proceed without explicit maintainer direction.
+- `ready-to-start`: the ticket has a clear goal, bounded scope, expected behavior, and a practical verification path.
+- `needs-clarification`: the ticket is actionable only after a missing scope, product, behavior, or verification decision is answered.
+- `needs-human-review`: the ticket touches security, privacy, data migration, release behavior, broad architecture, user-visible product direction, or another high-risk area that should not proceed without explicit maintainer direction.
 
-Treat the Fini `no-auto` label as a hard exclusion from autonomous pickup. Include `no-auto` issues in reports and handoffs for visibility, but do not classify them as `ready-to-start` or begin branch, commit, push, or PR work unless the maintainer explicitly overrides that issue's exclusion for the current task.
+Treat the Fini `no-auto` label as a hard exclusion from autonomous pickup. Include `no-auto` tickets in reports and handoffs for visibility, but do not classify them as `ready-to-start` or begin branch, commit, push, or review-artifact work unless the maintainer explicitly overrides that ticket's exclusion for the current task.
 
-Do not expose private agent internals, credential handling, or host-specific trust mechanics in GitHub issues, pull requests, or Telegram progress. Report only the Fini-facing contract: scope, assumptions, evidence, risk, and review needs.
+Do not expose private agent internals, credential handling, channel routing, or host-specific trust mechanics in tracker tickets, review artifacts, or messenger progress. Report only the Fini-facing contract: scope, assumptions, evidence, risk, and review needs.
 
-When an issue is `needs-clarification`, ask the smallest useful question and include the recommended answer. When it is `needs-human-review`, explain the Fini project risk and stop before implementation unless the maintainer explicitly delegates the next step.
+When a ticket is `needs-clarification`, ask the smallest useful question and include the recommended answer. When it is `needs-human-review`, explain the Fini project risk and stop before implementation unless the maintainer explicitly delegates the next step.
 
-When an issue is `ready-to-start` and not excluded by labels or maintainer direction, the agent loop should move from authoritative issue source to branch to pull request without waiting for a separate "create PR" prompt:
+When a ticket is `ready-to-start` and not excluded by labels or maintainer direction, the agent loop should move from authoritative ticket source to branch to review artifact without waiting for a separate "create PR" prompt:
 
-1. Create or reuse an issue-numbered branch before editing.
-2. Implement the smallest verified slice described by the issue.
+1. Create or reuse a ticket-numbered branch before editing when the tracker has stable ticket numbers.
+2. Implement the smallest verified slice described by the ticket.
 3. Run the smallest useful local verification and report the evidence.
 4. For implementation changes, wait for the user-verification gate required by `AGENTS.md` before committing, pushing, or opening the PR.
 5. For docs, specs, process guidance, or implementation work after required user verification, push the branch to the configured remote.
-6. Create or update the linked pull request as the review surface for the issue.
-7. Report the PR URL, readiness state, verification evidence, and remaining risks in the issue topic or handoff.
+6. Create or update the linked review artifact, such as a pull request for a GitHub-backed project.
+7. Report the review URL, readiness state, verification evidence, and remaining risks in the configured progress channel or handoff.
 
-If a host or policy prevents creating a public PR automatically, stop at the pushed branch and report that the missing PR is a delivery blocker, not a completed handoff.
+If a host or policy prevents creating a public review artifact automatically, stop at the pushed branch and report that the missing review artifact is a delivery blocker, not a completed handoff.
 
 For agent-assisted pull requests, include a review payload in the PR body or handoff:
 
-- linked issue
+- linked ticket
 - readiness state used at start
 - assumptions made
 - files or Fini areas changed
@@ -262,7 +262,7 @@ For PR-ready work, include:
 - remaining risks
 - whether human review is required before merge
 - manual checks still needed
-- whether Telegram progress delivery succeeded or failed
+- whether configured progress delivery succeeded or failed
 
 ## Non-Goals
 

--- a/.agents/skills/fini-dev-agent/SKILL.md
+++ b/.agents/skills/fini-dev-agent/SKILL.md
@@ -70,9 +70,11 @@ When an issue is `ready-to-start` and not excluded by labels or maintainer direc
 
 1. Create or reuse an issue-numbered branch before editing.
 2. Implement the smallest verified slice described by the issue.
-3. Push the branch to the configured remote when local verification is complete.
-4. Create or update the linked pull request as the review surface for the issue.
-5. Report the PR URL, readiness state, verification evidence, and remaining risks in the issue topic or handoff.
+3. Run the smallest useful local verification and report the evidence.
+4. For implementation changes, wait for the user-verification gate required by `AGENTS.md` before committing, pushing, or opening the PR.
+5. For docs, specs, process guidance, or implementation work after required user verification, push the branch to the configured remote.
+6. Create or update the linked pull request as the review surface for the issue.
+7. Report the PR URL, readiness state, verification evidence, and remaining risks in the issue topic or handoff.
 
 If a host or policy prevents creating a public PR automatically, stop at the pushed branch and report that the missing PR is a delivery blocker, not a completed handoff.
 

--- a/.agents/skills/fini-dev-agent/SKILL.md
+++ b/.agents/skills/fini-dev-agent/SKILL.md
@@ -62,6 +62,8 @@ Treat the GitHub issue as the authoritative work source for delegated Fini imple
 - `needs-clarification`: the issue is actionable only after a missing scope, product, behavior, or verification decision is answered.
 - `needs-human-review`: the issue touches security, privacy, data migration, release behavior, broad architecture, user-visible product direction, or another high-risk area that should not proceed without explicit maintainer direction.
 
+Treat the Fini `no-auto` label as a hard exclusion from autonomous pickup. Include `no-auto` issues in reports and handoffs for visibility, but do not classify them as `ready-to-start` or begin branch, commit, push, or PR work unless the maintainer explicitly overrides that issue's exclusion for the current task.
+
 Do not expose private agent internals, credential handling, or host-specific trust mechanics in GitHub issues, pull requests, or Telegram progress. Report only the Fini-facing contract: scope, assumptions, evidence, risk, and review needs.
 
 When an issue is `needs-clarification`, ask the smallest useful question and include the recommended answer. When it is `needs-human-review`, explain the Fini project risk and stop before implementation unless the maintainer explicitly delegates the next step.


### PR DESCRIPTION
## Outcome

- Define repository-facing readiness states for issue-driven contribution work.
- Make GitHub Issues the source for scope and acceptance examples before implementation begins.
- Define pull requests as the review surface for completed changes and verification evidence.
- Include active pull requests in project triage.

## Why

Closes #63. Contributors need a clear path from an actionable issue to a reviewable pull request without relying on undocumented handoff conventions.

## Verification

- `git diff --check` passed.
- Reviewed the guidance for issue linkage, readiness, verification evidence, and human review expectations.

## Review focus

- Confirm readiness is based on issue clarity and observable acceptance examples.
- Confirm pull requests report outcomes, verification, remaining product risk, and the linked issue.

## Follow-up

- Enforcement automation remains separate from this repository-facing contract.

Closes #63
