### PR TITLE
Upgrade Docker base image to Node 24.18.0 trixie slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM node:24.15.0-trixie-slim AS node-deps
+FROM node:24.18.0-trixie-slim AS node-deps
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Upgrade the Docker `node-deps` base image from `node:24.15.0-trixie-slim` to `node:24.18.0-trixie-slim`.

Closes #78.

## Verification
- `rg -n "node:24\\.(15|18)\\.0-trixie-slim" Dockerfile`
- `docker build --target node-deps -t fini-node-deps-issue-78 .`
- `docker run --rm fini-node-deps-issue-78 node --version` -> `v24.18.0`

## Risk
- Low. This is a patch-level Node base image refresh in the existing `trixie-slim` family.
