### PR TITLE
Add manual CLI update command

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -40,6 +40,8 @@ jobs:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          FINI_TAURI_UPDATER_PUBKEY: ${{ vars.FINI_TAURI_UPDATER_PUBKEY }}
         run: |
           set -euo pipefail
           required=(
@@ -48,6 +50,8 @@ jobs:
             ANDROID_KEYSTORE_PASSWORD
             ANDROID_KEY_ALIAS
             ANDROID_KEY_PASSWORD
+            TAURI_SIGNING_PRIVATE_KEY
+            FINI_TAURI_UPDATER_PUBKEY
           )
           for key in "${required[@]}"; do
             if [ -z "${!key:-}" ]; then
@@ -196,6 +200,9 @@ jobs:
         run: npm ci
 
       - name: Build Linux bundles
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm run tauri build -- --features ui-plane --target ${{ matrix.rust_target }} --bundles appimage,deb,rpm -- --bin fini-app
 
       - name: Verify Linux desktop binary
@@ -221,9 +228,14 @@ jobs:
           fi
 
       - name: Build Linux CLI
+        env:
+          FINI_TAURI_UPDATER_PUBKEY: ${{ vars.FINI_TAURI_UPDATER_PUBKEY }}
         run: cargo build --manifest-path src-tauri/Cargo.toml --locked --release --bin fini --features cli-plane --target ${{ matrix.rust_target }}
 
       - name: Collect Linux release files
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
           set -euo pipefail
           bundle_root="src-tauri/target/${{ matrix.rust_target }}/release/bundle"
@@ -265,6 +277,9 @@ jobs:
             echo "Expected Linux CLI binary was not produced: $cli_binary" >&2
             exit 1
           fi
+          raw_cli_asset="prep/linux/fini-prep-${short_sha}-linux-${{ matrix.arch }}-cli"
+          cp "$cli_binary" "$raw_cli_asset"
+          npm run tauri -- signer sign "$raw_cli_asset"
           tar -C "$(dirname "$cli_binary")" -czf "prep/linux/fini-prep-${short_sha}-linux-${{ matrix.arch }}-cli.tar.gz" fini
 
       - name: Upload Linux bundle artifact
@@ -316,9 +331,14 @@ jobs:
         run: npm ci
 
       - name: Build Windows bundles
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm run tauri build -- --features ui-plane,cli-plane --target ${{ matrix.rust_target }} --bundles nsis
 
       - name: Build Windows CLI
+        env:
+          FINI_TAURI_UPDATER_PUBKEY: ${{ vars.FINI_TAURI_UPDATER_PUBKEY }}
         run: cargo build --manifest-path src-tauri/Cargo.toml --locked --release --bin fini --features cli-plane --target ${{ matrix.rust_target }}
 
       - name: Collect Windows release files

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -117,6 +117,8 @@ jobs:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          FINI_TAURI_UPDATER_PUBKEY: ${{ vars.FINI_TAURI_UPDATER_PUBKEY }}
         run: |
           set -euo pipefail
           required=(
@@ -124,6 +126,8 @@ jobs:
             ANDROID_KEYSTORE_PASSWORD
             ANDROID_KEY_ALIAS
             ANDROID_KEY_PASSWORD
+            TAURI_SIGNING_PRIVATE_KEY
+            FINI_TAURI_UPDATER_PUBKEY
           )
           for key in "${required[@]}"; do
             if [ -z "${!key:-}" ]; then
@@ -299,6 +303,9 @@ jobs:
         run: npm ci
 
       - name: Build Linux bundles
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm run tauri build -- --features ui-plane --target ${{ matrix.rust_target }} --bundles appimage,deb,rpm -- --bin fini-app
 
       - name: Verify Linux desktop binary
@@ -324,9 +331,14 @@ jobs:
           fi
 
       - name: Build Linux CLI
+        env:
+          FINI_TAURI_UPDATER_PUBKEY: ${{ vars.FINI_TAURI_UPDATER_PUBKEY }}
         run: cargo build --manifest-path src-tauri/Cargo.toml --locked --release --bin fini --features cli-plane --target ${{ matrix.rust_target }}
 
       - name: Collect Linux release files
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
           set -euo pipefail
           bundle_root="src-tauri/target/${{ matrix.rust_target }}/release/bundle"
@@ -372,6 +384,9 @@ jobs:
             echo "Expected Linux CLI binary was not produced: $cli_binary" >&2
             exit 1
           fi
+          raw_cli_asset="release/linux/fini-${GITHUB_REF_NAME}-linux-${{ matrix.arch }}-cli"
+          cp "$cli_binary" "$raw_cli_asset"
+          npm run tauri -- signer sign "$raw_cli_asset"
           tar -C "$(dirname "$cli_binary")" -czf "release/linux/fini-${GITHUB_REF_NAME}-linux-${{ matrix.arch }}-cli.tar.gz" fini
 
       - name: Upload Linux artifact
@@ -436,9 +451,14 @@ jobs:
         run: npm ci
 
       - name: Build Windows bundles
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm run tauri build -- --features ui-plane,cli-plane --target ${{ matrix.rust_target }} --bundles nsis
 
       - name: Build Windows CLI
+        env:
+          FINI_TAURI_UPDATER_PUBKEY: ${{ vars.FINI_TAURI_UPDATER_PUBKEY }}
         run: cargo build --manifest-path src-tauri/Cargo.toml --locked --release --bin fini --features cli-plane --target ${{ matrix.rust_target }}
 
       - name: Collect Windows release files
@@ -771,6 +791,34 @@ jobs:
           path: release-assets
           merge-multiple: true
 
+      - name: Generate CLI updater manifest
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          x64_asset="fini-${GITHUB_REF_NAME}-linux-x64-cli"
+          arm64_asset="fini-${GITHUB_REF_NAME}-linux-arm64-cli"
+          for asset in "$x64_asset" "$arm64_asset"; do
+            test -f "release-assets/${asset}" || { echo "Missing CLI updater asset: ${asset}" >&2; exit 1; }
+            test -f "release-assets/${asset}.sig" || { echo "Missing CLI updater signature: ${asset}.sig" >&2; exit 1; }
+          done
+          x64_sig="$(cat "release-assets/${x64_asset}.sig")"
+          arm64_sig="$(cat "release-assets/${arm64_asset}.sig")"
+          cat > release-assets/latest-cli.json <<EOF
+          {
+            "version": "${version}",
+            "platforms": {
+              "cli-linux-x86_64": {
+                "signature": "${x64_sig}",
+                "url": "https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/${x64_asset}"
+              },
+              "cli-linux-aarch64": {
+                "signature": "${arm64_sig}",
+                "url": "https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/${arm64_asset}"
+              }
+            }
+          }
+          EOF
+
       - name: Create build provenance attestation
         uses: actions/attest-build-provenance@v2
         with:
@@ -829,6 +877,34 @@ jobs:
           pattern: release-*
           path: release-assets
           merge-multiple: true
+
+      - name: Generate CLI updater manifest
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          x64_asset="fini-${GITHUB_REF_NAME}-linux-x64-cli"
+          arm64_asset="fini-${GITHUB_REF_NAME}-linux-arm64-cli"
+          for asset in "$x64_asset" "$arm64_asset"; do
+            test -f "release-assets/${asset}" || { echo "Missing CLI updater asset: ${asset}" >&2; exit 1; }
+            test -f "release-assets/${asset}.sig" || { echo "Missing CLI updater signature: ${asset}.sig" >&2; exit 1; }
+          done
+          x64_sig="$(cat "release-assets/${x64_asset}.sig")"
+          arm64_sig="$(cat "release-assets/${arm64_asset}.sig")"
+          cat > release-assets/latest-cli.json <<EOF
+          {
+            "version": "${version}",
+            "platforms": {
+              "cli-linux-x86_64": {
+                "signature": "${x64_sig}",
+                "url": "https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/${x64_asset}"
+              },
+              "cli-linux-aarch64": {
+                "signature": "${arm64_sig}",
+                "url": "https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/${arm64_asset}"
+              }
+            }
+          }
+          EOF
 
       - name: Create build provenance attestation
         uses: actions/attest-build-provenance@v2

--- a/specs/cli/README.md
+++ b/specs/cli/README.md
@@ -34,6 +34,33 @@ GUI and CLI distribution are separate release surfaces.
 
 Desktop installers must not be required to expose the CLI on `PATH`. Users who want CLI-only automation should install the standalone CLI artifact or use the Docker runtime image.
 
+## CLI Updates
+
+`fini update` is the manual update entrypoint for the CLI plane. It must use
+Tauri's updater package for update discovery, signature verification, download,
+and installation rather than scraping GitHub releases or hand-rolling archive
+replacement.
+
+The default CLI update endpoint is the signed static manifest published with
+GitHub releases:
+
+```text
+https://github.com/VRuzhentsov/fini/releases/latest/download/latest-cli.json
+```
+
+The CLI updater uses a custom Tauri updater target named
+`cli-<platform>-<arch>`, such as `cli-linux-x86_64`, so CLI artifacts do not
+share platform keys with GUI app updater bundles. The manifest must contain a
+valid SemVer version and a Tauri updater signature for each exposed CLI target.
+The initial built-in updater manifest publishes Linux CLI targets only: Tauri's
+Windows updater install path expects a Windows installer, not a raw standalone
+`fini.exe` replacement.
+
+Release builds should embed the Tauri updater public key with
+`FINI_TAURI_UPDATER_PUBKEY`. Local and test builds may supply
+`FINI_UPDATE_PUBKEY` at runtime. `FINI_UPDATE_ENDPOINT` may override the default
+manifest endpoint for staging channels.
+
 ## Verification
 
 Use these checks when changing the binary contract:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1349,6 +1349,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,6 +1374,7 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "dirs 5.0.1",
+ "flate2",
  "futures-util",
  "gtk",
  "libsqlite3-sys",
@@ -1372,9 +1383,11 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2",
  "sherpa-onnx",
  "sherpa-onnx-sys",
  "socket2 0.6.3",
+ "tar",
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
@@ -4657,6 +4670,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6644,6 +6668,16 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1381,6 +1381,7 @@ dependencies = [
  "mdns-sd",
  "notify-rust",
  "reqwest 0.12.28",
+ "semver",
  "serde",
  "serde_json",
  "sha2",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1374,21 +1374,17 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "dirs 5.0.1",
- "flate2",
  "futures-util",
  "gtk",
  "libsqlite3-sys",
  "mdns-sd",
  "notify-rust",
  "reqwest 0.12.28",
- "semver",
  "serde",
  "serde_json",
- "sha2",
  "sherpa-onnx",
  "sherpa-onnx-sys",
  "socket2 0.6.3",
- "tar",
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
@@ -1396,12 +1392,14 @@ dependencies = [
  "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-playwright",
+ "tauri-plugin-updater",
  "time",
  "tokio",
  "tokio-tungstenite",
+ "url",
  "uuid",
  "zbus",
- "zip",
+ "zip 2.4.2",
  "zvariant",
 ]
 
@@ -2667,6 +2665,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2986,6 +2990,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3090,6 +3106,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3103,6 +3125,20 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3879,15 +3915,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3990,6 +4031,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3998,6 +4051,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4029,6 +4109,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4087,6 +4176,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -4926,6 +5038,39 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs 6.0.0",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.2",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -5902,6 +6047,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6860,6 +7014,18 @@ dependencies = [
  "memchr",
  "thiserror 2.0.18",
  "zopfli",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.13.0",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -51,9 +51,9 @@ tokio = { version = "1", features = ["full"] }
 dirs = "5"
 uuid = { version = "1", features = ["v4"] }
 clap = { version = "4", features = ["derive"], optional = true }
-flate2 = "1"
-sha2 = "0.10"
-tar = "0.4"
+flate2 = { version = "1", optional = true }
+sha2 = { version = "0.10", optional = true }
+tar = { version = "0.4", optional = true }
 tauri-plugin-notification = "2.3.3"
 tauri-plugin-autostart = "2.5.1"
 time = { version = "0.3.47", features = ["parsing", "formatting"] }
@@ -72,7 +72,7 @@ notify-rust = "4"
 [features]
 default = []
 ui-plane = []
-cli-plane = ["dep:clap"]
+cli-plane = ["dep:clap", "dep:flate2", "dep:sha2", "dep:tar"]
 # Enable developer/test control-plane hooks. Off by default; production builds
 # must not ship this because it exposes an in-process Playwright socket bridge.
 devtools = ["dep:tauri-plugin-playwright"]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -51,6 +51,9 @@ tokio = { version = "1", features = ["full"] }
 dirs = "5"
 uuid = { version = "1", features = ["v4"] }
 clap = { version = "4", features = ["derive"], optional = true }
+flate2 = "1"
+sha2 = "0.10"
+tar = "0.4"
 tauri-plugin-notification = "2.3.3"
 tauri-plugin-autostart = "2.5.1"
 time = { version = "0.3.47", features = ["parsing", "formatting"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,7 +41,6 @@ libsqlite3-sys = { version = "0.30", features = ["bundled"] }
 chrono = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-semver = { version = "1", optional = true }
 sherpa-onnx = "0.1.9"
 sherpa-onnx-sys = "0.1.9"
 cpal = "0.15"
@@ -52,9 +51,7 @@ tokio = { version = "1", features = ["full"] }
 dirs = "5"
 uuid = { version = "1", features = ["v4"] }
 clap = { version = "4", features = ["derive"], optional = true }
-flate2 = { version = "1", optional = true }
-sha2 = { version = "0.10", optional = true }
-tar = { version = "0.4", optional = true }
+tauri-plugin-updater = { version = "2.10.1", optional = true }
 tauri-plugin-notification = "2.3.3"
 tauri-plugin-autostart = "2.5.1"
 time = { version = "0.3.47", features = ["parsing", "formatting"] }
@@ -65,6 +62,7 @@ zbus = { version = "5.14.0", features = ["blocking-api"] }
 zvariant = "5.10.0"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 tauri-plugin-dialog = "2"
+url = { version = "2", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = "0.18.2"
@@ -73,7 +71,7 @@ notify-rust = "4"
 [features]
 default = []
 ui-plane = []
-cli-plane = ["dep:clap", "dep:flate2", "dep:semver", "dep:sha2", "dep:tar"]
+cli-plane = ["dep:clap", "dep:tauri-plugin-updater", "dep:url"]
 # Enable developer/test control-plane hooks. Off by default; production builds
 # must not ship this because it exposes an in-process Playwright socket bridge.
 devtools = ["dep:tauri-plugin-playwright"]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,6 +41,7 @@ libsqlite3-sys = { version = "0.30", features = ["bundled"] }
 chrono = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+semver = { version = "1", optional = true }
 sherpa-onnx = "0.1.9"
 sherpa-onnx-sys = "0.1.9"
 cpal = "0.15"
@@ -72,7 +73,7 @@ notify-rust = "4"
 [features]
 default = []
 ui-plane = []
-cli-plane = ["dep:clap", "dep:flate2", "dep:sha2", "dep:tar"]
+cli-plane = ["dep:clap", "dep:flate2", "dep:semver", "dep:sha2", "dep:tar"]
 # Enable developer/test control-plane hooks. Off by default; production builds
 # must not ship this because it exposes an in-process Playwright socket bridge.
 devtools = ["dep:tauri-plugin-playwright"]

--- a/src-tauri/src/services/cli.rs
+++ b/src-tauri/src/services/cli.rs
@@ -99,14 +99,25 @@ struct UpdateArgs {
     dry_run: bool,
     #[arg(
         long,
-        help = "Override the GitHub release repository in owner/name form"
+        help = "Override the Tauri updater endpoint; defaults to FINI_UPDATE_ENDPOINT or Fini's latest CLI manifest"
     )]
-    repo: Option<String>,
+    endpoint: Option<String>,
     #[arg(
         long,
-        help = "Override the activated CLI path; defaults to the target CLI name under ~/.local/bin"
+        help = "Override the Tauri updater public key; defaults to FINI_UPDATE_PUBKEY or the build-time key"
     )]
-    install_bin: Option<std::path::PathBuf>,
+    pubkey: Option<String>,
+    #[arg(
+        long,
+        help = "Override the Tauri updater target; defaults to cli-<platform>-<arch>"
+    )]
+    target: Option<String>,
+    #[arg(
+        long,
+        hide = true,
+        help = "Override the executable path passed to the Tauri updater"
+    )]
+    executable_path: Option<std::path::PathBuf>,
 }
 
 #[derive(Subcommand)]
