### PR TITLE
Add channel-aware database update recovery

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -65,6 +65,43 @@ use tauri_plugin_autostart::ManagerExt;
 const THEME_EVENT: &str = "theme://changed";
 
 #[cfg(feature = "ui-plane")]
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StartupRecovery {
+    kind: &'static str,
+    title: &'static str,
+    message: String,
+}
+
+#[cfg(feature = "ui-plane")]
+struct StartupRecoveryState(std::sync::Mutex<Option<StartupRecovery>>);
+
+#[cfg(feature = "ui-plane")]
+fn unsupported_schema_startup_recovery(error: String) -> Option<StartupRecovery> {
+    if !error.contains("database schema is not supported by this Fini binary") {
+        return None;
+    }
+
+    Some(StartupRecovery {
+        kind: "update-required",
+        title: "Update required",
+        message: error,
+    })
+}
+
+#[cfg(feature = "ui-plane")]
+#[tauri::command]
+fn startup_recovery(
+    state: tauri::State<StartupRecoveryState>,
+) -> Result<Option<StartupRecovery>, String> {
+    state
+        .0
+        .lock()
+        .map(|recovery| recovery.clone())
+        .map_err(|err| format!("failed to read startup recovery state: {err}"))
+}
+
+#[cfg(feature = "ui-plane")]
 #[tauri::command]
 fn notification_action(app: AppHandle, action_id: String, reminder_id: String) {
     dispatch_action(&app, &action_id, &reminder_id);
@@ -157,8 +194,19 @@ pub fn run() {
         .setup(|app| {
             let app_handle = app.handle();
 
-            let conn = try_open_db(&app_handle).map_err(std::io::Error::other)?;
-            app.manage(AppDbConnection(std::sync::Mutex::new(conn)));
+            match try_open_db(&app_handle) {
+                Ok(conn) => {
+                    app.manage(StartupRecoveryState(std::sync::Mutex::new(None)));
+                    app.manage(AppDbConnection(std::sync::Mutex::new(conn)));
+                }
+                Err(error) => match unsupported_schema_startup_recovery(error.clone()) {
+                    Some(recovery) => {
+                        app.manage(StartupRecoveryState(std::sync::Mutex::new(Some(recovery))));
+                        return Ok(());
+                    }
+                    None => return Err(std::io::Error::other(error).into()),
+                },
+            }
             app.manage(SchedulerState::new());
             #[cfg(feature = "devtools")]
             app.manage(NotificationObserverState::new());
@@ -243,6 +291,7 @@ pub fn run() {
             get_theme_mode,
             set_theme_mode,
             sync_native_theme,
+            startup_recovery,
             notification_action,
             notification_tap,
             #[cfg(feature = "devtools")]
@@ -254,4 +303,29 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(all(test, feature = "ui-plane"))]
+mod startup_recovery_tests {
+    use super::unsupported_schema_startup_recovery;
+
+    #[test]
+    fn unsupported_schema_error_selects_update_required_recovery() {
+        let recovery = unsupported_schema_startup_recovery(
+            "database schema is not supported by this Fini binary. Update required (AppImage)."
+                .to_string(),
+        )
+        .expect("unsupported schema should route to startup recovery");
+
+        assert_eq!(recovery.kind, "update-required");
+        assert_eq!(recovery.title, "Update required");
+        assert!(recovery.message.contains("Update required (AppImage)"));
+    }
+
+    #[test]
+    fn unrelated_database_error_remains_startup_failure() {
+        assert!(
+            unsupported_schema_startup_recovery("failed to open database".to_string()).is_none()
+        );
+    }
 }

--- a/src-tauri/src/services/cli.rs
+++ b/src-tauri/src/services/cli.rs
@@ -1197,6 +1197,7 @@ mod tests {
         let db_path = temp_db_path("cli-db-open-rejects-unknown-schema-migration");
         seed_unknown_schema_migration_db(&db_path);
         std::env::set_var("FINI_DB_PATH", &db_path);
+        std::env::set_var("FINI_INSTALL_CHANNEL", "appimage");
 
         let result = execute(Cli {
             json: true,
@@ -1205,6 +1206,7 @@ mod tests {
             }),
         });
         std::env::remove_var("FINI_DB_PATH");
+        std::env::remove_var("FINI_INSTALL_CHANNEL");
 
         let err = match result {
             Ok(_) => panic!("CLI execute must reject database with unknown migration"),
@@ -1219,8 +1221,13 @@ mod tests {
             err.message
         );
         assert!(
-            err.message.contains("Upgrade Fini"),
+            err.message.contains("Update required (AppImage)"),
             "error should include next step, got: {}",
+            err.message
+        );
+        assert!(
+            err.message.contains("latest Fini AppImage"),
+            "error should include AppImage guidance, got: {}",
             err.message
         );
 

--- a/src-tauri/src/services/db.rs
+++ b/src-tauri/src/services/db.rs
@@ -8,6 +8,8 @@ use std::path::{Path, PathBuf};
 #[cfg(any(feature = "ui-plane", test))]
 use std::sync::Mutex;
 
+use crate::services::update_recovery::unsupported_schema_guidance;
+
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
 #[cfg(target_os = "android")]
 pub const APP_DATA_DIR_NAME: &str = "com.fini.app";
@@ -82,8 +84,9 @@ fn ensure_database_schema_is_supported(conn: &mut SqliteConnection) -> Result<()
         .find(|version| !known_versions.contains(version))
     {
         return Err(format!(
-            "database schema is not supported by this Fini binary. Fini version: {}; unknown database migration: {version}. Upgrade Fini before opening this database.",
-            env!("CARGO_PKG_VERSION")
+            "database schema is not supported by this Fini binary. Fini version: {}; unknown database migration: {version}. {}",
+            env!("CARGO_PKG_VERSION"),
+            unsupported_schema_guidance()
         ));
     }
 

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -13,3 +13,4 @@ pub mod reminder;
 pub mod settings;
 pub mod space;
 pub mod space_sync;
+pub mod update_recovery;

--- a/src-tauri/src/services/update_recovery.rs
+++ b/src-tauri/src/services/update_recovery.rs
@@ -1,0 +1,134 @@
+use std::path::Path;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InstallChannel {
+    AppImage,
+    Flatpak,
+    LinuxPackage,
+    DevBuild,
+    Standalone,
+    Unknown,
+}
+
+impl InstallChannel {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::AppImage => "AppImage",
+            Self::Flatpak => "Flatpak",
+            Self::LinuxPackage => "Linux package",
+            Self::DevBuild => "development build",
+            Self::Standalone => "standalone build",
+            Self::Unknown => "unknown install channel",
+        }
+    }
+}
+
+pub fn detect_install_channel() -> InstallChannel {
+    if let Some(channel) = std::env::var("FINI_INSTALL_CHANNEL")
+        .ok()
+        .and_then(|value| parse_install_channel(&value))
+    {
+        return channel;
+    }
+
+    if std::env::var_os("APPIMAGE").is_some() {
+        return InstallChannel::AppImage;
+    }
+
+    if std::env::var_os("FLATPAK_ID").is_some() {
+        return InstallChannel::Flatpak;
+    }
+
+    if cfg!(debug_assertions) {
+        return InstallChannel::DevBuild;
+    }
+
+    match std::env::current_exe() {
+        Ok(path) if looks_like_system_package_path(&path) => InstallChannel::LinuxPackage,
+        Ok(_) => InstallChannel::Standalone,
+        Err(_) => InstallChannel::Unknown,
+    }
+}
+
+pub fn unsupported_schema_guidance() -> String {
+    unsupported_schema_guidance_for(detect_install_channel())
+}
+
+pub fn unsupported_schema_guidance_for(channel: InstallChannel) -> String {
+    let next_step = match channel {
+        InstallChannel::AppImage => {
+            "Download the latest Fini AppImage, replace the current AppImage, then reopen Fini."
+        }
+        InstallChannel::Flatpak => {
+            "Run `flatpak update` for Fini, then reopen the app or rerun the command."
+        }
+        InstallChannel::LinuxPackage => {
+            "Update Fini through your system package manager, then reopen the app or rerun the command."
+        }
+        InstallChannel::DevBuild => {
+            "Rebuild or switch to a Fini binary that includes the database migration, then rerun the command."
+        }
+        InstallChannel::Standalone => {
+            "Install the latest Fini binary for this machine, then reopen the app or rerun the command."
+        }
+        InstallChannel::Unknown => {
+            "Install the latest Fini release for this machine, then reopen the app or rerun the command."
+        }
+    };
+
+    format!(
+        "Update required ({channel}). {next_step} Fini cannot continue with this database until the running binary supports its schema.",
+        channel = channel.label()
+    )
+}
+
+fn parse_install_channel(value: &str) -> Option<InstallChannel> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "appimage" => Some(InstallChannel::AppImage),
+        "flatpak" => Some(InstallChannel::Flatpak),
+        "deb" | "rpm" | "package" | "linux-package" => Some(InstallChannel::LinuxPackage),
+        "dev" | "development" | "dev-build" => Some(InstallChannel::DevBuild),
+        "standalone" => Some(InstallChannel::Standalone),
+        "unknown" => Some(InstallChannel::Unknown),
+        _ => None,
+    }
+}
+
+fn looks_like_system_package_path(path: &Path) -> bool {
+    path.starts_with("/usr/bin") || path.starts_with("/usr/local/bin") || path.starts_with("/opt")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guidance_mentions_appimage_recovery() {
+        let guidance = unsupported_schema_guidance_for(InstallChannel::AppImage);
+
+        assert!(guidance.contains("Update required (AppImage)"));
+        assert!(guidance.contains("latest Fini AppImage"));
+        assert!(guidance.contains("cannot continue"));
+    }
+
+    #[test]
+    fn install_channel_override_supports_package_aliases() {
+        assert_eq!(
+            parse_install_channel("deb"),
+            Some(InstallChannel::LinuxPackage)
+        );
+        assert_eq!(
+            parse_install_channel("rpm"),
+            Some(InstallChannel::LinuxPackage)
+        );
+        assert_eq!(
+            parse_install_channel("linux-package"),
+            Some(InstallChannel::LinuxPackage)
+        );
+    }
+
+    #[test]
+    fn invalid_install_channel_override_is_ignored() {
+        assert_eq!(parse_install_channel("sideways"), None);
+    }
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,17 +7,38 @@ import SpacePicker from "./components/SpacePicker.vue";
 import { useDeviceStore } from "./stores/device";
 import { useNotificationActions } from "./composables/useNotificationActions";
 
+type StartupRecovery = {
+  kind: string;
+  title: string;
+  message: string;
+};
+
+const props = defineProps<{
+  startupRecovery?: StartupRecovery | null;
+}>();
+
 const deviceStore = useDeviceStore();
 
 useNotificationActions();
 
 onMounted(() => {
+  if (props.startupRecovery) {
+    return;
+  }
+
   void deviceStore.hydrate();
 });
 </script>
 
 <template>
-  <div class="app-shell">
+  <main v-if="startupRecovery" class="recovery-shell">
+    <section class="recovery-panel" role="alert" aria-live="assertive">
+      <p class="recovery-kicker">Fini cannot open this database</p>
+      <h1>{{ startupRecovery.title }}</h1>
+      <p class="recovery-message">{{ startupRecovery.message }}</p>
+    </section>
+  </main>
+  <div v-else class="app-shell">
     <nav class="nav">
       <div class="nav-links">
         <router-link to="/main">Focus</router-link>
@@ -71,6 +92,42 @@ html, body, #app {
   color: var(--color-base-content);
   background-color: var(--color-page-bg);
   padding-top: env(safe-area-inset-top);
+}
+
+.recovery-shell {
+  display: grid;
+  min-height: 100vh;
+  padding: 1rem;
+  place-items: center;
+  color: var(--color-base-content);
+  background: var(--color-page-bg);
+}
+
+.recovery-panel {
+  width: min(100%, 42rem);
+  padding: 1.5rem;
+  border: 1px solid color-mix(in srgb, var(--color-error) 35%, transparent);
+  border-radius: 8px;
+  background: var(--color-base-100);
+  box-shadow: var(--shadow-sm);
+}
+
+.recovery-kicker {
+  margin: 0 0 0.5rem;
+  color: var(--color-error);
+  font-size: 0.8125rem;
+  font-weight: 700;
+}
+
+.recovery-panel h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  line-height: 1.2;
+}
+
+.recovery-message {
+  margin: 1rem 0 0;
+  white-space: pre-wrap;
 }
 
 .nav {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,11 @@ import "./style.css";
 
 type ThemeMode = "dark" | "light" | "system";
 type ThemeSource = "bootstrap" | "native" | "portal";
+type StartupRecovery = {
+  kind: string;
+  title: string;
+  message: string;
+};
 
 const themeSourceRank: Record<ThemeSource, number> = {
   bootstrap: 0,
@@ -56,9 +61,16 @@ async function applyTheme(theme: ThemeMode, source: ThemeSource) {
 }
 
 async function bootstrap() {
+  let startupRecovery: StartupRecovery | null = null;
   let theme: ThemeMode = window.matchMedia("(prefers-color-scheme: dark)").matches
     ? "dark"
     : "light";
+
+  try {
+    startupRecovery = await invoke<StartupRecovery | null>("startup_recovery");
+  } catch {
+    startupRecovery = null;
+  }
 
   try {
     const hint = await invoke<string>("theme_hint");
@@ -73,7 +85,7 @@ async function bootstrap() {
 
   await applyTheme(theme, "bootstrap");
 
-  createApp(App).use(createPinia()).use(router).use(i18n).mount("#app");
+  createApp(App, { startupRecovery }).use(createPinia()).use(router).use(i18n).mount("#app");
 
   try {
     await getCurrentWindow().onThemeChanged(({ payload }) => {


### PR DESCRIPTION
## Outcome

- Detect how Fini was installed and provide channel-specific recovery guidance when the database schema is newer than the running application supports.
- Show a blocking recovery screen for GUI startup instead of continuing with an unsupported database.
- Keep CLI failures non-interactive and actionable.

## Why

Refs #60. Users need a safe recovery path when an older application build encounters data written by a newer schema.

## Verification

- `cargo fmt` passed.
- `cargo test update_recovery --lib` passed.
- `cargo test database_with_unknown_migration_is_rejected --lib` passed.
- CLI unsupported-schema guard tests passed.
- GUI startup recovery tests passed.
- `cargo check --features ui-plane` passed.
- `npm run build` passed with a clean dependency installation.
- `git diff --check` passed.

## Review focus

- Confirm every supported install channel receives actionable guidance.
- Confirm unsupported schemas block GUI startup and fail safely in the CLI.

## Follow-up

- Automatic application update and re-execution remain outside this change.

Refs #60