@@ -517,8 +528,10 @@ fn execute(cli: Cli) -> CliResult<i32> {
     if let Some(Command::Update(args)) = cli.command {
         let value = run_update(UpdateOptions {
             dry_run: args.dry_run,
-            repo: args.repo,
-            install_bin: args.install_bin,
+            endpoint: args.endpoint,
+            pubkey: args.pubkey,
+            target: args.target,
+            executable_path: args.executable_path,
         })
         .map_err(CliError::runtime)?;
         print_output(&value, cli.json).map_err(CliError::runtime)?;

--- a/src-tauri/src/services/cli.rs
+++ b/src-tauri/src/services/cli.rs
@@ -104,7 +104,7 @@ struct UpdateArgs {
     repo: Option<String>,
     #[arg(
         long,
-        help = "Override the activated CLI path; defaults to ~/.local/bin/fini"
+        help = "Override the activated CLI path; defaults to the target CLI name under ~/.local/bin"
     )]
     install_bin: Option<std::path::PathBuf>,
 }

--- a/src-tauri/src/services/cli.rs
+++ b/src-tauri/src/services/cli.rs
@@ -8,6 +8,7 @@ use crate::models::{
 };
 use crate::schema::quests;
 use crate::services::backup;
+use crate::services::cli_update::{run_update, UpdateOptions};
 use crate::services::db::{db_default_path, try_open_db_at_path, utc_now};
 use crate::services::device_connection::types::{
     DevicePairRequestAckInput, DevicePairRequestInput,
@@ -53,6 +54,8 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
+    #[command(about = "Download and install the latest standalone Fini CLI release")]
+    Update(UpdateArgs),
     Focus {
         #[command(subcommand)]
         command: FocusCommand,
@@ -85,6 +88,25 @@ enum Command {
         #[command(subcommand)]
         command: SettingsCommand,
     },
+}
+
+#[derive(Args)]
+struct UpdateArgs {
+    #[arg(
+        long,
+        help = "Print the selected release and install paths without changing files"
+    )]
+    dry_run: bool,
+    #[arg(
+        long,
+        help = "Override the GitHub release repository in owner/name form"
+    )]
+    repo: Option<String>,
+    #[arg(
+        long,
+        help = "Override the activated CLI path; defaults to ~/.local/bin/fini"
+    )]
+    install_bin: Option<std::path::PathBuf>,
 }
 
 #[derive(Subcommand)]
@@ -492,9 +514,21 @@ pub fn run(args: Vec<String>) -> i32 {
 }
 
 fn execute(cli: Cli) -> CliResult<i32> {
+    if let Some(Command::Update(args)) = cli.command {
+        let value = run_update(UpdateOptions {
+            dry_run: args.dry_run,
+            repo: args.repo,
+            install_bin: args.install_bin,
+        })
+        .map_err(CliError::runtime)?;
+        print_output(&value, cli.json).map_err(CliError::runtime)?;
+        return Ok(EXIT_SUCCESS);
+    }
+
     let ctx = CliContext::new()?;
     let value = match cli.command {
         None => handle_focus(&ctx, FocusCommand::Get)?,
+        Some(Command::Update(_)) => unreachable!("update is handled before DB initialization"),
         Some(Command::Focus { command }) => handle_focus(&ctx, command)?,
         Some(Command::Quest { command }) => handle_quest(&ctx, command)?,
         Some(Command::Space { command }) => handle_space(&ctx, command)?,

--- a/src-tauri/src/services/cli_update.rs
+++ b/src-tauri/src/services/cli_update.rs
@@ -74,7 +74,7 @@ pub fn run_update(options: UpdateOptions) -> Result<Value, String> {
     let install_bin = options
         .install_bin
         .or_else(|| std::env::var_os("FINI_UPDATE_BIN_PATH").map(PathBuf::from))
-        .unwrap_or_else(default_install_bin);
+        .unwrap_or_else(|| default_install_bin(&target));
     let releases = list_releases(&repo)?;
     let plan = select_update_plan(
         repo,
@@ -97,22 +97,8 @@ fn list_releases(repo: &str) -> Result<Vec<GitHubRelease>, String> {
     let runtime = tokio::runtime::Runtime::new()
         .map_err(|err| format!("failed to create update runtime: {err}"))?;
     runtime.block_on(async {
-        let mut headers = HeaderMap::new();
-        headers.insert(USER_AGENT, HeaderValue::from_static("fini-cli-updater"));
-        headers.insert(
-            ACCEPT,
-            HeaderValue::from_static("application/vnd.github+json"),
-        );
-        if let Ok(token) = std::env::var("GH_TOKEN") {
-            if !token.trim().is_empty() {
-                let value = HeaderValue::from_str(&format!("Bearer {}", token.trim()))
-                    .map_err(|err| format!("invalid GH_TOKEN for GitHub API: {err}"))?;
-                headers.insert(AUTHORIZATION, value);
-            }
-        }
-
         let client = reqwest::Client::builder()
-            .default_headers(headers)
+            .default_headers(github_headers()?)
             .build()
             .map_err(|err| format!("failed to create GitHub client: {err}"))?;
         let response = client
@@ -168,7 +154,7 @@ fn download_asset(url: &str, archive_path: &Path) -> Result<(), String> {
         .map_err(|err| format!("failed to create download runtime: {err}"))?;
     let bytes = runtime.block_on(async {
         let client = reqwest::Client::builder()
-            .user_agent("fini-cli-updater")
+            .default_headers(github_headers()?)
             .build()
             .map_err(|err| format!("failed to create download client: {err}"))?;
         let response = client
@@ -190,6 +176,28 @@ fn download_asset(url: &str, archive_path: &Path) -> Result<(), String> {
     fs::write(archive_path, bytes)
         .map_err(|err| format!("failed to write update archive: {err}"))?;
     Ok(())
+}
+
+fn github_headers() -> Result<HeaderMap, String> {
+    github_headers_from_token(std::env::var("GH_TOKEN").ok())
+}
+
+fn github_headers_from_token(token: Option<String>) -> Result<HeaderMap, String> {
+    let mut headers = HeaderMap::new();
+    headers.insert(USER_AGENT, HeaderValue::from_static("fini-cli-updater"));
+    headers.insert(
+        ACCEPT,
+        HeaderValue::from_static("application/vnd.github+json"),
+    );
+    if let Some(token) = token {
+        let token = token.trim();
+        if !token.is_empty() {
+            let value = HeaderValue::from_str(&format!("Bearer {token}"))
+                .map_err(|err| format!("invalid GH_TOKEN for GitHub API: {err}"))?;
+            headers.insert(AUTHORIZATION, value);
+        }
+    }
+    Ok(headers)
 }
 
 fn verify_digest(archive_path: &Path, expected: Option<&str>) -> Result<(), String> {
@@ -481,10 +489,10 @@ fn default_install_root() -> Result<PathBuf, String> {
         .ok_or_else(|| "could not determine home directory for CLI install".to_string())
 }
 
-fn default_install_bin() -> PathBuf {
+fn default_install_bin(target: &CliAssetTarget) -> PathBuf {
     dirs::home_dir()
-        .map(|home| home.join(".local/bin/fini"))
-        .unwrap_or_else(|| PathBuf::from("fini"))
+        .map(|home| home.join(".local/bin").join(&target.executable_name))
+        .unwrap_or_else(|| PathBuf::from(&target.executable_name))
 }
 
 fn plan_json(plan: &UpdatePlan, dry_run: bool, updated: bool) -> Value {
@@ -521,6 +529,31 @@ mod tests {
         assert_eq!(
             cli_asset_name("v0.1.33", &windows),
             "fini-v0.1.33-windows-arm64-cli.zip"
+        );
+    }
+
+    #[test]
+    fn default_install_bin_uses_target_executable_name() {
+        let windows = cli_asset_target("windows", "x86_64").expect("windows x64 target");
+        assert_eq!(
+            default_install_bin(&windows),
+            dirs::home_dir().expect("home").join(".local/bin/fini.exe")
+        );
+
+        assert_eq!(
+            default_install_bin(&linux_x64_target()),
+            dirs::home_dir().expect("home").join(".local/bin/fini")
+        );
+    }
+
+    #[test]
+    fn github_headers_include_authorization_when_token_is_present() {
+        let headers = github_headers_from_token(Some("  test-token  ".to_string()))
+            .expect("headers with token");
+
+        assert_eq!(
+            headers.get(AUTHORIZATION).expect("authorization header"),
+            "Bearer test-token"
         );
     }
 

--- a/src-tauri/src/services/cli_update.rs
+++ b/src-tauri/src/services/cli_update.rs
@@ -517,16 +517,21 @@ fn select_update_plan(
     target: CliAssetTarget,
     install_bin: PathBuf,
 ) -> Result<UpdatePlan, String> {
-    let release = releases
+    let (release, asset) = releases
         .iter()
-        .find(|release| !release.draft && !release.prerelease)
-        .ok_or_else(|| "no stable GitHub release found".to_string())?;
-    let asset_name = cli_asset_name(&release.tag_name, &target);
-    let asset = release
-        .assets
-        .iter()
-        .find(|asset| asset.name == asset_name)
-        .ok_or_else(|| format!("release {} does not include {asset_name}", release.tag_name))?;
+        .filter(|release| !release.draft && !release.prerelease)
+        .filter_map(|release| {
+            let version = release_version(&release.tag_name).ok()?;
+            let asset_name = cli_asset_name(&release.tag_name, &target);
+            let asset = release
+                .assets
+                .iter()
+                .find(|asset| asset.name == asset_name)?;
+            Some((version, release, asset))
+        })
+        .max_by(|(left, _, _), (right, _, _)| left.cmp(right))
+        .map(|(_, release, asset)| (release, asset))
+        .ok_or_else(|| "no stable GitHub release with matching CLI asset found".to_string())?;
 
     build_update_plan(
         repo,
@@ -538,6 +543,11 @@ fn select_update_plan(
         install_bin,
         target,
     )
+}
+
+fn release_version(tag: &str) -> Result<Version, String> {
+    let version = tag.strip_prefix('v').unwrap_or(tag);
+    Version::parse(version).map_err(|err| format!("failed to parse release tag {tag}: {err}"))
 }
 
 pub fn cli_asset_name(tag: &str, target: &CliAssetTarget) -> String {
@@ -741,6 +751,56 @@ mod tests {
             plan.asset_url,
             "https://example.test/stable.tar.gz".to_string()
         );
+    }
+
+    #[test]
+    fn select_update_plan_chooses_highest_stable_matching_asset() {
+        let releases = vec![
+            GitHubRelease {
+                tag_name: "v0.1.32".to_string(),
+                draft: false,
+                prerelease: false,
+                assets: vec![GitHubAsset {
+                    name: "fini-v0.1.32-linux-x64-cli.tar.gz".to_string(),
+                    browser_download_url: "https://example.test/old.tar.gz".to_string(),
+                    digest: None,
+                }],
+            },
+            GitHubRelease {
+                tag_name: "v0.1.34".to_string(),
+                draft: false,
+                prerelease: false,
+                assets: vec![GitHubAsset {
+                    name: "fini-v0.1.34-linux-x64-cli.tar.gz".to_string(),
+                    browser_download_url: "https://example.test/new.tar.gz".to_string(),
+                    digest: Some("sha256:def".to_string()),
+                }],
+            },
+            GitHubRelease {
+                tag_name: "v0.1.35-rc.1".to_string(),
+                draft: false,
+                prerelease: true,
+                assets: vec![GitHubAsset {
+                    name: "fini-v0.1.35-rc.1-linux-x64-cli.tar.gz".to_string(),
+                    browser_download_url: "https://example.test/pre.tar.gz".to_string(),
+                    digest: None,
+                }],
+            },
+        ];
+
+        let plan = select_update_plan(
+            "example/fini".to_string(),
+            "0.1.33",
+            &releases,
+            linux_x64_target(),
+            PathBuf::from("/var/tmp/fini-test-bin/fini"),
+        )
+        .expect("selected update plan");
+
+        assert!(!plan.already_current);
+        assert_eq!(plan.target_tag, "v0.1.34");
+        assert_eq!(plan.asset_name, "fini-v0.1.34-linux-x64-cli.tar.gz");
+        assert_eq!(plan.asset_url, "https://example.test/new.tar.gz");
     }
 
     #[test]

--- a/src-tauri/src/services/cli_update.rs
+++ b/src-tauri/src/services/cli_update.rs
@@ -1,7 +1,9 @@
 use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT};
+use semver::Version;
 use serde::Deserialize;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
+use std::cmp::Ordering;
 use std::fs::{self, File};
 use std::io::{self, Cursor};
 use std::path::{Path, PathBuf};
@@ -471,12 +473,18 @@ fn build_update_plan(
         .strip_prefix('v')
         .unwrap_or(&target_tag)
         .to_string();
+    let version_order = compare_update_versions(&current_version, &target_version)?;
+    if version_order == Ordering::Less {
+        return Err(format!(
+            "refusing to downgrade CLI from {current_version} to {target_version}"
+        ));
+    }
     let install_root = default_install_root()?;
     let install_dir = install_root.join(&target_tag);
     let target_binary = install_dir.join(&target.executable_name);
     Ok(UpdatePlan {
         repo,
-        already_current: current_version == target_version,
+        already_current: version_order == Ordering::Equal,
         current_version,
         target_tag,
         target_version,
@@ -489,6 +497,17 @@ fn build_update_plan(
         archive_kind: target.archive_kind,
         executable_name: target.executable_name,
     })
+}
+
+fn compare_update_versions(
+    current_version: &str,
+    target_version: &str,
+) -> Result<Ordering, String> {
+    let current = Version::parse(current_version)
+        .map_err(|err| format!("failed to parse current CLI version {current_version}: {err}"))?;
+    let target = Version::parse(target_version)
+        .map_err(|err| format!("failed to parse target CLI version {target_version}: {err}"))?;
+    Ok(target.cmp(&current))
 }
 
 fn select_update_plan(
@@ -659,6 +678,25 @@ mod tests {
             dirs::home_dir()
                 .expect("home")
                 .join(".local/lib/fini/v0.1.33/fini")
+        );
+    }
+
+    #[test]
+    fn update_plan_rejects_target_older_than_current_version() {
+        let result = build_update_plan(
+            "example/fini".to_string(),
+            "0.1.34-rc.1".to_string(),
+            "v0.1.33".to_string(),
+            "fini-v0.1.33-linux-x64-cli.tar.gz".to_string(),
+            "https://example.test/fini.tar.gz".to_string(),
+            Some("sha256:abc".to_string()),
+            PathBuf::from("/var/tmp/fini-test-bin/fini"),
+            linux_x64_target(),
+        );
+
+        assert_eq!(
+            result.expect_err("older target rejected"),
+            "refusing to downgrade CLI from 0.1.34-rc.1 to 0.1.33"
         );
     }
 

--- a/src-tauri/src/services/cli_update.rs
+++ b/src-tauri/src/services/cli_update.rs
@@ -1,982 +1,229 @@
-use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT};
-use semver::Version;
-use serde::Deserialize;
 use serde_json::{json, Value};
-use sha2::{Digest, Sha256};
-use std::cmp::Ordering;
-use std::fs::{self, File};
-use std::io::{self, Cursor};
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::path::PathBuf;
+use tauri_plugin_updater::UpdaterExt;
+use url::Url;
 
-const DEFAULT_REPO: &str = "VRuzhentsov/fini";
-const GITHUB_API: &str = "https://api.github.com";
-const GITHUB_RELEASES_PER_PAGE: usize = 100;
-const GITHUB_RELEASES_MAX_PAGES: usize = 20;
+const DEFAULT_UPDATE_ENDPOINT: &str =
+    "https://github.com/VRuzhentsov/fini/releases/latest/download/latest-cli.json";
+const COMPILED_UPDATE_PUBKEY: Option<&str> = option_env!("FINI_TAURI_UPDATER_PUBKEY");
 
 #[derive(Debug, Clone)]
 pub struct UpdateOptions {
     pub dry_run: bool,
-    pub repo: Option<String>,
-    pub install_bin: Option<PathBuf>,
+    pub endpoint: Option<String>,
+    pub pubkey: Option<String>,
+    pub target: Option<String>,
+    pub executable_path: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ArchiveKind {
-    TarGz,
-    Zip,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CliAssetTarget {
-    pub os: String,
-    pub arch: String,
-    pub executable_name: String,
-    pub archive_kind: ArchiveKind,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct UpdatePlan {
-    pub repo: String,
-    pub current_version: String,
-    pub target_tag: String,
-    pub target_version: String,
-    pub asset_name: String,
-    pub asset_url: String,
-    pub asset_digest: Option<String>,
-    pub install_dir: PathBuf,
-    pub install_bin: PathBuf,
-    pub target_binary: PathBuf,
-    pub already_current: bool,
-    archive_kind: ArchiveKind,
-    executable_name: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct GitHubRelease {
-    tag_name: String,
-    draft: bool,
-    prerelease: bool,
-    assets: Vec<GitHubAsset>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GitHubAsset {
-    name: String,
-    url: String,
-    digest: Option<String>,
+struct CliUpdateConfig {
+    endpoint: Url,
+    pubkey: String,
+    target: String,
+    executable_path: PathBuf,
 }
 
 pub fn run_update(options: UpdateOptions) -> Result<Value, String> {
-    let repo = options
-        .repo
-        .or_else(|| std::env::var("FINI_UPDATE_REPO").ok())
-        .unwrap_or_else(|| DEFAULT_REPO.to_string());
-    validate_repo(&repo)?;
+    let config = resolve_update_config(options.clone())?;
+    ensure_tauri_updater_runtime_available()?;
+    let app = tauri::Builder::default()
+        .plugin(
+            tauri_plugin_updater::Builder::new()
+                .pubkey(config.pubkey.clone())
+                .target(config.target.clone())
+                .build(),
+        )
+        .build(tauri::generate_context!())
+        .map_err(|err| format!("failed to initialize Tauri updater: {err}"))?;
 
-    let target = current_cli_asset_target()?;
-    let install_bin = options
-        .install_bin
-        .or_else(|| std::env::var_os("FINI_UPDATE_BIN_PATH").map(PathBuf::from))
-        .unwrap_or_else(|| default_install_bin(&target));
-    let releases = list_releases(&repo)?;
-    let plan = select_update_plan(
-        repo,
-        env!("CARGO_PKG_VERSION"),
-        &releases,
-        target,
-        install_bin,
-    )?;
-
-    if options.dry_run || plan.already_current {
-        return Ok(plan_json(&plan, options.dry_run, false));
-    }
-
-    apply_update(&plan)?;
-    Ok(plan_json(&plan, false, true))
-}
-
-fn list_releases(repo: &str) -> Result<Vec<GitHubRelease>, String> {
+    let app_handle = app.handle().clone();
     let runtime = tokio::runtime::Runtime::new()
         .map_err(|err| format!("failed to create update runtime: {err}"))?;
-    runtime.block_on(async {
-        let client = reqwest::Client::builder()
-            .default_headers(github_headers()?)
-            .build()
-            .map_err(|err| format!("failed to create GitHub client: {err}"))?;
-        let mut releases = Vec::new();
-        let mut page = 1;
-        loop {
-            let response = client
-                .get(releases_page_url(repo, page))
-                .send()
-                .await
-                .map_err(|err| format!("failed to query GitHub releases: {err}"))?;
-            if !response.status().is_success() {
-                return Err(format!(
-                    "GitHub releases query failed with HTTP {}",
-                    response.status()
-                ));
-            }
-            let text = response
-                .text()
-                .await
-                .map_err(|err| format!("failed to read GitHub release response: {err}"))?;
-            let mut page_releases: Vec<GitHubRelease> = serde_json::from_str(&text)
-                .map_err(|err| format!("failed to parse GitHub release response: {err}"))?;
-            let fetched = page_releases.len();
-            releases.append(&mut page_releases);
-            let Some(next_page) = next_releases_page(page, fetched) else {
-                break;
-            };
-            page = next_page;
+    runtime.block_on(async move {
+        let mut builder = app_handle
+            .updater_builder()
+            .target(config.target.clone())
+            .pubkey(config.pubkey.clone())
+            .endpoints(vec![config.endpoint.clone()])
+            .map_err(|err| format!("failed to configure updater endpoint: {err}"))?
+            .executable_path(&config.executable_path);
+
+        if let Some(token) = github_token() {
+            builder = builder
+                .header("Authorization", format!("Bearer {token}"))
+                .map_err(|err| format!("failed to configure updater auth header: {err}"))?;
         }
-        Ok(releases)
+
+        let updater = builder
+            .build()
+            .map_err(|err| format!("failed to build updater: {err}"))?;
+        let update = updater
+            .check()
+            .await
+            .map_err(|err| format!("failed to check for updates: {err}"))?;
+
+        let Some(update) = update else {
+            return Ok(json!({
+                "current_version": env!("CARGO_PKG_VERSION"),
+                "target_version": env!("CARGO_PKG_VERSION"),
+                "endpoint": config.endpoint,
+                "target": config.target,
+                "executable_path": config.executable_path,
+                "dry_run": options.dry_run,
+                "already_current": true,
+                "updated": false,
+            }));
+        };
+
+        let result = json!({
+            "current_version": update.current_version,
+            "target_version": update.version,
+            "endpoint": config.endpoint,
+            "target": update.target,
+            "download_url": update.download_url,
+            "executable_path": config.executable_path,
+            "dry_run": options.dry_run,
+            "already_current": false,
+            "updated": !options.dry_run,
+        });
+
+        if !options.dry_run {
+            update
+                .download_and_install(|_, _| {}, || {})
+                .await
+                .map_err(|err| format!("failed to install update: {err}"))?;
+        }
+
+        Ok(result)
     })
 }
 
-fn releases_page_url(repo: &str, page: usize) -> String {
-    format!("{GITHUB_API}/repos/{repo}/releases?per_page={GITHUB_RELEASES_PER_PAGE}&page={page}")
-}
-
-fn next_releases_page(current_page: usize, fetched: usize) -> Option<usize> {
-    if fetched < GITHUB_RELEASES_PER_PAGE || current_page >= GITHUB_RELEASES_MAX_PAGES {
-        None
-    } else {
-        Some(current_page + 1)
-    }
-}
-
-fn apply_update(plan: &UpdatePlan) -> Result<(), String> {
-    let staging_dir = plan.install_dir.join(".download");
-    if staging_dir.exists() {
-        fs::remove_dir_all(&staging_dir)
-            .map_err(|err| format!("failed to clear update staging dir: {err}"))?;
-    }
-    fs::create_dir_all(&staging_dir)
-        .map_err(|err| format!("failed to create update staging dir: {err}"))?;
-    fs::create_dir_all(&plan.install_dir)
-        .map_err(|err| format!("failed to create install dir: {err}"))?;
-
-    let archive_path = staging_dir.join(&plan.asset_name);
-    download_asset(&plan.asset_url, &archive_path)?;
-    verify_digest(&archive_path, plan.asset_digest.as_deref())?;
-    extract_binary(
-        &archive_path,
-        &plan.target_binary,
-        &plan.archive_kind,
-        &plan.executable_name,
-    )?;
-    verify_candidate_binary(&plan.target_binary, &plan.target_version)?;
-    activate_binary(&plan.target_binary, &plan.install_bin)?;
-    fs::remove_dir_all(&staging_dir)
-        .map_err(|err| format!("failed to remove update staging dir: {err}"))?;
-    Ok(())
-}
-
-fn download_asset(url: &str, archive_path: &Path) -> Result<(), String> {
-    let runtime = tokio::runtime::Runtime::new()
-        .map_err(|err| format!("failed to create download runtime: {err}"))?;
-    let bytes = runtime.block_on(async {
-        let client = reqwest::Client::builder()
-            .default_headers(github_headers()?)
-            .build()
-            .map_err(|err| format!("failed to create download client: {err}"))?;
-        let response = client
-            .get(url)
-            .header(ACCEPT, HeaderValue::from_static("application/octet-stream"))
-            .send()
-            .await
-            .map_err(|err| format!("failed to download update asset: {err}"))?;
-        if !response.status().is_success() {
-            return Err(format!(
-                "release asset download failed with HTTP {}",
-                response.status()
-            ));
-        }
-        response
-            .bytes()
-            .await
-            .map_err(|err| format!("failed to read update asset: {err}"))
-    })?;
-    fs::write(archive_path, bytes)
-        .map_err(|err| format!("failed to write update archive: {err}"))?;
-    Ok(())
-}
-
-fn github_headers() -> Result<HeaderMap, String> {
-    github_headers_from_token(std::env::var("GH_TOKEN").ok())
-}
-
-fn github_headers_from_token(token: Option<String>) -> Result<HeaderMap, String> {
-    let mut headers = HeaderMap::new();
-    headers.insert(USER_AGENT, HeaderValue::from_static("fini-cli-updater"));
-    headers.insert(
-        ACCEPT,
-        HeaderValue::from_static("application/vnd.github+json"),
-    );
-    if let Some(token) = token {
-        let token = token.trim();
-        if !token.is_empty() {
-            let value = HeaderValue::from_str(&format!("Bearer {token}"))
-                .map_err(|err| format!("invalid GH_TOKEN for GitHub API: {err}"))?;
-            headers.insert(AUTHORIZATION, value);
-        }
-    }
-    Ok(headers)
-}
-
-fn verify_digest(archive_path: &Path, expected: Option<&str>) -> Result<(), String> {
-    let Some(expected) = expected else {
-        return Ok(());
-    };
-    let expected = expected
-        .strip_prefix("sha256:")
-        .unwrap_or(expected)
-        .to_ascii_lowercase();
-    let bytes = fs::read(archive_path)
-        .map_err(|err| format!("failed to read update archive for digest check: {err}"))?;
-    let actual = format!("{:x}", Sha256::digest(&bytes));
-    if actual != expected {
-        return Err(format!(
-            "update archive digest mismatch: expected {expected}, got {actual}"
-        ));
-    }
-    Ok(())
-}
-
-fn extract_binary(
-    archive_path: &Path,
-    target_binary: &Path,
-    archive_kind: &ArchiveKind,
-    executable_name: &str,
-) -> Result<(), String> {
-    let parent = target_binary
-        .parent()
-        .ok_or_else(|| "target binary path has no parent directory".to_string())?;
-    fs::create_dir_all(parent).map_err(|err| format!("failed to create install dir: {err}"))?;
-
-    match archive_kind {
-        ArchiveKind::TarGz => extract_tar_gz_binary(archive_path, target_binary, executable_name)?,
-        ArchiveKind::Zip => extract_zip_binary(archive_path, target_binary, executable_name)?,
-    }
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut permissions = fs::metadata(target_binary)
-            .map_err(|err| format!("failed to inspect extracted binary: {err}"))?
-            .permissions();
-        permissions.set_mode(0o755);
-        fs::set_permissions(target_binary, permissions)
-            .map_err(|err| format!("failed to mark extracted binary executable: {err}"))?;
-    }
-
-    Ok(())
-}
-
-fn extract_tar_gz_binary(
-    archive_path: &Path,
-    target_binary: &Path,
-    executable_name: &str,
-) -> Result<(), String> {
-    let file = File::open(archive_path).map_err(|err| format!("failed to open archive: {err}"))?;
-    let decoder = flate2::read::GzDecoder::new(file);
-    let mut archive = tar::Archive::new(decoder);
-    for entry in archive
-        .entries()
-        .map_err(|err| format!("failed to read tar archive: {err}"))?
-    {
-        let mut entry = entry.map_err(|err| format!("failed to read tar entry: {err}"))?;
-        let path = entry
-            .path()
-            .map_err(|err| format!("failed to inspect tar entry path: {err}"))?;
-        if path.file_name().and_then(|name| name.to_str()) == Some(executable_name) {
-            let mut output = File::create(target_binary)
-                .map_err(|err| format!("failed to create target binary: {err}"))?;
-            io::copy(&mut entry, &mut output)
-                .map_err(|err| format!("failed to extract CLI binary: {err}"))?;
-            return Ok(());
-        }
-    }
-    Err(format!("archive does not contain {executable_name}"))
-}
-
-fn extract_zip_binary(
-    archive_path: &Path,
-    target_binary: &Path,
-    executable_name: &str,
-) -> Result<(), String> {
-    let bytes = fs::read(archive_path).map_err(|err| format!("failed to open archive: {err}"))?;
-    let reader = Cursor::new(bytes);
-    let mut archive =
-        zip::ZipArchive::new(reader).map_err(|err| format!("failed to read zip archive: {err}"))?;
-    for index in 0..archive.len() {
-        let mut file = archive
-            .by_index(index)
-            .map_err(|err| format!("failed to read zip entry: {err}"))?;
-        let name = Path::new(file.name())
-            .file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or_default()
-            .to_string();
-        if name == executable_name {
-            let mut output = File::create(target_binary)
-                .map_err(|err| format!("failed to create target binary: {err}"))?;
-            io::copy(&mut file, &mut output)
-                .map_err(|err| format!("failed to extract CLI binary: {err}"))?;
-            return Ok(());
-        }
-    }
-    Err(format!("archive does not contain {executable_name}"))
-}
-
-fn verify_candidate_binary(binary: &Path, target_version: &str) -> Result<(), String> {
-    let output = Command::new(binary)
-        .arg("--version")
-        .output()
-        .map_err(|err| format!("failed to run extracted CLI binary: {err}"))?;
-    if !output.status.success() {
-        return Err("extracted CLI binary failed minimal version check".to_string());
-    }
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let actual_version = candidate_version_from_stdout(&stdout)?;
-    let expected_version = Version::parse(target_version)
-        .map_err(|err| format!("failed to parse target CLI version {target_version}: {err}"))?;
-    if actual_version != expected_version {
-        return Err(format!(
-            "extracted CLI version check failed: expected {target_version}, got {}",
-            stdout.trim()
-        ));
-    }
-    Ok(())
-}
-
-fn candidate_version_from_stdout(stdout: &str) -> Result<Version, String> {
-    stdout
-        .split_whitespace()
-        .find_map(|part| Version::parse(part.trim_start_matches('v')).ok())
+fn resolve_update_config(options: UpdateOptions) -> Result<CliUpdateConfig, String> {
+    let endpoint = options
+        .endpoint
+        .or_else(|| std::env::var("FINI_UPDATE_ENDPOINT").ok())
+        .unwrap_or_else(|| DEFAULT_UPDATE_ENDPOINT.to_string())
+        .parse::<Url>()
+        .map_err(|err| format!("invalid updater endpoint: {err}"))?;
+    let pubkey = options
+        .pubkey
+        .or_else(|| std::env::var("FINI_UPDATE_PUBKEY").ok())
+        .or_else(|| COMPILED_UPDATE_PUBKEY.map(str::to_string))
+        .filter(|value| !value.trim().is_empty())
         .ok_or_else(|| {
-            format!(
-                "extracted CLI version check failed: could not parse version from {}",
-                stdout.trim()
-            )
-        })
-}
+            "missing Tauri updater public key; set FINI_UPDATE_PUBKEY or build with FINI_TAURI_UPDATER_PUBKEY".to_string()
+        })?;
+    let target = options.target.unwrap_or(default_cli_update_target()?);
+    let executable_path = options
+        .executable_path
+        .map(Ok)
+        .unwrap_or_else(std::env::current_exe)
+        .map_err(|err| format!("failed to resolve current CLI executable: {err}"))?;
 
-#[cfg(unix)]
-fn activate_binary(target_binary: &Path, install_bin: &Path) -> Result<(), String> {
-    use std::os::unix::fs::symlink;
-    let parent = install_bin
-        .parent()
-        .ok_or_else(|| "install path has no parent directory".to_string())?;
-    fs::create_dir_all(parent).map_err(|err| format!("failed to create bin dir: {err}"))?;
-    let tmp_link = install_bin.with_extension("fini-update-tmp");
-    if tmp_link.exists() {
-        fs::remove_file(&tmp_link)
-            .map_err(|err| format!("failed to remove stale update link: {err}"))?;
-    }
-    symlink(target_binary, &tmp_link)
-        .map_err(|err| format!("failed to create update symlink: {err}"))?;
-    fs::rename(&tmp_link, install_bin)
-        .map_err(|err| format!("failed to activate updated CLI binary: {err}"))?;
-    Ok(())
-}
-
-#[cfg(not(unix))]
-fn activate_binary(target_binary: &Path, install_bin: &Path) -> Result<(), String> {
-    let parent = install_bin
-        .parent()
-        .ok_or_else(|| "install path has no parent directory".to_string())?;
-    fs::create_dir_all(parent).map_err(|err| format!("failed to create bin dir: {err}"))?;
-    let tmp_bin = install_bin.with_extension("fini-update-tmp");
-    if tmp_bin.exists() {
-        fs::remove_file(&tmp_bin)
-            .map_err(|err| format!("failed to remove stale staged CLI binary: {err}"))?;
-    }
-    if let Err(err) = fs::copy(target_binary, &tmp_bin) {
-        let _ = fs::remove_file(&tmp_bin);
-        return Err(format!("failed to stage updated CLI binary: {err}"));
-    }
-    replace_file_non_unix(&tmp_bin, install_bin)?;
-    Ok(())
-}
-
-#[cfg(any(not(unix), test))]
-fn replace_file_non_unix(staged: &Path, destination: &Path) -> Result<(), String> {
-    if destination.exists() {
-        if should_defer_non_unix_replacement(destination)? {
-            return schedule_deferred_non_unix_replacement(staged, destination);
-        }
-        if let Err(err) = fs::remove_file(destination) {
-            let _ = fs::remove_file(staged);
-            return Err(format!("failed to replace existing CLI binary: {err}"));
-        }
-    }
-    if let Err(err) = fs::rename(staged, destination) {
-        let _ = fs::remove_file(staged);
-        return Err(format!("failed to activate updated CLI binary: {err}"));
-    }
-    Ok(())
-}
-
-#[cfg(any(not(unix), test))]
-fn should_defer_non_unix_replacement(destination: &Path) -> Result<bool, String> {
-    let current_exe = std::env::current_exe()
-        .map_err(|err| format!("failed to resolve current CLI binary: {err}"))?;
-    replacement_targets_running_binary(destination, &current_exe)
-}
-
-#[cfg(any(not(unix), test))]
-fn replacement_targets_running_binary(
-    destination: &Path,
-    current_exe: &Path,
-) -> Result<bool, String> {
-    let destination = destination
-        .canonicalize()
-        .map_err(|err| format!("failed to resolve existing CLI binary: {err}"))?;
-    let current_exe = current_exe
-        .canonicalize()
-        .map_err(|err| format!("failed to resolve current CLI binary: {err}"))?;
-    Ok(destination == current_exe)
-}
-
-#[cfg(windows)]
-fn schedule_deferred_non_unix_replacement(staged: &Path, destination: &Path) -> Result<(), String> {
-    let script = destination.with_extension("fini-update.cmd");
-    let content = windows_replacement_script(staged, destination);
-    fs::write(&script, content)
-        .map_err(|err| format!("failed to write deferred CLI replacement helper: {err}"))?;
-    Command::new("cmd")
-        .args(["/C", "start", "", "/min"])
-        .arg(&script)
-        .spawn()
-        .map_err(|err| format!("failed to start deferred CLI replacement helper: {err}"))?;
-    Ok(())
-}
-
-#[cfg(all(not(unix), not(windows)))]
-fn schedule_deferred_non_unix_replacement(
-    staged: &Path,
-    _destination: &Path,
-) -> Result<(), String> {
-    let _ = fs::remove_file(staged);
-    Err("cannot replace the running CLI binary on this platform".to_string())
-}
-
-#[cfg(all(test, not(windows)))]
-fn schedule_deferred_non_unix_replacement(
-    _staged: &Path,
-    _destination: &Path,
-) -> Result<(), String> {
-    Ok(())
-}
-
-#[cfg(any(windows, test))]
-fn windows_replacement_script(staged: &Path, destination: &Path) -> String {
-    let staged = batch_literal(staged);
-    let destination = batch_literal(destination);
-    format!(
-        "@echo off\r\n\
-         setlocal\r\n\
-         set \"STAGED={staged}\"\r\n\
-         set \"DESTINATION={destination}\"\r\n\
-         for /l %%i in (1,1,30) do (\r\n\
-         \u{20} move /Y \"%STAGED%\" \"%DESTINATION%\" >nul 2>nul\r\n\
-         \u{20} if not exist \"%STAGED%\" (\r\n\
-         \u{20}\u{20} del \"%~f0\" >nul 2>nul\r\n\
-         \u{20}\u{20} exit /b 0\r\n\
-         \u{20} )\r\n\
-         \u{20} timeout /t 1 /nobreak >nul\r\n\
-         )\r\n\
-         exit /b 1\r\n"
-    )
-}
-
-#[cfg(any(windows, test))]
-fn batch_literal(path: &Path) -> String {
-    path.to_string_lossy().replace('%', "%%")
-}
-
-fn build_update_plan(
-    repo: String,
-    current_version: String,
-    target_tag: String,
-    asset_name: String,
-    asset_url: String,
-    asset_digest: Option<String>,
-    install_bin: PathBuf,
-    target: CliAssetTarget,
-) -> Result<UpdatePlan, String> {
-    let target_version = target_tag
-        .strip_prefix('v')
-        .unwrap_or(&target_tag)
-        .to_string();
-    let version_order = compare_update_versions(&current_version, &target_version)?;
-    if version_order == Ordering::Less {
-        return Err(format!(
-            "refusing to downgrade CLI from {current_version} to {target_version}"
-        ));
-    }
-    let install_root = default_install_root()?;
-    let install_dir = install_root.join(&target_tag);
-    let target_binary = install_dir.join(&target.executable_name);
-    Ok(UpdatePlan {
-        repo,
-        already_current: version_order == Ordering::Equal,
-        current_version,
-        target_tag,
-        target_version,
-        asset_name,
-        asset_url,
-        asset_digest,
-        install_dir,
-        install_bin,
-        target_binary,
-        archive_kind: target.archive_kind,
-        executable_name: target.executable_name,
-    })
-}
-
-fn compare_update_versions(
-    current_version: &str,
-    target_version: &str,
-) -> Result<Ordering, String> {
-    let current = Version::parse(current_version)
-        .map_err(|err| format!("failed to parse current CLI version {current_version}: {err}"))?;
-    let target = Version::parse(target_version)
-        .map_err(|err| format!("failed to parse target CLI version {target_version}: {err}"))?;
-    Ok(target.cmp(&current))
-}
-
-fn select_update_plan(
-    repo: String,
-    current_version: &str,
-    releases: &[GitHubRelease],
-    target: CliAssetTarget,
-    install_bin: PathBuf,
-) -> Result<UpdatePlan, String> {
-    let (release, asset) = releases
-        .iter()
-        .filter(|release| !release.draft && !release.prerelease)
-        .filter_map(|release| {
-            let version = release_version(&release.tag_name).ok()?;
-            let asset_name = cli_asset_name(&release.tag_name, &target);
-            let asset = release
-                .assets
-                .iter()
-                .find(|asset| asset.name == asset_name)?;
-            Some((version, release, asset))
-        })
-        .max_by(|(left, _, _), (right, _, _)| left.cmp(right))
-        .map(|(_, release, asset)| (release, asset))
-        .ok_or_else(|| "no stable GitHub release with matching CLI asset found".to_string())?;
-
-    build_update_plan(
-        repo,
-        current_version.to_string(),
-        release.tag_name.clone(),
-        asset.name.clone(),
-        asset.url.clone(),
-        asset.digest.clone(),
-        install_bin,
+    Ok(CliUpdateConfig {
+        endpoint,
+        pubkey,
         target,
-    )
+        executable_path,
+    })
 }
 
-fn release_version(tag: &str) -> Result<Version, String> {
-    let version = tag.strip_prefix('v').unwrap_or(tag);
-    Version::parse(version).map_err(|err| format!("failed to parse release tag {tag}: {err}"))
+fn default_cli_update_target() -> Result<String, String> {
+    tauri_plugin_updater::target()
+        .map(|target| format!("cli-{target}"))
+        .ok_or_else(|| "CLI updates are not supported on this platform".to_string())
 }
 
-pub fn cli_asset_name(tag: &str, target: &CliAssetTarget) -> String {
-    let extension = match target.archive_kind {
-        ArchiveKind::TarGz => "tar.gz",
-        ArchiveKind::Zip => "zip",
-    };
-    format!("fini-{tag}-{}-{}-cli.{extension}", target.os, target.arch)
+fn github_token() -> Option<String> {
+    std::env::var("GH_TOKEN")
+        .ok()
+        .map(|token| token.trim().to_string())
+        .filter(|token| !token.is_empty())
 }
 
-pub fn current_cli_asset_target() -> Result<CliAssetTarget, String> {
-    cli_asset_target(std::env::consts::OS, std::env::consts::ARCH)
-}
-
-pub fn cli_asset_target(os: &str, arch: &str) -> Result<CliAssetTarget, String> {
-    let arch = match arch {
-        "x86_64" => "x64",
-        "aarch64" => "arm64",
-        other => return Err(format!("unsupported CLI update architecture: {other}")),
-    };
-    match os {
-        "linux" => Ok(CliAssetTarget {
-            os: "linux".to_string(),
-            arch: arch.to_string(),
-            executable_name: "fini".to_string(),
-            archive_kind: ArchiveKind::TarGz,
-        }),
-        "windows" => Ok(CliAssetTarget {
-            os: "windows".to_string(),
-            arch: arch.to_string(),
-            executable_name: "fini.exe".to_string(),
-            archive_kind: ArchiveKind::Zip,
-        }),
-        other => Err(format!("unsupported CLI update OS: {other}")),
-    }
-}
-
-fn validate_repo(repo: &str) -> Result<(), String> {
-    let parts: Vec<_> = repo.split('/').collect();
-    if parts.len() != 2 || parts.iter().any(|part| part.is_empty()) {
-        return Err("update repo must use owner/name format".to_string());
+fn ensure_tauri_updater_runtime_available() -> Result<(), String> {
+    #[cfg(target_os = "linux")]
+    {
+        if std::env::var_os("DISPLAY").is_none() && std::env::var_os("WAYLAND_DISPLAY").is_none() {
+            return Err(
+                "Tauri's built-in updater requires a graphical Linux session; set DISPLAY or WAYLAND_DISPLAY before running fini update".to_string(),
+            );
+        }
     }
     Ok(())
-}
-
-fn default_install_root() -> Result<PathBuf, String> {
-    dirs::home_dir()
-        .map(|home| home.join(".local/lib/fini"))
-        .ok_or_else(|| "could not determine home directory for CLI install".to_string())
-}
-
-fn default_install_bin(target: &CliAssetTarget) -> PathBuf {
-    dirs::home_dir()
-        .map(|home| home.join(".local/bin").join(&target.executable_name))
-        .unwrap_or_else(|| PathBuf::from(&target.executable_name))
-}
-
-fn plan_json(plan: &UpdatePlan, dry_run: bool, updated: bool) -> Value {
-    json!({
-        "current_version": plan.current_version,
-        "target_version": plan.target_version,
-        "target_tag": plan.target_tag,
-        "repo": plan.repo,
-        "asset": plan.asset_name,
-        "asset_digest": plan.asset_digest,
-        "install_dir": plan.install_dir,
-        "install_bin": plan.install_bin,
-        "dry_run": dry_run,
-        "already_current": plan.already_current,
-        "updated": updated,
-    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn linux_x64_target() -> CliAssetTarget {
-        cli_asset_target("linux", "x86_64").expect("linux x64 target")
-    }
-
     #[test]
-    fn cli_asset_name_uses_release_archive_contract() {
+    fn default_cli_target_prefixes_tauri_target() {
+        let target = default_cli_update_target().expect("supported updater target");
+
+        assert!(target.starts_with("cli-"));
         assert_eq!(
-            cli_asset_name("v0.1.33", &linux_x64_target()),
-            "fini-v0.1.33-linux-x64-cli.tar.gz"
-        );
-        let windows = cli_asset_target("windows", "aarch64").expect("windows arm64 target");
-        assert_eq!(
-            cli_asset_name("v0.1.33", &windows),
-            "fini-v0.1.33-windows-arm64-cli.zip"
+            Some(target.trim_start_matches("cli-")),
+            tauri_plugin_updater::target().as_deref()
         );
     }
 
     #[test]
-    fn default_install_bin_uses_target_executable_name() {
-        let windows = cli_asset_target("windows", "x86_64").expect("windows x64 target");
-        assert_eq!(
-            default_install_bin(&windows),
-            dirs::home_dir().expect("home").join(".local/bin/fini.exe")
-        );
+    fn update_config_uses_runtime_options() {
+        let executable_path = PathBuf::from("/var/tmp/fini-test-bin");
+        let config = resolve_update_config(UpdateOptions {
+            dry_run: true,
+            endpoint: Some("https://example.test/latest-cli.json".to_string()),
+            pubkey: Some("test-public-key".to_string()),
+            target: Some("cli-linux-x86_64".to_string()),
+            executable_path: Some(executable_path.clone()),
+        })
+        .expect("resolved update config");
 
         assert_eq!(
-            default_install_bin(&linux_x64_target()),
-            dirs::home_dir().expect("home").join(".local/bin/fini")
+            config.endpoint.as_str(),
+            "https://example.test/latest-cli.json"
         );
+        assert_eq!(config.pubkey, "test-public-key");
+        assert_eq!(config.target, "cli-linux-x86_64");
+        assert_eq!(config.executable_path, executable_path);
     }
 
     #[test]
-    fn github_headers_include_authorization_when_token_is_present() {
-        let headers = github_headers_from_token(Some("  test-token  ".to_string()))
-            .expect("headers with token");
+    fn update_config_requires_pubkey() {
+        let result = resolve_update_config(UpdateOptions {
+            dry_run: true,
+            endpoint: Some("https://example.test/latest-cli.json".to_string()),
+            pubkey: Some(" ".to_string()),
+            target: Some("cli-linux-x86_64".to_string()),
+            executable_path: Some(PathBuf::from("/var/tmp/fini-test-bin")),
+        });
 
-        assert_eq!(
-            headers.get(AUTHORIZATION).expect("authorization header"),
-            "Bearer test-token"
-        );
-    }
-
-    #[test]
-    fn update_plan_marks_matching_version_current() {
-        let plan = build_update_plan(
-            "example/fini".to_string(),
-            "0.1.33".to_string(),
-            "v0.1.33".to_string(),
-            "fini-v0.1.33-linux-x64-cli.tar.gz".to_string(),
-            "https://example.test/fini.tar.gz".to_string(),
-            Some("sha256:abc".to_string()),
-            PathBuf::from("/var/tmp/fini-test-bin/fini"),
-            linux_x64_target(),
-        )
-        .expect("plan");
-
-        assert!(plan.already_current);
-        assert_eq!(plan.target_version, "0.1.33");
-        assert_eq!(
-            plan.target_binary,
-            dirs::home_dir()
-                .expect("home")
-                .join(".local/lib/fini/v0.1.33/fini")
-        );
-    }
-
-    #[test]
-    fn update_plan_rejects_target_older_than_current_version() {
-        let result = build_update_plan(
-            "example/fini".to_string(),
-            "0.1.34-rc.1".to_string(),
-            "v0.1.33".to_string(),
-            "fini-v0.1.33-linux-x64-cli.tar.gz".to_string(),
-            "https://example.test/fini.tar.gz".to_string(),
-            Some("sha256:abc".to_string()),
-            PathBuf::from("/var/tmp/fini-test-bin/fini"),
-            linux_x64_target(),
-        );
-
-        assert_eq!(
-            result.expect_err("older target rejected"),
-            "refusing to downgrade CLI from 0.1.34-rc.1 to 0.1.33"
-        );
-    }
-
-    #[test]
-    fn candidate_version_parser_rejects_prefix_prerelease() {
-        let actual =
-            candidate_version_from_stdout("fini 0.1.33-rc.1\n").expect("candidate version");
-        let target = Version::parse("0.1.33").expect("target version");
-
-        assert_ne!(actual, target);
-    }
-
-    #[test]
-    fn candidate_version_parser_rejects_prefix_patch_version() {
-        let actual = candidate_version_from_stdout("fini 0.1.330\n").expect("candidate version");
-        let target = Version::parse("0.1.33").expect("target version");
-
-        assert_ne!(actual, target);
-    }
-
-    #[test]
-    fn candidate_version_parser_accepts_exact_target() {
-        assert_eq!(
-            candidate_version_from_stdout("fini 0.1.33\n").expect("candidate version"),
-            Version::parse("0.1.33").expect("target version")
-        );
-    }
-
-    #[test]
-    fn select_update_plan_chooses_stable_matching_asset_and_no_change() {
-        let releases = vec![
-            GitHubRelease {
-                tag_name: "v0.1.34".to_string(),
-                draft: false,
-                prerelease: true,
-                assets: vec![GitHubAsset {
-                    name: "fini-v0.1.34-linux-x64-cli.tar.gz".to_string(),
-                    url: "https://api.github.test/assets/pre".to_string(),
-                    digest: None,
-                }],
-            },
-            GitHubRelease {
-                tag_name: "v0.1.33".to_string(),
-                draft: false,
-                prerelease: false,
-                assets: vec![GitHubAsset {
-                    name: "fini-v0.1.33-linux-x64-cli.tar.gz".to_string(),
-                    url: "https://api.github.test/assets/stable".to_string(),
-                    digest: Some("sha256:abc".to_string()),
-                }],
-            },
-        ];
-
-        let plan = select_update_plan(
-            "example/fini".to_string(),
-            "0.1.33",
-            &releases,
-            linux_x64_target(),
-            PathBuf::from("/var/tmp/fini-test-bin/fini"),
-        )
-        .expect("selected update plan");
-
-        assert!(plan.already_current);
-        assert_eq!(plan.target_tag, "v0.1.33");
-        assert_eq!(plan.asset_name, "fini-v0.1.33-linux-x64-cli.tar.gz");
-        assert_eq!(
-            plan.asset_url,
-            "https://api.github.test/assets/stable".to_string()
-        );
-    }
-
-    #[test]
-    fn select_update_plan_chooses_highest_stable_matching_asset() {
-        let releases = vec![
-            GitHubRelease {
-                tag_name: "v0.1.32".to_string(),
-                draft: false,
-                prerelease: false,
-                assets: vec![GitHubAsset {
-                    name: "fini-v0.1.32-linux-x64-cli.tar.gz".to_string(),
-                    url: "https://api.github.test/assets/old".to_string(),
-                    digest: None,
-                }],
-            },
-            GitHubRelease {
-                tag_name: "v0.1.34".to_string(),
-                draft: false,
-                prerelease: false,
-                assets: vec![GitHubAsset {
-                    name: "fini-v0.1.34-linux-x64-cli.tar.gz".to_string(),
-                    url: "https://api.github.test/assets/new".to_string(),
-                    digest: Some("sha256:def".to_string()),
-                }],
-            },
-            GitHubRelease {
-                tag_name: "v0.1.35-rc.1".to_string(),
-                draft: false,
-                prerelease: true,
-                assets: vec![GitHubAsset {
-                    name: "fini-v0.1.35-rc.1-linux-x64-cli.tar.gz".to_string(),
-                    url: "https://api.github.test/assets/pre".to_string(),
-                    digest: None,
-                }],
-            },
-        ];
-
-        let plan = select_update_plan(
-            "example/fini".to_string(),
-            "0.1.33",
-            &releases,
-            linux_x64_target(),
-            PathBuf::from("/var/tmp/fini-test-bin/fini"),
-        )
-        .expect("selected update plan");
-
-        assert!(!plan.already_current);
-        assert_eq!(plan.target_tag, "v0.1.34");
-        assert_eq!(plan.asset_name, "fini-v0.1.34-linux-x64-cli.tar.gz");
-        assert_eq!(plan.asset_url, "https://api.github.test/assets/new");
-    }
-
-    #[test]
-    fn releases_page_url_requests_bounded_pages() {
-        assert_eq!(
-            releases_page_url("example/fini", 2),
-            "https://api.github.com/repos/example/fini/releases?per_page=100&page=2"
-        );
-    }
-
-    #[test]
-    fn release_pagination_continues_only_after_full_pages() {
-        assert_eq!(next_releases_page(1, GITHUB_RELEASES_PER_PAGE), Some(2));
-        assert_eq!(next_releases_page(1, GITHUB_RELEASES_PER_PAGE - 1), None);
-        assert_eq!(
-            next_releases_page(GITHUB_RELEASES_MAX_PAGES, GITHUB_RELEASES_PER_PAGE),
-            None
-        );
-    }
-
-    #[test]
-    fn digest_verification_rejects_mismatch() {
-        let path = PathBuf::from("/var/tmp").join(format!(
-            "fini-digest-test-{}-{}",
-            std::process::id(),
-            "mismatch"
-        ));
-        fs::write(&path, b"archive").expect("write test archive");
-        let result = verify_digest(&path, Some("sha256:0000"));
-        let _ = fs::remove_file(&path);
-
-        assert!(result.is_err());
         assert!(result
-            .expect_err("digest mismatch")
-            .contains("digest mismatch"));
+            .expect_err("missing pubkey should fail")
+            .contains("missing Tauri updater public key"));
     }
 
     #[test]
-    fn non_unix_replacement_overwrites_existing_destination() {
-        let root = PathBuf::from("/var/tmp").join(format!(
-            "fini-replace-test-{}-{}",
-            std::process::id(),
-            "overwrite"
-        ));
-        fs::create_dir_all(&root).expect("create temp dir");
-        let staged = root.join("fini-update-tmp");
-        let destination = root.join("fini.exe");
-        fs::write(&staged, b"new").expect("write staged");
-        fs::write(&destination, b"old").expect("write destination");
+    #[cfg(target_os = "linux")]
+    fn tauri_updater_runtime_requires_linux_graphical_session() {
+        let display = std::env::var_os("DISPLAY");
+        let wayland_display = std::env::var_os("WAYLAND_DISPLAY");
+        std::env::remove_var("DISPLAY");
+        std::env::remove_var("WAYLAND_DISPLAY");
 
-        replace_file_non_unix(&staged, &destination).expect("replace destination");
+        let result = ensure_tauri_updater_runtime_available();
 
-        assert!(!staged.exists());
-        assert_eq!(fs::read(&destination).expect("read destination"), b"new");
-        let _ = fs::remove_dir_all(&root);
-    }
+        if let Some(display) = display {
+            std::env::set_var("DISPLAY", display);
+        }
+        if let Some(wayland_display) = wayland_display {
+            std::env::set_var("WAYLAND_DISPLAY", wayland_display);
+        }
 
-    #[test]
-    fn non_unix_replacement_cleans_staged_file_when_destination_cannot_be_removed() {
-        let root = PathBuf::from("/var/tmp").join(format!(
-            "fini-replace-test-{}-{}",
-            std::process::id(),
-            "cleanup"
-        ));
-        fs::create_dir_all(&root).expect("create temp dir");
-        let staged = root.join("fini-update-tmp");
-        let destination = root.join("fini.exe");
-        fs::write(&staged, b"new").expect("write staged");
-        fs::create_dir(&destination).expect("create blocking destination");
-
-        let result = replace_file_non_unix(&staged, &destination);
-
-        assert!(result.is_err());
-        assert!(!staged.exists());
-        assert!(destination.is_dir());
-        let _ = fs::remove_dir_all(&root);
-    }
-
-    #[test]
-    fn non_unix_replacement_detects_running_destination() {
-        let root = PathBuf::from("/var/tmp").join(format!(
-            "fini-replace-test-{}-{}",
-            std::process::id(),
-            "running"
-        ));
-        fs::create_dir_all(&root).expect("create temp dir");
-        fs::create_dir_all(root.join("nested")).expect("create nested temp dir");
-        let current = root.join("fini.exe");
-        let alias = root.join("nested").join("..").join("fini.exe");
-        let other = root.join("other.exe");
-        fs::write(&current, b"current").expect("write current");
-        fs::write(&other, b"other").expect("write other");
-
-        assert!(
-            replacement_targets_running_binary(&alias, &current).expect("compare running target")
-        );
-        assert!(
-            !replacement_targets_running_binary(&other, &current).expect("compare other target")
-        );
-        let _ = fs::remove_dir_all(&root);
-    }
-
-    #[test]
-    fn windows_replacement_script_escapes_percent_paths() {
-        let staged = PathBuf::from(r"C:\Users\example\AppData\Local\fini%20folder\fini.tmp");
-        let destination = PathBuf::from(r"C:\Users\example\.local\bin\fini.exe");
-
-        let script = windows_replacement_script(&staged, &destination);
-
-        assert!(script.contains(r"fini%%20folder"));
-        assert!(script.contains("move /Y"));
-        assert!(script.contains(r"%STAGED%"));
-        assert!(script.contains(r"%DESTINATION%"));
+        assert!(result
+            .expect_err("headless updater should fail")
+            .contains("requires a graphical Linux session"));
     }
 }

--- a/src-tauri/src/services/cli_update.rs
+++ b/src-tauri/src/services/cli_update.rs
@@ -11,6 +11,8 @@ use std::process::Command;
 
 const DEFAULT_REPO: &str = "VRuzhentsov/fini";
 const GITHUB_API: &str = "https://api.github.com";
+const GITHUB_RELEASES_PER_PAGE: usize = 100;
+const GITHUB_RELEASES_MAX_PAGES: usize = 20;
 
 #[derive(Debug, Clone)]
 pub struct UpdateOptions {
@@ -61,7 +63,7 @@ struct GitHubRelease {
 #[derive(Debug, Deserialize)]
 struct GitHubAsset {
     name: String,
-    browser_download_url: String,
+    url: String,
     digest: Option<String>,
 }
 
@@ -95,7 +97,6 @@ pub fn run_update(options: UpdateOptions) -> Result<Value, String> {
 }
 
 fn list_releases(repo: &str) -> Result<Vec<GitHubRelease>, String> {
-    let url = format!("{GITHUB_API}/repos/{repo}/releases");
     let runtime = tokio::runtime::Runtime::new()
         .map_err(|err| format!("failed to create update runtime: {err}"))?;
     runtime.block_on(async {
@@ -103,25 +104,47 @@ fn list_releases(repo: &str) -> Result<Vec<GitHubRelease>, String> {
             .default_headers(github_headers()?)
             .build()
             .map_err(|err| format!("failed to create GitHub client: {err}"))?;
-        let response = client
-            .get(url)
-            .send()
-            .await
-            .map_err(|err| format!("failed to query GitHub releases: {err}"))?;
-        if !response.status().is_success() {
-            return Err(format!(
-                "GitHub releases query failed with HTTP {}",
-                response.status()
-            ));
+        let mut releases = Vec::new();
+        let mut page = 1;
+        loop {
+            let response = client
+                .get(releases_page_url(repo, page))
+                .send()
+                .await
+                .map_err(|err| format!("failed to query GitHub releases: {err}"))?;
+            if !response.status().is_success() {
+                return Err(format!(
+                    "GitHub releases query failed with HTTP {}",
+                    response.status()
+                ));
+            }
+            let text = response
+                .text()
+                .await
+                .map_err(|err| format!("failed to read GitHub release response: {err}"))?;
+            let mut page_releases: Vec<GitHubRelease> = serde_json::from_str(&text)
+                .map_err(|err| format!("failed to parse GitHub release response: {err}"))?;
+            let fetched = page_releases.len();
+            releases.append(&mut page_releases);
+            let Some(next_page) = next_releases_page(page, fetched) else {
+                break;
+            };
+            page = next_page;
         }
-        let text = response
-            .text()
-            .await
-            .map_err(|err| format!("failed to read GitHub release response: {err}"))?;
-        let releases: Vec<GitHubRelease> = serde_json::from_str(&text)
-            .map_err(|err| format!("failed to parse GitHub release response: {err}"))?;
         Ok(releases)
     })
+}
+
+fn releases_page_url(repo: &str, page: usize) -> String {
+    format!("{GITHUB_API}/repos/{repo}/releases?per_page={GITHUB_RELEASES_PER_PAGE}&page={page}")
+}
+
+fn next_releases_page(current_page: usize, fetched: usize) -> Option<usize> {
+    if fetched < GITHUB_RELEASES_PER_PAGE || current_page >= GITHUB_RELEASES_MAX_PAGES {
+        None
+    } else {
+        Some(current_page + 1)
+    }
 }
 
 fn apply_update(plan: &UpdatePlan) -> Result<(), String> {
@@ -161,6 +184,7 @@ fn download_asset(url: &str, archive_path: &Path) -> Result<(), String> {
             .map_err(|err| format!("failed to create download client: {err}"))?;
         let response = client
             .get(url)
+            .header(ACCEPT, HeaderValue::from_static("application/octet-stream"))
             .send()
             .await
             .map_err(|err| format!("failed to download update asset: {err}"))?;
@@ -553,7 +577,7 @@ fn select_update_plan(
         current_version.to_string(),
         release.tag_name.clone(),
         asset.name.clone(),
-        asset.browser_download_url.clone(),
+        asset.url.clone(),
         asset.digest.clone(),
         install_bin,
         target,
@@ -759,7 +783,7 @@ mod tests {
                 prerelease: true,
                 assets: vec![GitHubAsset {
                     name: "fini-v0.1.34-linux-x64-cli.tar.gz".to_string(),
-                    browser_download_url: "https://example.test/pre.tar.gz".to_string(),
+                    url: "https://api.github.test/assets/pre".to_string(),
                     digest: None,
                 }],
             },
@@ -769,7 +793,7 @@ mod tests {
                 prerelease: false,
                 assets: vec![GitHubAsset {
                     name: "fini-v0.1.33-linux-x64-cli.tar.gz".to_string(),
-                    browser_download_url: "https://example.test/stable.tar.gz".to_string(),
+                    url: "https://api.github.test/assets/stable".to_string(),
                     digest: Some("sha256:abc".to_string()),
                 }],
             },
@@ -789,7 +813,7 @@ mod tests {
         assert_eq!(plan.asset_name, "fini-v0.1.33-linux-x64-cli.tar.gz");
         assert_eq!(
             plan.asset_url,
-            "https://example.test/stable.tar.gz".to_string()
+            "https://api.github.test/assets/stable".to_string()
         );
     }
 
@@ -802,7 +826,7 @@ mod tests {
                 prerelease: false,
                 assets: vec![GitHubAsset {
                     name: "fini-v0.1.32-linux-x64-cli.tar.gz".to_string(),
-                    browser_download_url: "https://example.test/old.tar.gz".to_string(),
+                    url: "https://api.github.test/assets/old".to_string(),
                     digest: None,
                 }],
             },
@@ -812,7 +836,7 @@ mod tests {
                 prerelease: false,
                 assets: vec![GitHubAsset {
                     name: "fini-v0.1.34-linux-x64-cli.tar.gz".to_string(),
-                    browser_download_url: "https://example.test/new.tar.gz".to_string(),
+                    url: "https://api.github.test/assets/new".to_string(),
                     digest: Some("sha256:def".to_string()),
                 }],
             },
@@ -822,7 +846,7 @@ mod tests {
                 prerelease: true,
                 assets: vec![GitHubAsset {
                     name: "fini-v0.1.35-rc.1-linux-x64-cli.tar.gz".to_string(),
-                    browser_download_url: "https://example.test/pre.tar.gz".to_string(),
+                    url: "https://api.github.test/assets/pre".to_string(),
                     digest: None,
                 }],
             },
@@ -840,7 +864,25 @@ mod tests {
         assert!(!plan.already_current);
         assert_eq!(plan.target_tag, "v0.1.34");
         assert_eq!(plan.asset_name, "fini-v0.1.34-linux-x64-cli.tar.gz");
-        assert_eq!(plan.asset_url, "https://example.test/new.tar.gz");
+        assert_eq!(plan.asset_url, "https://api.github.test/assets/new");
+    }
+
+    #[test]
+    fn releases_page_url_requests_bounded_pages() {
+        assert_eq!(
+            releases_page_url("example/fini", 2),
+            "https://api.github.com/repos/example/fini/releases?per_page=100&page=2"
+        );
+    }
+
+    #[test]
+    fn release_pagination_continues_only_after_full_pages() {
+        assert_eq!(next_releases_page(1, GITHUB_RELEASES_PER_PAGE), Some(2));
+        assert_eq!(next_releases_page(1, GITHUB_RELEASES_PER_PAGE - 1), None);
+        assert_eq!(
+            next_releases_page(GITHUB_RELEASES_MAX_PAGES, GITHUB_RELEASES_PER_PAGE),
+            None
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/cli_update.rs
+++ b/src-tauri/src/services/cli_update.rs
@@ -1,0 +1,590 @@
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use std::fs::{self, File};
+use std::io::{self, Cursor};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const DEFAULT_REPO: &str = "VRuzhentsov/fini";
+const GITHUB_API: &str = "https://api.github.com";
+
+#[derive(Debug, Clone)]
+pub struct UpdateOptions {
+    pub dry_run: bool,
+    pub repo: Option<String>,
+    pub install_bin: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ArchiveKind {
+    TarGz,
+    Zip,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CliAssetTarget {
+    pub os: String,
+    pub arch: String,
+    pub executable_name: String,
+    pub archive_kind: ArchiveKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdatePlan {
+    pub repo: String,
+    pub current_version: String,
+    pub target_tag: String,
+    pub target_version: String,
+    pub asset_name: String,
+    pub asset_url: String,
+    pub asset_digest: Option<String>,
+    pub install_dir: PathBuf,
+    pub install_bin: PathBuf,
+    pub target_binary: PathBuf,
+    pub already_current: bool,
+    archive_kind: ArchiveKind,
+    executable_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubRelease {
+    tag_name: String,
+    draft: bool,
+    prerelease: bool,
+    assets: Vec<GitHubAsset>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubAsset {
+    name: String,
+    browser_download_url: String,
+    digest: Option<String>,
+}
+
+pub fn run_update(options: UpdateOptions) -> Result<Value, String> {
+    let repo = options
+        .repo
+        .or_else(|| std::env::var("FINI_UPDATE_REPO").ok())
+        .unwrap_or_else(|| DEFAULT_REPO.to_string());
+    validate_repo(&repo)?;
+
+    let target = current_cli_asset_target()?;
+    let install_bin = options
+        .install_bin
+        .or_else(|| std::env::var_os("FINI_UPDATE_BIN_PATH").map(PathBuf::from))
+        .unwrap_or_else(default_install_bin);
+    let releases = list_releases(&repo)?;
+    let plan = select_update_plan(
+        repo,
+        env!("CARGO_PKG_VERSION"),
+        &releases,
+        target,
+        install_bin,
+    )?;
+
+    if options.dry_run || plan.already_current {
+        return Ok(plan_json(&plan, options.dry_run, false));
+    }
+
+    apply_update(&plan)?;
+    Ok(plan_json(&plan, false, true))
+}
+
+fn list_releases(repo: &str) -> Result<Vec<GitHubRelease>, String> {
+    let url = format!("{GITHUB_API}/repos/{repo}/releases");
+    let runtime = tokio::runtime::Runtime::new()
+        .map_err(|err| format!("failed to create update runtime: {err}"))?;
+    runtime.block_on(async {
+        let mut headers = HeaderMap::new();
+        headers.insert(USER_AGENT, HeaderValue::from_static("fini-cli-updater"));
+        headers.insert(
+            ACCEPT,
+            HeaderValue::from_static("application/vnd.github+json"),
+        );
+        if let Ok(token) = std::env::var("GH_TOKEN") {
+            if !token.trim().is_empty() {
+                let value = HeaderValue::from_str(&format!("Bearer {}", token.trim()))
+                    .map_err(|err| format!("invalid GH_TOKEN for GitHub API: {err}"))?;
+                headers.insert(AUTHORIZATION, value);
+            }
+        }
+
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()
+            .map_err(|err| format!("failed to create GitHub client: {err}"))?;
+        let response = client
+            .get(url)
+            .send()
+            .await
+            .map_err(|err| format!("failed to query GitHub releases: {err}"))?;
+        if !response.status().is_success() {
+            return Err(format!(
+                "GitHub releases query failed with HTTP {}",
+                response.status()
+            ));
+        }
+        let text = response
+            .text()
+            .await
+            .map_err(|err| format!("failed to read GitHub release response: {err}"))?;
+        let releases: Vec<GitHubRelease> = serde_json::from_str(&text)
+            .map_err(|err| format!("failed to parse GitHub release response: {err}"))?;
+        Ok(releases)
+    })
+}
+
+fn apply_update(plan: &UpdatePlan) -> Result<(), String> {
+    let staging_dir = plan.install_dir.join(".download");
+    if staging_dir.exists() {
+        fs::remove_dir_all(&staging_dir)
+            .map_err(|err| format!("failed to clear update staging dir: {err}"))?;
+    }
+    fs::create_dir_all(&staging_dir)
+        .map_err(|err| format!("failed to create update staging dir: {err}"))?;
+    fs::create_dir_all(&plan.install_dir)
+        .map_err(|err| format!("failed to create install dir: {err}"))?;
+
+    let archive_path = staging_dir.join(&plan.asset_name);
+    download_asset(&plan.asset_url, &archive_path)?;
+    verify_digest(&archive_path, plan.asset_digest.as_deref())?;
+    extract_binary(
+        &archive_path,
+        &plan.target_binary,
+        &plan.archive_kind,
+        &plan.executable_name,
+    )?;
+    verify_candidate_binary(&plan.target_binary, &plan.target_version)?;
+    activate_binary(&plan.target_binary, &plan.install_bin)?;
+    fs::remove_dir_all(&staging_dir)
+        .map_err(|err| format!("failed to remove update staging dir: {err}"))?;
+    Ok(())
+}
+
+fn download_asset(url: &str, archive_path: &Path) -> Result<(), String> {
+    let runtime = tokio::runtime::Runtime::new()
+        .map_err(|err| format!("failed to create download runtime: {err}"))?;
+    let bytes = runtime.block_on(async {
+        let client = reqwest::Client::builder()
+            .user_agent("fini-cli-updater")
+            .build()
+            .map_err(|err| format!("failed to create download client: {err}"))?;
+        let response = client
+            .get(url)
+            .send()
+            .await
+            .map_err(|err| format!("failed to download update asset: {err}"))?;
+        if !response.status().is_success() {
+            return Err(format!(
+                "release asset download failed with HTTP {}",
+                response.status()
+            ));
+        }
+        response
+            .bytes()
+            .await
+            .map_err(|err| format!("failed to read update asset: {err}"))
+    })?;
+    fs::write(archive_path, bytes)
+        .map_err(|err| format!("failed to write update archive: {err}"))?;
+    Ok(())
+}
+
+fn verify_digest(archive_path: &Path, expected: Option<&str>) -> Result<(), String> {
+    let Some(expected) = expected else {
+        return Ok(());
+    };
+    let expected = expected
+        .strip_prefix("sha256:")
+        .unwrap_or(expected)
+        .to_ascii_lowercase();
+    let bytes = fs::read(archive_path)
+        .map_err(|err| format!("failed to read update archive for digest check: {err}"))?;
+    let actual = format!("{:x}", Sha256::digest(&bytes));
+    if actual != expected {
+        return Err(format!(
+            "update archive digest mismatch: expected {expected}, got {actual}"
+        ));
+    }
+    Ok(())
+}
+
+fn extract_binary(
+    archive_path: &Path,
+    target_binary: &Path,
+    archive_kind: &ArchiveKind,
+    executable_name: &str,
+) -> Result<(), String> {
+    let parent = target_binary
+        .parent()
+        .ok_or_else(|| "target binary path has no parent directory".to_string())?;
+    fs::create_dir_all(parent).map_err(|err| format!("failed to create install dir: {err}"))?;
+
+    match archive_kind {
+        ArchiveKind::TarGz => extract_tar_gz_binary(archive_path, target_binary, executable_name)?,
+        ArchiveKind::Zip => extract_zip_binary(archive_path, target_binary, executable_name)?,
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = fs::metadata(target_binary)
+            .map_err(|err| format!("failed to inspect extracted binary: {err}"))?
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(target_binary, permissions)
+            .map_err(|err| format!("failed to mark extracted binary executable: {err}"))?;
+    }
+
+    Ok(())
+}
+
+fn extract_tar_gz_binary(
+    archive_path: &Path,
+    target_binary: &Path,
+    executable_name: &str,
+) -> Result<(), String> {
+    let file = File::open(archive_path).map_err(|err| format!("failed to open archive: {err}"))?;
+    let decoder = flate2::read::GzDecoder::new(file);
+    let mut archive = tar::Archive::new(decoder);
+    for entry in archive
+        .entries()
+        .map_err(|err| format!("failed to read tar archive: {err}"))?
+    {
+        let mut entry = entry.map_err(|err| format!("failed to read tar entry: {err}"))?;
+        let path = entry
+            .path()
+            .map_err(|err| format!("failed to inspect tar entry path: {err}"))?;
+        if path.file_name().and_then(|name| name.to_str()) == Some(executable_name) {
+            let mut output = File::create(target_binary)
+                .map_err(|err| format!("failed to create target binary: {err}"))?;
+            io::copy(&mut entry, &mut output)
+                .map_err(|err| format!("failed to extract CLI binary: {err}"))?;
+            return Ok(());
+        }
+    }
+    Err(format!("archive does not contain {executable_name}"))
+}
+
+fn extract_zip_binary(
+    archive_path: &Path,
+    target_binary: &Path,
+    executable_name: &str,
+) -> Result<(), String> {
+    let bytes = fs::read(archive_path).map_err(|err| format!("failed to open archive: {err}"))?;
+    let reader = Cursor::new(bytes);
+    let mut archive =
+        zip::ZipArchive::new(reader).map_err(|err| format!("failed to read zip archive: {err}"))?;
+    for index in 0..archive.len() {
+        let mut file = archive
+            .by_index(index)
+            .map_err(|err| format!("failed to read zip entry: {err}"))?;
+        let name = Path::new(file.name())
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default()
+            .to_string();
+        if name == executable_name {
+            let mut output = File::create(target_binary)
+                .map_err(|err| format!("failed to create target binary: {err}"))?;
+            io::copy(&mut file, &mut output)
+                .map_err(|err| format!("failed to extract CLI binary: {err}"))?;
+            return Ok(());
+        }
+    }
+    Err(format!("archive does not contain {executable_name}"))
+}
+
+fn verify_candidate_binary(binary: &Path, target_version: &str) -> Result<(), String> {
+    let output = Command::new(binary)
+        .arg("--version")
+        .output()
+        .map_err(|err| format!("failed to run extracted CLI binary: {err}"))?;
+    if !output.status.success() {
+        return Err("extracted CLI binary failed minimal version check".to_string());
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if !stdout.contains(target_version) {
+        return Err(format!(
+            "extracted CLI version check failed: expected {target_version}, got {}",
+            stdout.trim()
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn activate_binary(target_binary: &Path, install_bin: &Path) -> Result<(), String> {
+    use std::os::unix::fs::symlink;
+    let parent = install_bin
+        .parent()
+        .ok_or_else(|| "install path has no parent directory".to_string())?;
+    fs::create_dir_all(parent).map_err(|err| format!("failed to create bin dir: {err}"))?;
+    let tmp_link = install_bin.with_extension("fini-update-tmp");
+    if tmp_link.exists() {
+        fs::remove_file(&tmp_link)
+            .map_err(|err| format!("failed to remove stale update link: {err}"))?;
+    }
+    symlink(target_binary, &tmp_link)
+        .map_err(|err| format!("failed to create update symlink: {err}"))?;
+    fs::rename(&tmp_link, install_bin)
+        .map_err(|err| format!("failed to activate updated CLI binary: {err}"))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn activate_binary(target_binary: &Path, install_bin: &Path) -> Result<(), String> {
+    let parent = install_bin
+        .parent()
+        .ok_or_else(|| "install path has no parent directory".to_string())?;
+    fs::create_dir_all(parent).map_err(|err| format!("failed to create bin dir: {err}"))?;
+    let tmp_bin = install_bin.with_extension("fini-update-tmp");
+    fs::copy(target_binary, &tmp_bin)
+        .map_err(|err| format!("failed to stage updated CLI binary: {err}"))?;
+    fs::rename(&tmp_bin, install_bin)
+        .map_err(|err| format!("failed to activate updated CLI binary: {err}"))?;
+    Ok(())
+}
+
+fn build_update_plan(
+    repo: String,
+    current_version: String,
+    target_tag: String,
+    asset_name: String,
+    asset_url: String,
+    asset_digest: Option<String>,
+    install_bin: PathBuf,
+    target: CliAssetTarget,
+) -> Result<UpdatePlan, String> {
+    let target_version = target_tag
+        .strip_prefix('v')
+        .unwrap_or(&target_tag)
+        .to_string();
+    let install_root = default_install_root()?;
+    let install_dir = install_root.join(&target_tag);
+    let target_binary = install_dir.join(&target.executable_name);
+    Ok(UpdatePlan {
+        repo,
+        already_current: current_version == target_version,
+        current_version,
+        target_tag,
+        target_version,
+        asset_name,
+        asset_url,
+        asset_digest,
+        install_dir,
+        install_bin,
+        target_binary,
+        archive_kind: target.archive_kind,
+        executable_name: target.executable_name,
+    })
+}
+
+fn select_update_plan(
+    repo: String,
+    current_version: &str,
+    releases: &[GitHubRelease],
+    target: CliAssetTarget,
+    install_bin: PathBuf,
+) -> Result<UpdatePlan, String> {
+    let release = releases
+        .iter()
+        .find(|release| !release.draft && !release.prerelease)
+        .ok_or_else(|| "no stable GitHub release found".to_string())?;
+    let asset_name = cli_asset_name(&release.tag_name, &target);
+    let asset = release
+        .assets
+        .iter()
+        .find(|asset| asset.name == asset_name)
+        .ok_or_else(|| format!("release {} does not include {asset_name}", release.tag_name))?;
+
+    build_update_plan(
+        repo,
+        current_version.to_string(),
+        release.tag_name.clone(),
+        asset.name.clone(),
+        asset.browser_download_url.clone(),
+        asset.digest.clone(),
+        install_bin,
+        target,
+    )
+}
+
+pub fn cli_asset_name(tag: &str, target: &CliAssetTarget) -> String {
+    let extension = match target.archive_kind {
+        ArchiveKind::TarGz => "tar.gz",
+        ArchiveKind::Zip => "zip",
+    };
+    format!("fini-{tag}-{}-{}-cli.{extension}", target.os, target.arch)
+}
+
+pub fn current_cli_asset_target() -> Result<CliAssetTarget, String> {
+    cli_asset_target(std::env::consts::OS, std::env::consts::ARCH)
+}
+
+pub fn cli_asset_target(os: &str, arch: &str) -> Result<CliAssetTarget, String> {
+    let arch = match arch {
+        "x86_64" => "x64",
+        "aarch64" => "arm64",
+        other => return Err(format!("unsupported CLI update architecture: {other}")),
+    };
+    match os {
+        "linux" => Ok(CliAssetTarget {
+            os: "linux".to_string(),
+            arch: arch.to_string(),
+            executable_name: "fini".to_string(),
+            archive_kind: ArchiveKind::TarGz,
+        }),
+        "windows" => Ok(CliAssetTarget {
+            os: "windows".to_string(),
+            arch: arch.to_string(),
+            executable_name: "fini.exe".to_string(),
+            archive_kind: ArchiveKind::Zip,
+        }),
+        other => Err(format!("unsupported CLI update OS: {other}")),
+    }
+}
+
+fn validate_repo(repo: &str) -> Result<(), String> {
+    let parts: Vec<_> = repo.split('/').collect();
+    if parts.len() != 2 || parts.iter().any(|part| part.is_empty()) {
+        return Err("update repo must use owner/name format".to_string());
+    }
+    Ok(())
+}
+
+fn default_install_root() -> Result<PathBuf, String> {
+    dirs::home_dir()
+        .map(|home| home.join(".local/lib/fini"))
+        .ok_or_else(|| "could not determine home directory for CLI install".to_string())
+}
+
+fn default_install_bin() -> PathBuf {
+    dirs::home_dir()
+        .map(|home| home.join(".local/bin/fini"))
+        .unwrap_or_else(|| PathBuf::from("fini"))
+}
+
+fn plan_json(plan: &UpdatePlan, dry_run: bool, updated: bool) -> Value {
+    json!({
+        "current_version": plan.current_version,
+        "target_version": plan.target_version,
+        "target_tag": plan.target_tag,
+        "repo": plan.repo,
+        "asset": plan.asset_name,
+        "asset_digest": plan.asset_digest,
+        "install_dir": plan.install_dir,
+        "install_bin": plan.install_bin,
+        "dry_run": dry_run,
+        "already_current": plan.already_current,
+        "updated": updated,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn linux_x64_target() -> CliAssetTarget {
+        cli_asset_target("linux", "x86_64").expect("linux x64 target")
+    }
+
+    #[test]
+    fn cli_asset_name_uses_release_archive_contract() {
+        assert_eq!(
+            cli_asset_name("v0.1.33", &linux_x64_target()),
+            "fini-v0.1.33-linux-x64-cli.tar.gz"
+        );
+        let windows = cli_asset_target("windows", "aarch64").expect("windows arm64 target");
+        assert_eq!(
+            cli_asset_name("v0.1.33", &windows),
+            "fini-v0.1.33-windows-arm64-cli.zip"
+        );
+    }
+
+    #[test]
+    fn update_plan_marks_matching_version_current() {
+        let plan = build_update_plan(
+            "example/fini".to_string(),
+            "0.1.33".to_string(),
+            "v0.1.33".to_string(),
+            "fini-v0.1.33-linux-x64-cli.tar.gz".to_string(),
+            "https://example.test/fini.tar.gz".to_string(),
+            Some("sha256:abc".to_string()),
+            PathBuf::from("/var/tmp/fini-test-bin/fini"),
+            linux_x64_target(),
+        )
+        .expect("plan");
+
+        assert!(plan.already_current);
+        assert_eq!(plan.target_version, "0.1.33");
+        assert_eq!(
+            plan.target_binary,
+            dirs::home_dir()
+                .expect("home")
+                .join(".local/lib/fini/v0.1.33/fini")
+        );
+    }
+
+    #[test]
+    fn select_update_plan_chooses_stable_matching_asset_and_no_change() {
+        let releases = vec![
+            GitHubRelease {
+                tag_name: "v0.1.34".to_string(),
+                draft: false,
+                prerelease: true,
+                assets: vec![GitHubAsset {
+                    name: "fini-v0.1.34-linux-x64-cli.tar.gz".to_string(),
+                    browser_download_url: "https://example.test/pre.tar.gz".to_string(),
+                    digest: None,
+                }],
+            },
+            GitHubRelease {
+                tag_name: "v0.1.33".to_string(),
+                draft: false,
+                prerelease: false,
+                assets: vec![GitHubAsset {
+                    name: "fini-v0.1.33-linux-x64-cli.tar.gz".to_string(),
+                    browser_download_url: "https://example.test/stable.tar.gz".to_string(),
+                    digest: Some("sha256:abc".to_string()),
+                }],
+            },
+        ];
+
+        let plan = select_update_plan(
+            "example/fini".to_string(),
+            "0.1.33",
+            &releases,
+            linux_x64_target(),
+            PathBuf::from("/var/tmp/fini-test-bin/fini"),
+        )
+        .expect("selected update plan");
+
+        assert!(plan.already_current);
+        assert_eq!(plan.target_tag, "v0.1.33");
+        assert_eq!(plan.asset_name, "fini-v0.1.33-linux-x64-cli.tar.gz");
+        assert_eq!(
+            plan.asset_url,
+            "https://example.test/stable.tar.gz".to_string()
+        );
+    }
+
+    #[test]
+    fn digest_verification_rejects_mismatch() {
+        let path = PathBuf::from("/var/tmp").join(format!(
+            "fini-digest-test-{}-{}",
+            std::process::id(),
+            "mismatch"
+        ));
+        fs::write(&path, b"archive").expect("write test archive");
+        let result = verify_digest(&path, Some("sha256:0000"));
+        let _ = fs::remove_file(&path);
+
+        assert!(result.is_err());
+        assert!(result
+            .expect_err("digest mismatch")
+            .contains("digest mismatch"));
+    }
+}

--- a/src-tauri/src/services/cli_update.rs
+++ b/src-tauri/src/services/cli_update.rs
@@ -40,19 +40,13 @@ pub fn run_update(options: UpdateOptions) -> Result<Value, String> {
     let runtime = tokio::runtime::Runtime::new()
         .map_err(|err| format!("failed to create update runtime: {err}"))?;
     runtime.block_on(async move {
-        let mut builder = app_handle
+        let builder = app_handle
             .updater_builder()
             .target(config.target.clone())
             .pubkey(config.pubkey.clone())
             .endpoints(vec![config.endpoint.clone()])
             .map_err(|err| format!("failed to configure updater endpoint: {err}"))?
             .executable_path(&config.executable_path);
-
-        if let Some(token) = github_token_for_endpoint(&config.endpoint) {
-            builder = builder
-                .header("Authorization", format!("Bearer {token}"))
-                .map_err(|err| format!("failed to configure updater auth header: {err}"))?;
-        }
 
         let updater = builder
             .build()
@@ -134,22 +128,6 @@ fn default_cli_update_target() -> Result<String, String> {
         .ok_or_else(|| "CLI updates are not supported on this platform".to_string())
 }
 
-fn github_token_for_endpoint(endpoint: &Url) -> Option<String> {
-    if !is_trusted_github_update_endpoint(endpoint) {
-        return None;
-    }
-
-    std::env::var("GH_TOKEN")
-        .ok()
-        .map(|token| token.trim().to_string())
-        .filter(|token| !token.is_empty())
-}
-
-fn is_trusted_github_update_endpoint(endpoint: &Url) -> bool {
-    endpoint.scheme() == "https"
-        && matches!(endpoint.host_str(), Some("github.com" | "api.github.com"))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -204,32 +182,27 @@ mod tests {
     }
 
     #[test]
-    fn github_token_is_only_used_for_trusted_github_update_endpoints() {
+    fn github_token_does_not_affect_cli_update_config() {
         let _guard = ENV_LOCK.lock().expect("env lock poisoned");
         let previous = std::env::var_os("GH_TOKEN");
         std::env::set_var("GH_TOKEN", " test-token ");
 
-        let github_endpoint = Url::parse(
-            "https://github.com/VRuzhentsov/fini/releases/latest/download/latest-cli.json",
-        )
-        .expect("valid GitHub endpoint");
-        let api_endpoint = Url::parse("https://api.github.com/repos/VRuzhentsov/fini/releases")
-            .expect("valid GitHub API endpoint");
-        let custom_endpoint =
-            Url::parse("https://updates.example.test/latest-cli.json").expect("valid endpoint");
-        let insecure_endpoint =
-            Url::parse("http://github.com/VRuzhentsov/fini/latest-cli.json").expect("valid URL");
+        let config = resolve_update_config(UpdateOptions {
+            dry_run: true,
+            endpoint: Some(
+                "https://github.com/VRuzhentsov/fini/releases/latest/download/latest-cli.json"
+                    .to_string(),
+            ),
+            pubkey: Some("test-public-key".to_string()),
+            target: Some("cli-linux-x86_64".to_string()),
+            executable_path: Some(PathBuf::from("/var/tmp/fini-test-bin")),
+        })
+        .expect("resolved update config");
 
         assert_eq!(
-            github_token_for_endpoint(&github_endpoint).as_deref(),
-            Some("test-token")
+            config.endpoint.as_str(),
+            "https://github.com/VRuzhentsov/fini/releases/latest/download/latest-cli.json"
         );
-        assert_eq!(
-            github_token_for_endpoint(&api_endpoint).as_deref(),
-            Some("test-token")
-        );
-        assert_eq!(github_token_for_endpoint(&custom_endpoint), None);
-        assert_eq!(github_token_for_endpoint(&insecure_endpoint), None);
 
         match previous {
             Some(value) => std::env::set_var("GH_TOKEN", value),

--- a/src-tauri/src/services/cli_update.rs
+++ b/src-tauri/src/services/cli_update.rs
@@ -364,6 +364,9 @@ fn activate_binary(target_binary: &Path, install_bin: &Path) -> Result<(), Strin
 #[cfg(any(not(unix), test))]
 fn replace_file_non_unix(staged: &Path, destination: &Path) -> Result<(), String> {
     if destination.exists() {
+        if should_defer_non_unix_replacement(destination)? {
+            return schedule_deferred_non_unix_replacement(staged, destination);
+        }
         if let Err(err) = fs::remove_file(destination) {
             let _ = fs::remove_file(staged);
             return Err(format!("failed to replace existing CLI binary: {err}"));
@@ -374,6 +377,84 @@ fn replace_file_non_unix(staged: &Path, destination: &Path) -> Result<(), String
         return Err(format!("failed to activate updated CLI binary: {err}"));
     }
     Ok(())
+}
+
+#[cfg(any(not(unix), test))]
+fn should_defer_non_unix_replacement(destination: &Path) -> Result<bool, String> {
+    let current_exe = std::env::current_exe()
+        .map_err(|err| format!("failed to resolve current CLI binary: {err}"))?;
+    replacement_targets_running_binary(destination, &current_exe)
+}
+
+#[cfg(any(not(unix), test))]
+fn replacement_targets_running_binary(
+    destination: &Path,
+    current_exe: &Path,
+) -> Result<bool, String> {
+    let destination = destination
+        .canonicalize()
+        .map_err(|err| format!("failed to resolve existing CLI binary: {err}"))?;
+    let current_exe = current_exe
+        .canonicalize()
+        .map_err(|err| format!("failed to resolve current CLI binary: {err}"))?;
+    Ok(destination == current_exe)
+}
+
+#[cfg(windows)]
+fn schedule_deferred_non_unix_replacement(staged: &Path, destination: &Path) -> Result<(), String> {
+    let script = destination.with_extension("fini-update.cmd");
+    let content = windows_replacement_script(staged, destination);
+    fs::write(&script, content)
+        .map_err(|err| format!("failed to write deferred CLI replacement helper: {err}"))?;
+    Command::new("cmd")
+        .args(["/C", "start", "", "/min"])
+        .arg(&script)
+        .spawn()
+        .map_err(|err| format!("failed to start deferred CLI replacement helper: {err}"))?;
+    Ok(())
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn schedule_deferred_non_unix_replacement(
+    staged: &Path,
+    _destination: &Path,
+) -> Result<(), String> {
+    let _ = fs::remove_file(staged);
+    Err("cannot replace the running CLI binary on this platform".to_string())
+}
+
+#[cfg(all(test, not(windows)))]
+fn schedule_deferred_non_unix_replacement(
+    _staged: &Path,
+    _destination: &Path,
+) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(any(windows, test))]
+fn windows_replacement_script(staged: &Path, destination: &Path) -> String {
+    let staged = batch_literal(staged);
+    let destination = batch_literal(destination);
+    format!(
+        "@echo off\r\n\
+         setlocal\r\n\
+         set \"STAGED={staged}\"\r\n\
+         set \"DESTINATION={destination}\"\r\n\
+         for /l %%i in (1,1,30) do (\r\n\
+         \u{20} move /Y \"%STAGED%\" \"%DESTINATION%\" >nul 2>nul\r\n\
+         \u{20} if not exist \"%STAGED%\" (\r\n\
+         \u{20}\u{20} del \"%~f0\" >nul 2>nul\r\n\
+         \u{20}\u{20} exit /b 0\r\n\
+         \u{20} )\r\n\
+         \u{20} timeout /t 1 /nobreak >nul\r\n\
+         )\r\n\
+         exit /b 1\r\n"
+    )
+}
+
+#[cfg(any(windows, test))]
+fn batch_literal(path: &Path) -> String {
+    path.to_string_lossy().replace('%', "%%")
 }
 
 fn build_update_plan(
@@ -680,5 +761,42 @@ mod tests {
         assert!(!staged.exists());
         assert!(destination.is_dir());
         let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn non_unix_replacement_detects_running_destination() {
+        let root = PathBuf::from("/var/tmp").join(format!(
+            "fini-replace-test-{}-{}",
+            std::process::id(),
+            "running"
+        ));
+        fs::create_dir_all(&root).expect("create temp dir");
+        fs::create_dir_all(root.join("nested")).expect("create nested temp dir");
+        let current = root.join("fini.exe");
+        let alias = root.join("nested").join("..").join("fini.exe");
+        let other = root.join("other.exe");
+        fs::write(&current, b"current").expect("write current");
+        fs::write(&other, b"other").expect("write other");
+
+        assert!(
+            replacement_targets_running_binary(&alias, &current).expect("compare running target")
+        );
+        assert!(
+            !replacement_targets_running_binary(&other, &current).expect("compare other target")
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn windows_replacement_script_escapes_percent_paths() {
+        let staged = PathBuf::from(r"C:\Users\example\AppData\Local\fini%20folder\fini.tmp");
+        let destination = PathBuf::from(r"C:\Users\example\.local\bin\fini.exe");
+
+        let script = windows_replacement_script(&staged, &destination);
+
+        assert!(script.contains(r"fini%%20folder"));
+        assert!(script.contains("move /Y"));
+        assert!(script.contains(r"%STAGED%"));
+        assert!(script.contains(r"%DESTINATION%"));
     }
 }

--- a/src-tauri/src/services/cli_update.rs
+++ b/src-tauri/src/services/cli_update.rs
@@ -316,13 +316,28 @@ fn verify_candidate_binary(binary: &Path, target_version: &str) -> Result<(), St
         return Err("extracted CLI binary failed minimal version check".to_string());
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
-    if !stdout.contains(target_version) {
+    let actual_version = candidate_version_from_stdout(&stdout)?;
+    let expected_version = Version::parse(target_version)
+        .map_err(|err| format!("failed to parse target CLI version {target_version}: {err}"))?;
+    if actual_version != expected_version {
         return Err(format!(
             "extracted CLI version check failed: expected {target_version}, got {}",
             stdout.trim()
         ));
     }
     Ok(())
+}
+
+fn candidate_version_from_stdout(stdout: &str) -> Result<Version, String> {
+    stdout
+        .split_whitespace()
+        .find_map(|part| Version::parse(part.trim_start_matches('v')).ok())
+        .ok_or_else(|| {
+            format!(
+                "extracted CLI version check failed: could not parse version from {}",
+                stdout.trim()
+            )
+        })
 }
 
 #[cfg(unix)]
@@ -707,6 +722,31 @@ mod tests {
         assert_eq!(
             result.expect_err("older target rejected"),
             "refusing to downgrade CLI from 0.1.34-rc.1 to 0.1.33"
+        );
+    }
+
+    #[test]
+    fn candidate_version_parser_rejects_prefix_prerelease() {
+        let actual =
+            candidate_version_from_stdout("fini 0.1.33-rc.1\n").expect("candidate version");
+        let target = Version::parse("0.1.33").expect("target version");
+
+        assert_ne!(actual, target);
+    }
+
+    #[test]
+    fn candidate_version_parser_rejects_prefix_patch_version() {
+        let actual = candidate_version_from_stdout("fini 0.1.330\n").expect("candidate version");
+        let target = Version::parse("0.1.33").expect("target version");
+
+        assert_ne!(actual, target);
+    }
+
+    #[test]
+    fn candidate_version_parser_accepts_exact_target() {
+        assert_eq!(
+            candidate_version_from_stdout("fini 0.1.33\n").expect("candidate version"),
+            Version::parse("0.1.33").expect("target version")
         );
     }
 

--- a/src-tauri/src/services/cli_update.rs
+++ b/src-tauri/src/services/cli_update.rs
@@ -341,10 +341,30 @@ fn activate_binary(target_binary: &Path, install_bin: &Path) -> Result<(), Strin
         .ok_or_else(|| "install path has no parent directory".to_string())?;
     fs::create_dir_all(parent).map_err(|err| format!("failed to create bin dir: {err}"))?;
     let tmp_bin = install_bin.with_extension("fini-update-tmp");
-    fs::copy(target_binary, &tmp_bin)
-        .map_err(|err| format!("failed to stage updated CLI binary: {err}"))?;
-    fs::rename(&tmp_bin, install_bin)
-        .map_err(|err| format!("failed to activate updated CLI binary: {err}"))?;
+    if tmp_bin.exists() {
+        fs::remove_file(&tmp_bin)
+            .map_err(|err| format!("failed to remove stale staged CLI binary: {err}"))?;
+    }
+    if let Err(err) = fs::copy(target_binary, &tmp_bin) {
+        let _ = fs::remove_file(&tmp_bin);
+        return Err(format!("failed to stage updated CLI binary: {err}"));
+    }
+    replace_file_non_unix(&tmp_bin, install_bin)?;
+    Ok(())
+}
+
+#[cfg(any(not(unix), test))]
+fn replace_file_non_unix(staged: &Path, destination: &Path) -> Result<(), String> {
+    if destination.exists() {
+        if let Err(err) = fs::remove_file(destination) {
+            let _ = fs::remove_file(staged);
+            return Err(format!("failed to replace existing CLI binary: {err}"));
+        }
+    }
+    if let Err(err) = fs::rename(staged, destination) {
+        let _ = fs::remove_file(staged);
+        return Err(format!("failed to activate updated CLI binary: {err}"));
+    }
     Ok(())
 }
 
@@ -586,5 +606,46 @@ mod tests {
         assert!(result
             .expect_err("digest mismatch")
             .contains("digest mismatch"));
+    }
+
+    #[test]
+    fn non_unix_replacement_overwrites_existing_destination() {
+        let root = PathBuf::from("/var/tmp").join(format!(
+            "fini-replace-test-{}-{}",
+            std::process::id(),
+            "overwrite"
+        ));
+        fs::create_dir_all(&root).expect("create temp dir");
+        let staged = root.join("fini-update-tmp");
+        let destination = root.join("fini.exe");
+        fs::write(&staged, b"new").expect("write staged");
+        fs::write(&destination, b"old").expect("write destination");
+
+        replace_file_non_unix(&staged, &destination).expect("replace destination");
+
+        assert!(!staged.exists());
+        assert_eq!(fs::read(&destination).expect("read destination"), b"new");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn non_unix_replacement_cleans_staged_file_when_destination_cannot_be_removed() {
+        let root = PathBuf::from("/var/tmp").join(format!(
+            "fini-replace-test-{}-{}",
+            std::process::id(),
+            "cleanup"
+        ));
+        fs::create_dir_all(&root).expect("create temp dir");
+        let staged = root.join("fini-update-tmp");
+        let destination = root.join("fini.exe");
+        fs::write(&staged, b"new").expect("write staged");
+        fs::create_dir(&destination).expect("create blocking destination");
+
+        let result = replace_file_non_unix(&staged, &destination);
+
+        assert!(result.is_err());
+        assert!(!staged.exists());
+        assert!(destination.is_dir());
+        let _ = fs::remove_dir_all(&root);
     }
 }

--- a/src-tauri/src/services/cli_update.rs
+++ b/src-tauri/src/services/cli_update.rs
@@ -26,7 +26,6 @@ struct CliUpdateConfig {
 
 pub fn run_update(options: UpdateOptions) -> Result<Value, String> {
     let config = resolve_update_config(options.clone())?;
-    ensure_tauri_updater_runtime_available()?;
     let app = tauri::Builder::default()
         .plugin(
             tauri_plugin_updater::Builder::new()
@@ -49,7 +48,7 @@ pub fn run_update(options: UpdateOptions) -> Result<Value, String> {
             .map_err(|err| format!("failed to configure updater endpoint: {err}"))?
             .executable_path(&config.executable_path);
 
-        if let Some(token) = github_token() {
+        if let Some(token) = github_token_for_endpoint(&config.endpoint) {
             builder = builder
                 .header("Authorization", format!("Bearer {token}"))
                 .map_err(|err| format!("failed to configure updater auth header: {err}"))?;
@@ -135,28 +134,27 @@ fn default_cli_update_target() -> Result<String, String> {
         .ok_or_else(|| "CLI updates are not supported on this platform".to_string())
 }
 
-fn github_token() -> Option<String> {
+fn github_token_for_endpoint(endpoint: &Url) -> Option<String> {
+    if !is_trusted_github_update_endpoint(endpoint) {
+        return None;
+    }
+
     std::env::var("GH_TOKEN")
         .ok()
         .map(|token| token.trim().to_string())
         .filter(|token| !token.is_empty())
 }
 
-fn ensure_tauri_updater_runtime_available() -> Result<(), String> {
-    #[cfg(target_os = "linux")]
-    {
-        if std::env::var_os("DISPLAY").is_none() && std::env::var_os("WAYLAND_DISPLAY").is_none() {
-            return Err(
-                "Tauri's built-in updater requires a graphical Linux session; set DISPLAY or WAYLAND_DISPLAY before running fini update".to_string(),
-            );
-        }
-    }
-    Ok(())
+fn is_trusted_github_update_endpoint(endpoint: &Url) -> bool {
+    endpoint.scheme() == "https"
+        && matches!(endpoint.host_str(), Some("github.com" | "api.github.com"))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     #[test]
     fn default_cli_target_prefixes_tauri_target() {
@@ -206,24 +204,36 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_os = "linux")]
-    fn tauri_updater_runtime_requires_linux_graphical_session() {
-        let display = std::env::var_os("DISPLAY");
-        let wayland_display = std::env::var_os("WAYLAND_DISPLAY");
-        std::env::remove_var("DISPLAY");
-        std::env::remove_var("WAYLAND_DISPLAY");
+    fn github_token_is_only_used_for_trusted_github_update_endpoints() {
+        let _guard = ENV_LOCK.lock().expect("env lock poisoned");
+        let previous = std::env::var_os("GH_TOKEN");
+        std::env::set_var("GH_TOKEN", " test-token ");
 
-        let result = ensure_tauri_updater_runtime_available();
+        let github_endpoint = Url::parse(
+            "https://github.com/VRuzhentsov/fini/releases/latest/download/latest-cli.json",
+        )
+        .expect("valid GitHub endpoint");
+        let api_endpoint = Url::parse("https://api.github.com/repos/VRuzhentsov/fini/releases")
+            .expect("valid GitHub API endpoint");
+        let custom_endpoint =
+            Url::parse("https://updates.example.test/latest-cli.json").expect("valid endpoint");
+        let insecure_endpoint =
+            Url::parse("http://github.com/VRuzhentsov/fini/latest-cli.json").expect("valid URL");
 
-        if let Some(display) = display {
-            std::env::set_var("DISPLAY", display);
+        assert_eq!(
+            github_token_for_endpoint(&github_endpoint).as_deref(),
+            Some("test-token")
+        );
+        assert_eq!(
+            github_token_for_endpoint(&api_endpoint).as_deref(),
+            Some("test-token")
+        );
+        assert_eq!(github_token_for_endpoint(&custom_endpoint), None);
+        assert_eq!(github_token_for_endpoint(&insecure_endpoint), None);
+
+        match previous {
+            Some(value) => std::env::set_var("GH_TOKEN", value),
+            None => std::env::remove_var("GH_TOKEN"),
         }
-        if let Some(wayland_display) = wayland_display {
-            std::env::set_var("WAYLAND_DISPLAY", wayland_display);
-        }
-
-        assert!(result
-            .expect_err("headless updater should fail")
-            .contains("requires a graphical Linux session"));
     }
 }

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -3,6 +3,8 @@ pub mod appimage_desktop;
 pub mod backup;
 #[cfg(feature = "cli-plane")]
 pub mod cli;
+#[cfg(feature = "cli-plane")]
+pub mod cli_update;
 pub mod db;
 pub mod device_connection;
 pub mod due_time;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,6 +25,7 @@
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": "all",
     "icon": [
       "icons/icon.png",


### PR DESCRIPTION
## Outcome

- Add `fini update` for the standalone CLI distribution.
- Select the latest compatible stable release asset for the current platform.
- Verify, extract, smoke-check, and activate the new executable without replacing the current installation until all checks succeed.
- Add `--dry-run` reporting for release, asset, version, and destination selection.

## Why

Fixes #69. CLI users should be able to update safely without manually reconstructing release asset names and installation steps.

## Verification

- `cargo fmt --manifest-path src-tauri/Cargo.toml` passed.
- CLI update unit tests passed.
- The CLI build passed.
- `fini update --help` was exercised.
- JSON dry-run and already-current update paths were exercised.
- `git diff --check` passed.

## Review focus

- Confirm platform asset selection and destination naming on Linux and Windows.
- Confirm activation preserves the existing executable on every failure path.

## Follow-up

- Windows replacement of a running executable requires a deferred activation path.

Fixes #69
