### PR TITLE
Add rich quest creation composer

### DIFF
--- a/.agents/skills/fini-design/SKILL.md
+++ b/.agents/skills/fini-design/SKILL.md
@@ -69,6 +69,9 @@ The prototypes are reference, not production code. Recreate the visual output in
 - Match visual output pixel-for-pixel. Do not copy the prototype's HTML structure unless it happens to fit the target.
 - Map prototype tokens to the existing app tokens. Do not introduce a parallel token system. If a prototype token has no app equivalent, surface that as a question before adding one.
 - Reuse existing Vue components in `src/components/` first. Read before creating.
+- In Vue templates, start with DaisyUI component classes for known controls/surfaces and Tailwind utilities for layout, spacing, sizing, states, and small visual adjustments.
+- Use scoped custom CSS/classes only when the framework utilities cannot achieve the needed quality, when an existing semantic component class should be reused, or when a narrow interaction/layout behavior would be less maintainable as utilities.
+- Keep custom CSS small and local. Avoid broad one-off class taxonomies, parallel style systems, and copying prototype class names into production Vue.
 - Match the exact vocabulary in `project/README.md` ("Quest", "Space", "Focus", "Abandon", etc.). Do not rename product concepts.
 - Sentence case for buttons and labels; uppercase tracked-out only for app-chrome section headers (`SPACES`, `DEVICES`, `VOICE MODEL`).
 

--- a/.agents/skills/fini-dev/SKILL.md
+++ b/.agents/skills/fini-dev/SKILL.md
@@ -140,6 +140,13 @@ Use the repo structure as the default map:
 - Domain specs and companion specs: `specs/`, folder `README.md` files, and sidecar `.md` files next to source files.
 - Repo automation: `Makefile` is the primary human execution entrypoint, `npm run` owns JS/TS package tasks, and `xtask/` owns non-trivial automation logic. See `fini-scripting`.
 
+For Vue templates and CSS/class work, prefer the existing UI framework before writing local styles:
+
+- Use DaisyUI component classes first when they express the control or surface.
+- Use Tailwind utilities for layout, spacing, sizing, state, and small visual adjustments.
+- Add scoped custom CSS/classes only when DaisyUI/Tailwind cannot produce a high-quality result, when a reusable semantic component class already exists locally, or when a narrow interaction/layout behavior would be unreadable as utilities.
+- Keep custom CSS concise and justify it through the component/spec context; do not create parallel style systems, broad one-off class taxonomies, or copied prototype class names.
+
 Before changing a significant source file, read its companion `.md` spec when present. Write code to match the spec, or update docs/specs deliberately when the behavior changes.
 
 For product semantics, read wiki context using this order:

--- a/src/components/FocusView/NewQuestForm.md
+++ b/src/components/FocusView/NewQuestForm.md
@@ -16,6 +16,7 @@ The composer uses the same compact card language as [[QuestEditor]] instead of t
 - Inline `select` listing all spaces from `spaces` store.
 - Default: the current global selected space when present; otherwise built-in Personal (`id = "1"`); otherwise the first loaded space.
 - Selection is local to the draft and does not mutate the global Space filter.
+- Empty drafts follow changes to the global Space filter so quick-capture creates into the visible filtered Space.
 
 ## Reminder / date
 
@@ -28,6 +29,7 @@ The composer uses the same compact card language as [[QuestEditor]] instead of t
 On submit, calls `createQuest({ title, space_id, due, due_time, repeat_rule })` via [[quest.ts]].
 
 Empty titles cannot create a Quest.
+While a create request is pending, the composer disables submit controls and ignores duplicate submits.
 
 After a successful create:
 

--- a/src/components/FocusView/NewQuestForm.md
+++ b/src/components/FocusView/NewQuestForm.md
@@ -1,31 +1,44 @@
 # NewQuestForm
 
-Thin wrapper that connects [[ChatInput]] to quest creation. Used in [[FocusView]].
+Rich draft composer for Quest creation. Used in [[FocusView]].
 
 ## Layout
 
 ```
-[ Space selector ▾ ]
-[ Chat input field  ] [Send]
+[ checkbox affordance ] [ title input                    ] [ Space ▾ ]
+[ Date / reminder ]                                      [ Send ]
 ```
 
-Space selector sits directly above the input row.
+The composer uses the same compact card language as [[QuestEditor]] instead of the bottom chat-only input.
 
 ## Space selector
 
-- DaisyUI `select select-sm` dropdown listing all spaces from `spaces` store
-- Default: built-in Personal space (`id = "1"`), or the last selected space (`localStorage.lastSpaceId`)
-- On mount: restore `lastSpaceId`; fall back to built-in Personal; fall back to first available space
-- On change: save selection to `localStorage`
+- Inline `select` listing all spaces from `spaces` store.
+- Default: the current global selected space when present; otherwise built-in Personal (`id = "1"`); otherwise the first loaded space.
+- Selection is local to the draft and does not mutate the global Space filter.
+
+## Reminder / date
+
+- `Date` opens [[ReminderMenu]] against a draft Quest object.
+- Saving the reminder stores `due`, `due_time`, and `repeat_rule` in draft state.
+- Clearing the reminder resets those draft fields before creation.
 
 ## Behaviour
 
-On `submit` from [[ChatInput]], calls `createQuest({ title: text, space_id: selectedSpaceId })` via [[quest.ts]].
+On submit, calls `createQuest({ title, space_id, due, due_time, repeat_rule })` via [[quest.ts]].
+
+Empty titles cannot create a Quest.
+
+After a successful create:
+
+- title is cleared
+- reminder fields are cleared
+- selected Space is preserved for the next draft
 
 ## Dependencies
 
-| Dep           | Role                     |
-| ------------- | ------------------------ |
-| [[ChatInput]] | Input UI, emits `submit` |
-| [[quest.ts]]  | `createQuest`            |
-| [[spaces.ts]] | Space list for selector  |
+| Dep              | Role                                    |
+| ---------------- | --------------------------------------- |
+| [[quest.ts]]     | `createQuest` and draft Quest typing    |
+| [[spaces.ts]]    | Space list and color classes            |
+| [[ReminderMenu]] | Date/time/repeat picker for draft state |

--- a/src/components/FocusView/NewQuestForm.md
+++ b/src/components/FocusView/NewQuestForm.md
@@ -6,6 +6,7 @@ Rich draft composer for Quest creation. Used in [[FocusView]].
 
 ```
 [ checkbox affordance ] [ title input                    ] [ Space ▾ ]
+[ description textarea                                      ]
 [ Date / reminder ]                                      [ Send ]
 ```
 
@@ -26,7 +27,9 @@ The composer uses the same compact card language as [[QuestEditor]] instead of t
 
 ## Behaviour
 
-On submit, calls `createQuest({ title, space_id, due, due_time, repeat_rule })` via [[quest.ts]].
+On submit, calls `createQuest({ title, description, space_id, due, due_time, repeat_rule })` via [[quest.ts]].
+
+Description is optional. Whitespace-only descriptions are saved as `null`.
 
 Empty titles cannot create a Quest.
 While a create request is pending, the composer disables submit controls and ignores duplicate submits.
@@ -34,6 +37,7 @@ While a create request is pending, the composer disables submit controls and ign
 After a successful create:
 
 - title is cleared
+- description is cleared
 - reminder fields are cleared
 - selected Space is preserved for the next draft
 

--- a/src/components/FocusView/NewQuestForm.md
+++ b/src/components/FocusView/NewQuestForm.md
@@ -18,6 +18,7 @@ The composer uses the same compact card language as [[QuestEditor]] instead of t
 - Default: the current global selected space when present; otherwise built-in Personal (`id = "1"`); otherwise the first loaded space.
 - Selection is local to the draft and does not mutate the global Space filter.
 - Empty drafts follow changes to the global Space filter so quick-capture creates into the visible filtered Space.
+- If a filter change happens while the draft has content, the draft resyncs to the current filter as soon as it becomes empty again.
 
 ## Reminder / date
 
@@ -39,7 +40,7 @@ After a successful create:
 - title is cleared
 - description is cleared
 - reminder fields are cleared
-- selected Space is preserved for the next draft
+- selected Space resyncs to the current global Space filter for the next empty draft
 
 ## Dependencies
 

--- a/src/components/FocusView/NewQuestForm.vue
+++ b/src/components/FocusView/NewQuestForm.vue
@@ -11,6 +11,7 @@ const spaceStore = useSpaceStore();
 const { ensureReminderNotificationsAllowed } = useReminderNotifications();
 
 const title = ref("");
+const description = ref("");
 const selectedSpaceId = ref(spaceStore.selectedSpaceId ?? "1");
 const due = ref<string | null>(null);
 const dueTime = ref<string | null>(null);
@@ -18,7 +19,14 @@ const repeatRule = ref<string | null>(null);
 const reminderOpen = ref(false);
 const isSubmitting = ref(false);
 
-const hasDraftContent = computed(() => title.value.trim().length > 0 || !!due.value || !!dueTime.value || !!repeatRule.value);
+const hasDraftContent = computed(
+  () =>
+    title.value.trim().length > 0 ||
+    description.value.trim().length > 0 ||
+    !!due.value ||
+    !!dueTime.value ||
+    !!repeatRule.value,
+);
 
 function defaultSpaceId() {
   return spaceStore.selectedSpaceId ?? spaceStore.spaces.find((space) => space.id === "1")?.id ?? spaceStore.spaces[0]?.id ?? "1";
@@ -46,7 +54,7 @@ const draftQuest = computed<Quest>(() => ({
   id: "__new_quest__",
   space_id: selectedSpaceId.value,
   title: title.value,
-  description: null,
+  description: description.value.trim() || null,
   status: "active",
   energy: "medium",
   priority: 1,
@@ -135,11 +143,13 @@ function onTitleKeydown(event: KeyboardEvent) {
 async function onSubmit() {
   const value = title.value.trim();
   if (!value || isSubmitting.value) return;
+  const descriptionValue = description.value.trim() || null;
 
   isSubmitting.value = true;
   try {
     await questStore.createQuest({
       title: value,
+      description: descriptionValue,
       space_id: selectedSpaceId.value,
       due: due.value,
       due_time: dueTime.value,
@@ -147,6 +157,7 @@ async function onSubmit() {
     });
 
     title.value = "";
+    description.value = "";
     clearReminder();
   } finally {
     isSubmitting.value = false;
@@ -180,6 +191,15 @@ async function onSubmit() {
         </option>
       </select>
     </div>
+
+    <textarea
+      v-model="description"
+      data-testid="new-quest-description"
+      class="new-quest-description"
+      placeholder="Description"
+      rows="2"
+      :disabled="isSubmitting"
+    />
 
     <div class="new-quest-footer">
       <div class="new-quest-date-wrap">
@@ -265,6 +285,21 @@ async function onSubmit() {
 }
 
 .new-quest-title::placeholder {
+  color: var(--fg-5);
+}
+
+.new-quest-description {
+  min-height: 2.75rem;
+  padding: 0.125rem 0 0.125rem calc(18px + 0.625rem);
+  color: var(--fg-2);
+  font: 400 13px/1.35 Inter, Avenir, Helvetica, Arial, sans-serif;
+  resize: vertical;
+  background: transparent;
+  border: 0;
+  outline: none;
+}
+
+.new-quest-description::placeholder {
   color: var(--fg-5);
 }
 

--- a/src/components/FocusView/NewQuestForm.vue
+++ b/src/components/FocusView/NewQuestForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import { useQuestStore, type Quest } from "../../stores/quest";
 import { SPACE_COLOR_CLASS, useSpaceStore } from "../../stores/space";
 import { useReminderNotifications } from "../../composables/useReminderNotifications";
@@ -16,15 +16,31 @@ const due = ref<string | null>(null);
 const dueTime = ref<string | null>(null);
 const repeatRule = ref<string | null>(null);
 const reminderOpen = ref(false);
+const isSubmitting = ref(false);
+
+const hasDraftContent = computed(() => title.value.trim().length > 0 || !!due.value || !!dueTime.value || !!repeatRule.value);
+
+function defaultSpaceId() {
+  return spaceStore.selectedSpaceId ?? spaceStore.spaces.find((space) => space.id === "1")?.id ?? spaceStore.spaces[0]?.id ?? "1";
+}
 
 onMounted(async () => {
   if (!spaceStore.spaces.length) {
     await spaceStore.fetchSpaces();
   }
   if (!spaceStore.spaces.some((space) => space.id === selectedSpaceId.value)) {
-    selectedSpaceId.value = spaceStore.spaces.find((space) => space.id === "1")?.id ?? spaceStore.spaces[0]?.id ?? "1";
+    selectedSpaceId.value = defaultSpaceId();
   }
 });
+
+watch(
+  () => spaceStore.selectedSpaceId,
+  () => {
+    if (!hasDraftContent.value) {
+      selectedSpaceId.value = defaultSpaceId();
+    }
+  },
+);
 
 const draftQuest = computed<Quest>(() => ({
   id: "__new_quest__",
@@ -47,7 +63,7 @@ const draftQuest = computed<Quest>(() => ({
   period_key: null,
 }));
 
-const canSubmit = computed(() => title.value.trim().length > 0);
+const canSubmit = computed(() => title.value.trim().length > 0 && !isSubmitting.value);
 
 function spaceCss(spaceId: string): string {
   return SPACE_COLOR_CLASS[spaceId] ?? "";
@@ -111,18 +127,23 @@ function clearReminder() {
 
 async function onSubmit() {
   const value = title.value.trim();
-  if (!value) return;
+  if (!value || isSubmitting.value) return;
 
-  await questStore.createQuest({
-    title: value,
-    space_id: selectedSpaceId.value,
-    due: due.value,
-    due_time: dueTime.value,
-    repeat_rule: repeatRule.value,
-  });
+  isSubmitting.value = true;
+  try {
+    await questStore.createQuest({
+      title: value,
+      space_id: selectedSpaceId.value,
+      due: due.value,
+      due_time: dueTime.value,
+      repeat_rule: repeatRule.value,
+    });
 
-  title.value = "";
-  clearReminder();
+    title.value = "";
+    clearReminder();
+  } finally {
+    isSubmitting.value = false;
+  }
 }
 </script>
 
@@ -136,6 +157,7 @@ async function onSubmit() {
         class="new-quest-title"
         type="text"
         placeholder="New quest"
+        :disabled="isSubmitting"
       />
       <select
         v-model="selectedSpaceId"
@@ -143,6 +165,7 @@ async function onSubmit() {
         class="new-quest-space"
         :class="spaceCss(selectedSpaceId)"
         aria-label="Quest space"
+        :disabled="isSubmitting"
       >
         <option v-for="space in spaceStore.spaces" :key="space.id" :value="space.id">
           {{ space.name }}

--- a/src/components/FocusView/NewQuestForm.vue
+++ b/src/components/FocusView/NewQuestForm.vue
@@ -42,7 +42,7 @@ onMounted(async () => {
 });
 
 watch(
-  () => spaceStore.selectedSpaceId,
+  [() => spaceStore.selectedSpaceId, hasDraftContent],
   () => {
     if (!hasDraftContent.value) {
       selectedSpaceId.value = defaultSpaceId();

--- a/src/components/FocusView/NewQuestForm.vue
+++ b/src/components/FocusView/NewQuestForm.vue
@@ -125,6 +125,13 @@ function clearReminder() {
   repeatRule.value = null;
 }
 
+function onTitleKeydown(event: KeyboardEvent) {
+  if (event.key === "Enter" && !event.shiftKey) {
+    event.preventDefault();
+    void onSubmit();
+  }
+}
+
 async function onSubmit() {
   const value = title.value.trim();
   if (!value || isSubmitting.value) return;
@@ -151,13 +158,14 @@ async function onSubmit() {
   <form class="new-quest-composer" @submit.prevent="onSubmit">
     <div class="new-quest-title-row">
       <span class="new-quest-check" aria-hidden="true" />
-      <input
+      <textarea
         v-model="title"
-        data-testid="new-quest-title"
+        data-testid="chat-input"
         class="new-quest-title"
-        type="text"
         placeholder="New quest"
+        rows="1"
         :disabled="isSubmitting"
+        @keydown="onTitleKeydown"
       />
       <select
         v-model="selectedSpaceId"
@@ -198,7 +206,7 @@ async function onSubmit() {
 
       <button
         type="submit"
-        data-testid="new-quest-submit"
+        data-testid="chat-submit"
         class="new-quest-submit"
         :disabled="!canSubmit"
         aria-label="Create quest"

--- a/src/components/FocusView/NewQuestForm.vue
+++ b/src/components/FocusView/NewQuestForm.vue
@@ -1,17 +1,386 @@
 <script setup lang="ts">
-import { useQuestStore } from "../../stores/quest";
-import { useSpaceStore } from "../../stores/space";
-import ChatInput from "../ChatInput.vue";
+import { computed, onMounted, ref } from "vue";
+import { useQuestStore, type Quest } from "../../stores/quest";
+import { SPACE_COLOR_CLASS, useSpaceStore } from "../../stores/space";
+import { useReminderNotifications } from "../../composables/useReminderNotifications";
+import { CalendarDaysIcon, PaperAirplaneIcon, XMarkIcon } from "@heroicons/vue/24/outline";
+import ReminderMenu from "../QuestsView/ReminderMenu.vue";
 
 const questStore = useQuestStore();
 const spaceStore = useSpaceStore();
+const { ensureReminderNotificationsAllowed } = useReminderNotifications();
 
-async function onSubmit(text: string) {
-  const spaceId = spaceStore.selectedSpaceId ?? "1";
-  await questStore.createQuest({ title: text, space_id: spaceId });
+const title = ref("");
+const selectedSpaceId = ref(spaceStore.selectedSpaceId ?? "1");
+const due = ref<string | null>(null);
+const dueTime = ref<string | null>(null);
+const repeatRule = ref<string | null>(null);
+const reminderOpen = ref(false);
+
+onMounted(async () => {
+  if (!spaceStore.spaces.length) {
+    await spaceStore.fetchSpaces();
+  }
+  if (!spaceStore.spaces.some((space) => space.id === selectedSpaceId.value)) {
+    selectedSpaceId.value = spaceStore.spaces.find((space) => space.id === "1")?.id ?? spaceStore.spaces[0]?.id ?? "1";
+  }
+});
+
+const draftQuest = computed<Quest>(() => ({
+  id: "__new_quest__",
+  space_id: selectedSpaceId.value,
+  title: title.value,
+  description: null,
+  status: "active",
+  energy: "medium",
+  priority: 1,
+  pinned: false,
+  due: due.value,
+  due_time: dueTime.value,
+  repeat_rule: repeatRule.value,
+  completed_at: null,
+  order_rank: 0,
+  focus_enter_count: 0,
+  created_at: "",
+  updated_at: "",
+  series_id: null,
+  period_key: null,
+}));
+
+const canSubmit = computed(() => title.value.trim().length > 0);
+
+function spaceCss(spaceId: string): string {
+  return SPACE_COLOR_CLASS[spaceId] ?? "";
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value + "T00:00:00");
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function formatTime(value: string): string {
+  const [hour, minute] = value.split(":").map(Number);
+  return `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+}
+
+function formatRepeat(value: string): string {
+  try {
+    const rule = JSON.parse(value);
+    const labels: Record<string, string> = {
+      daily: "every day",
+      weekdays: "weekdays",
+      weekends: "weekends",
+      weekly: "every week",
+      monthly: "every month",
+      yearly: "every year",
+    };
+    return labels[rule.preset] ?? "";
+  } catch {
+    return "";
+  }
+}
+
+const reminderText = computed(() => {
+  const parts: string[] = [];
+  if (due.value) {
+    parts.push(`${formatDate(due.value)}${dueTime.value ? `, ${formatTime(dueTime.value)}` : ""}`);
+  }
+  if (repeatRule.value) {
+    const repeat = formatRepeat(repeatRule.value);
+    if (repeat) parts.push(repeat);
+  }
+  return parts.join(", ");
+});
+
+async function onReminderSave(payload: { due: string | null; due_time: string | null; repeat_rule: string | null }) {
+  if (!(await ensureReminderNotificationsAllowed(payload))) {
+    return;
+  }
+
+  due.value = payload.due;
+  dueTime.value = payload.due_time;
+  repeatRule.value = payload.repeat_rule;
+  reminderOpen.value = false;
+}
+
+function clearReminder() {
+  due.value = null;
+  dueTime.value = null;
+  repeatRule.value = null;
+}
+
+async function onSubmit() {
+  const value = title.value.trim();
+  if (!value) return;
+
+  await questStore.createQuest({
+    title: value,
+    space_id: selectedSpaceId.value,
+    due: due.value,
+    due_time: dueTime.value,
+    repeat_rule: repeatRule.value,
+  });
+
+  title.value = "";
+  clearReminder();
 }
 </script>
 
 <template>
-  <ChatInput @submit="onSubmit" />
+  <form class="new-quest-composer" @submit.prevent="onSubmit">
+    <div class="new-quest-title-row">
+      <span class="new-quest-check" aria-hidden="true" />
+      <input
+        v-model="title"
+        data-testid="new-quest-title"
+        class="new-quest-title"
+        type="text"
+        placeholder="New quest"
+      />
+      <select
+        v-model="selectedSpaceId"
+        data-testid="new-quest-space"
+        class="new-quest-space"
+        :class="spaceCss(selectedSpaceId)"
+        aria-label="Quest space"
+      >
+        <option v-for="space in spaceStore.spaces" :key="space.id" :value="space.id">
+          {{ space.name }}
+        </option>
+      </select>
+    </div>
+
+    <div class="new-quest-footer">
+      <div class="new-quest-date-wrap">
+        <button
+          type="button"
+          data-testid="new-quest-reminder"
+          class="new-quest-date"
+          :class="{ set: reminderText }"
+          @click.stop="reminderOpen = true"
+        >
+          <CalendarDaysIcon />
+          <span>{{ reminderText || "Date" }}</span>
+        </button>
+        <button
+          v-if="reminderText"
+          type="button"
+          class="new-quest-clear-date"
+          aria-label="Clear date"
+          @click.stop="clearReminder"
+        >
+          <XMarkIcon />
+        </button>
+      </div>
+
+      <button
+        type="submit"
+        data-testid="new-quest-submit"
+        class="new-quest-submit"
+        :disabled="!canSubmit"
+        aria-label="Create quest"
+      >
+        <PaperAirplaneIcon />
+      </button>
+    </div>
+  </form>
+
+  <ReminderMenu
+    v-if="reminderOpen"
+    :quest="draftQuest"
+    @close="reminderOpen = false"
+    @save="onReminderSave"
+  />
 </template>
+
+<style scoped>
+.new-quest-composer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.75rem 0.875rem 0.625rem;
+  color: var(--fg-1);
+  background: var(--color-base-100);
+  border: 1px solid var(--color-border-soft);
+  border-radius: 14px;
+  box-shadow: var(--shadow-sm);
+}
+
+.new-quest-title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+.new-quest-check {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  border: 1.5px solid var(--fg-5);
+  border-radius: 4px;
+}
+
+.new-quest-title {
+  min-width: 0;
+  flex: 1;
+  padding: 0.125rem 0;
+  color: var(--fg-1);
+  font: 600 15px/1.3 Inter, Avenir, Helvetica, Arial, sans-serif;
+  letter-spacing: -0.01em;
+  background: transparent;
+  border: 0;
+  outline: none;
+}
+
+.new-quest-title::placeholder {
+  color: var(--fg-5);
+}
+
+.new-quest-space {
+  max-width: 42%;
+  min-width: 6.5rem;
+  height: 1.375rem;
+  flex-shrink: 0;
+  padding: 0 1.5rem 0 0.5rem;
+  overflow: hidden;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border: 0;
+  border-radius: 5px;
+  outline: 0;
+}
+
+.new-quest-space.space-color-personal,
+.new-quest-space.space-color-work {
+  color: #fff;
+}
+
+.new-quest-space.space-color-family {
+  color: #1a1a1a;
+}
+
+.new-quest-space.space-color-personal {
+  background: var(--space-color-personal);
+}
+
+.new-quest-space.space-color-family {
+  background: var(--space-color-family);
+}
+
+.new-quest-space.space-color-work {
+  background: var(--space-color-work);
+}
+
+.new-quest-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding-top: 0.5rem;
+}
+
+.new-quest-date-wrap {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.new-quest-date {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0.625rem 0.375rem 0.25rem;
+  color: var(--fg-1);
+  font: 600 13px/1 Inter, Avenir, Helvetica, Arial, sans-serif;
+  cursor: pointer;
+  background: transparent;
+  border: 0;
+  border-radius: 8px;
+}
+
+.new-quest-date:hover {
+  background: var(--color-base-200);
+}
+
+.new-quest-date svg {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  color: var(--fg-3);
+  stroke-width: 1.7;
+}
+
+.new-quest-date span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.new-quest-date.set,
+.new-quest-date.set svg {
+  color: var(--color-success);
+}
+
+.new-quest-clear-date,
+.new-quest-submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  padding: 0;
+  cursor: pointer;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+}
+
+.new-quest-clear-date {
+  color: var(--fg-4);
+}
+
+.new-quest-clear-date:hover {
+  color: var(--fg-1);
+  background: var(--color-base-200);
+}
+
+.new-quest-submit {
+  color: var(--color-primary-content);
+  background: var(--color-primary);
+}
+
+.new-quest-submit:hover:not(:disabled) {
+  filter: brightness(0.92);
+}
+
+.new-quest-submit:disabled {
+  cursor: not-allowed;
+  opacity: 0.3;
+}
+
+.new-quest-clear-date svg,
+.new-quest-submit svg {
+  width: 18px;
+  height: 18px;
+  stroke-width: 1.7;
+}
+
+@media (max-width: 420px) {
+  .new-quest-title-row {
+    flex-wrap: wrap;
+  }
+
+  .new-quest-space {
+    max-width: none;
+    margin-left: calc(18px + 0.625rem);
+  }
+}
+</style>

--- a/src/components/FocusView/NewQuestForm.vue
+++ b/src/components/FocusView/NewQuestForm.vue
@@ -121,13 +121,19 @@ async function onReminderSave(payload: { due: string | null; due_time: string | 
     return;
   }
 
-  if (!(await ensureReminderNotificationsAllowed(payload))) {
+  const reminder = {
+    due: payload.due,
+    due_time: payload.due ? payload.due_time : null,
+    repeat_rule: payload.repeat_rule,
+  };
+
+  if (!(await ensureReminderNotificationsAllowed(reminder))) {
     return;
   }
 
-  due.value = payload.due;
-  dueTime.value = payload.due_time;
-  repeatRule.value = payload.repeat_rule;
+  due.value = reminder.due;
+  dueTime.value = reminder.due_time;
+  repeatRule.value = reminder.repeat_rule;
   reminderOpen.value = false;
 }
 

--- a/src/components/FocusView/NewQuestForm.vue
+++ b/src/components/FocusView/NewQuestForm.vue
@@ -117,6 +117,10 @@ const reminderText = computed(() => {
 });
 
 async function onReminderSave(payload: { due: string | null; due_time: string | null; repeat_rule: string | null }) {
+  if (isSubmitting.value) {
+    return;
+  }
+
   if (!(await ensureReminderNotificationsAllowed(payload))) {
     return;
   }
@@ -208,6 +212,7 @@ async function onSubmit() {
           data-testid="new-quest-reminder"
           class="new-quest-date"
           :class="{ set: reminderText }"
+          :disabled="isSubmitting"
           @click.stop="reminderOpen = true"
         >
           <CalendarDaysIcon />
@@ -216,8 +221,10 @@ async function onSubmit() {
         <button
           v-if="reminderText"
           type="button"
+          data-testid="new-quest-clear-reminder"
           class="new-quest-clear-date"
           aria-label="Clear date"
+          :disabled="isSubmitting"
           @click.stop="clearReminder"
         >
           <XMarkIcon />
@@ -237,7 +244,7 @@ async function onSubmit() {
   </form>
 
   <ReminderMenu
-    v-if="reminderOpen"
+    v-if="reminderOpen && !isSubmitting"
     :quest="draftQuest"
     @close="reminderOpen = false"
     @save="onReminderSave"
@@ -374,6 +381,15 @@ async function onSubmit() {
   background: var(--color-base-200);
 }
 
+.new-quest-date:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.new-quest-date:disabled:hover {
+  background: transparent;
+}
+
 .new-quest-date svg {
   width: 18px;
   height: 18px;
@@ -416,6 +432,16 @@ async function onSubmit() {
 .new-quest-clear-date:hover {
   color: var(--fg-1);
   background: var(--color-base-200);
+}
+
+.new-quest-clear-date:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.new-quest-clear-date:disabled:hover {
+  color: var(--fg-4);
+  background: transparent;
 }
 
 .new-quest-submit {

--- a/src/spec/components/NewQuestForm.spec.ts
+++ b/src/spec/components/NewQuestForm.spec.ts
@@ -1,4 +1,5 @@
 import { mount } from "@vue/test-utils";
+import { nextTick, reactive } from "vue";
 import NewQuestForm from "../../components/FocusView/NewQuestForm.vue";
 import { useQuestStore } from "../../stores/quest";
 import { useSpaceStore } from "../../stores/space";
@@ -30,15 +31,16 @@ const reminderPayload = {
 describe("NewQuestForm", () => {
   let createQuest: jest.Mock;
   let fetchSpaces: jest.Mock;
+  let spaceStoreState: {
+    selectedSpaceId: string | null;
+    spaces: Array<{ id: string; name: string }>;
+    fetchSpaces: jest.Mock;
+  };
 
   beforeEach(() => {
     createQuest = jest.fn().mockResolvedValue({});
     fetchSpaces = jest.fn().mockResolvedValue(undefined);
-
-    (useQuestStore as unknown as jest.Mock).mockReturnValue({
-      createQuest,
-    });
-    (useSpaceStore as unknown as jest.Mock).mockReturnValue({
+    spaceStoreState = reactive({
       selectedSpaceId: null,
       spaces: [
         { id: "1", name: "Personal" },
@@ -46,6 +48,11 @@ describe("NewQuestForm", () => {
       ],
       fetchSpaces,
     });
+
+    (useQuestStore as unknown as jest.Mock).mockReturnValue({
+      createQuest,
+    });
+    (useSpaceStore as unknown as jest.Mock).mockReturnValue(spaceStoreState);
   });
 
   it("creates a quest with explicit space and reminder draft fields", async () => {
@@ -89,5 +96,52 @@ describe("NewQuestForm", () => {
     await wrapper.find("form").trigger("submit");
 
     expect(createQuest).not.toHaveBeenCalled();
+  });
+
+  it("prevents duplicate creates while submit is pending", async () => {
+    let resolveCreate: () => void = () => {};
+    createQuest.mockReturnValue(new Promise<void>((resolve) => {
+      resolveCreate = resolve;
+    }));
+    const wrapper = mount(NewQuestForm, {
+      global: {
+        stubs: {
+          ReminderMenu: true,
+        },
+      },
+    });
+
+    await wrapper.find('[data-testid="new-quest-title"]').setValue("Avoid duplicates");
+    await wrapper.find("form").trigger("submit");
+    await wrapper.find("form").trigger("submit");
+
+    expect(createQuest).toHaveBeenCalledTimes(1);
+    expect(wrapper.find('[data-testid="new-quest-submit"]').attributes("disabled")).toBeDefined();
+
+    resolveCreate();
+    await nextTick();
+  });
+
+  it("keeps an empty draft space aligned with the active filter", async () => {
+    const wrapper = mount(NewQuestForm, {
+      global: {
+        stubs: {
+          ReminderMenu: true,
+        },
+      },
+    });
+
+    spaceStoreState.selectedSpaceId = "2";
+    await nextTick();
+    await wrapper.find('[data-testid="new-quest-title"]').setValue("Create in filtered space");
+    await wrapper.find("form").trigger("submit");
+
+    expect(createQuest).toHaveBeenCalledWith({
+      title: "Create in filtered space",
+      space_id: "2",
+      due: null,
+      due_time: null,
+      repeat_rule: null,
+    });
   });
 });

--- a/src/spec/components/NewQuestForm.spec.ts
+++ b/src/spec/components/NewQuestForm.spec.ts
@@ -55,7 +55,7 @@ describe("NewQuestForm", () => {
     (useSpaceStore as unknown as jest.Mock).mockReturnValue(spaceStoreState);
   });
 
-  it("creates a quest with explicit space and reminder draft fields", async () => {
+  it("creates a quest with explicit space, description, and reminder draft fields", async () => {
     const wrapper = mount(NewQuestForm, {
       global: {
         stubs: {
@@ -70,6 +70,7 @@ describe("NewQuestForm", () => {
     });
 
     await wrapper.find('[data-testid="chat-input"]').setValue("Plan the rich composer");
+    await wrapper.find('[data-testid="new-quest-description"]').setValue("Capture the extra notes here.");
     await wrapper.find('[data-testid="new-quest-space"]').setValue("2");
     await wrapper.find('[data-testid="new-quest-reminder"]').trigger("click");
     await wrapper.find('[data-testid="stub-reminder-save"]').trigger("click");
@@ -77,6 +78,7 @@ describe("NewQuestForm", () => {
 
     expect(createQuest).toHaveBeenCalledWith({
       title: "Plan the rich composer",
+      description: "Capture the extra notes here.",
       space_id: "2",
       due: "2099-06-15",
       due_time: "14:30",
@@ -138,6 +140,7 @@ describe("NewQuestForm", () => {
 
     expect(createQuest).toHaveBeenCalledWith({
       title: "Create in filtered space",
+      description: null,
       space_id: "2",
       due: null,
       due_time: null,

--- a/src/spec/components/NewQuestForm.spec.ts
+++ b/src/spec/components/NewQuestForm.spec.ts
@@ -124,6 +124,41 @@ describe("NewQuestForm", () => {
     await nextTick();
   });
 
+  it("disables reminder controls while submit is pending", async () => {
+    let resolveCreate: () => void = () => {};
+    createQuest.mockReturnValue(new Promise<void>((resolve) => {
+      resolveCreate = resolve;
+    }));
+    const wrapper = mount(NewQuestForm, {
+      global: {
+        stubs: {
+          ReminderMenu: {
+            template: '<button data-testid="stub-reminder-save" @click="$emit(\'save\', payload)">save reminder</button>',
+            props: ["quest"],
+            emits: ["save", "close"],
+            data: () => ({ payload: reminderPayload }),
+          },
+        },
+      },
+    });
+
+    await wrapper.find('[data-testid="chat-input"]').setValue("Keep reminder stable");
+    await wrapper.find('[data-testid="new-quest-reminder"]').trigger("click");
+    await wrapper.find('[data-testid="stub-reminder-save"]').trigger("click");
+    await wrapper.find("form").trigger("submit");
+    await nextTick();
+
+    expect(wrapper.find('[data-testid="new-quest-reminder"]').attributes("disabled")).toBeDefined();
+    expect(wrapper.find('[data-testid="new-quest-clear-reminder"]').attributes("disabled")).toBeDefined();
+
+    await wrapper.find('[data-testid="new-quest-reminder"]').trigger("click");
+
+    expect(wrapper.find('[data-testid="stub-reminder-save"]').exists()).toBe(false);
+
+    resolveCreate();
+    await nextTick();
+  });
+
   it("keeps an empty draft space aligned with the active filter", async () => {
     const wrapper = mount(NewQuestForm, {
       global: {

--- a/src/spec/components/NewQuestForm.spec.ts
+++ b/src/spec/components/NewQuestForm.spec.ts
@@ -182,4 +182,31 @@ describe("NewQuestForm", () => {
       repeat_rule: null,
     });
   });
+
+  it("resyncs draft space after skipped filter changes when the draft becomes empty", async () => {
+    const wrapper = mount(NewQuestForm, {
+      global: {
+        stubs: {
+          ReminderMenu: true,
+        },
+      },
+    });
+
+    await wrapper.find('[data-testid="chat-input"]').setValue("Started in Personal");
+    spaceStoreState.selectedSpaceId = "2";
+    await nextTick();
+    await wrapper.find('[data-testid="chat-input"]').setValue("");
+    await nextTick();
+    await wrapper.find('[data-testid="chat-input"]').setValue("Create in refreshed filter");
+    await wrapper.find("form").trigger("submit");
+
+    expect(createQuest).toHaveBeenCalledWith({
+      title: "Create in refreshed filter",
+      description: null,
+      space_id: "2",
+      due: null,
+      due_time: null,
+      repeat_rule: null,
+    });
+  });
 });

--- a/src/spec/components/NewQuestForm.spec.ts
+++ b/src/spec/components/NewQuestForm.spec.ts
@@ -1,0 +1,93 @@
+import { mount } from "@vue/test-utils";
+import NewQuestForm from "../../components/FocusView/NewQuestForm.vue";
+import { useQuestStore } from "../../stores/quest";
+import { useSpaceStore } from "../../stores/space";
+
+jest.mock("../../stores/quest", () => ({
+  useQuestStore: jest.fn(),
+}));
+
+jest.mock("../../stores/space", () => ({
+  useSpaceStore: jest.fn(),
+  SPACE_COLOR_CLASS: {
+    "1": "space-color-personal",
+    "2": "space-color-family",
+  },
+}));
+
+jest.mock("../../composables/useReminderNotifications", () => ({
+  useReminderNotifications: () => ({
+    ensureReminderNotificationsAllowed: jest.fn().mockResolvedValue(true),
+  }),
+}));
+
+const reminderPayload = {
+  due: "2099-06-15",
+  due_time: "14:30",
+  repeat_rule: null,
+};
+
+describe("NewQuestForm", () => {
+  let createQuest: jest.Mock;
+  let fetchSpaces: jest.Mock;
+
+  beforeEach(() => {
+    createQuest = jest.fn().mockResolvedValue({});
+    fetchSpaces = jest.fn().mockResolvedValue(undefined);
+
+    (useQuestStore as unknown as jest.Mock).mockReturnValue({
+      createQuest,
+    });
+    (useSpaceStore as unknown as jest.Mock).mockReturnValue({
+      selectedSpaceId: null,
+      spaces: [
+        { id: "1", name: "Personal" },
+        { id: "2", name: "Family" },
+      ],
+      fetchSpaces,
+    });
+  });
+
+  it("creates a quest with explicit space and reminder draft fields", async () => {
+    const wrapper = mount(NewQuestForm, {
+      global: {
+        stubs: {
+          ReminderMenu: {
+            template: '<button data-testid="stub-reminder-save" @click="$emit(\'save\', payload)">save reminder</button>',
+            props: ["quest"],
+            emits: ["save", "close"],
+            data: () => ({ payload: reminderPayload }),
+          },
+        },
+      },
+    });
+
+    await wrapper.find('[data-testid="new-quest-title"]').setValue("Plan the rich composer");
+    await wrapper.find('[data-testid="new-quest-space"]').setValue("2");
+    await wrapper.find('[data-testid="new-quest-reminder"]').trigger("click");
+    await wrapper.find('[data-testid="stub-reminder-save"]').trigger("click");
+    await wrapper.find("form").trigger("submit");
+
+    expect(createQuest).toHaveBeenCalledWith({
+      title: "Plan the rich composer",
+      space_id: "2",
+      due: "2099-06-15",
+      due_time: "14:30",
+      repeat_rule: null,
+    });
+  });
+
+  it("does not create a quest without a title", async () => {
+    const wrapper = mount(NewQuestForm, {
+      global: {
+        stubs: {
+          ReminderMenu: true,
+        },
+      },
+    });
+
+    await wrapper.find("form").trigger("submit");
+
+    expect(createQuest).not.toHaveBeenCalled();
+  });
+});

--- a/src/spec/components/NewQuestForm.spec.ts
+++ b/src/spec/components/NewQuestForm.spec.ts
@@ -86,6 +86,35 @@ describe("NewQuestForm", () => {
     });
   });
 
+  it("drops reminder time when no due date is selected", async () => {
+    const wrapper = mount(NewQuestForm, {
+      global: {
+        stubs: {
+          ReminderMenu: {
+            template: '<button data-testid="stub-reminder-save" @click="$emit(\'save\', payload)">save reminder</button>',
+            props: ["quest"],
+            emits: ["save", "close"],
+            data: () => ({ payload: { due: null, due_time: "14:30", repeat_rule: null } }),
+          },
+        },
+      },
+    });
+
+    await wrapper.find('[data-testid="chat-input"]').setValue("Do not keep invisible reminder time");
+    await wrapper.find('[data-testid="new-quest-reminder"]').trigger("click");
+    await wrapper.find('[data-testid="stub-reminder-save"]').trigger("click");
+    await wrapper.find("form").trigger("submit");
+
+    expect(createQuest).toHaveBeenCalledWith({
+      title: "Do not keep invisible reminder time",
+      description: null,
+      space_id: "1",
+      due: null,
+      due_time: null,
+      repeat_rule: null,
+    });
+  });
+
   it("does not create a quest without a title", async () => {
     const wrapper = mount(NewQuestForm, {
       global: {

--- a/src/spec/components/NewQuestForm.spec.ts
+++ b/src/spec/components/NewQuestForm.spec.ts
@@ -69,7 +69,7 @@ describe("NewQuestForm", () => {
       },
     });
 
-    await wrapper.find('[data-testid="new-quest-title"]').setValue("Plan the rich composer");
+    await wrapper.find('[data-testid="chat-input"]').setValue("Plan the rich composer");
     await wrapper.find('[data-testid="new-quest-space"]').setValue("2");
     await wrapper.find('[data-testid="new-quest-reminder"]').trigger("click");
     await wrapper.find('[data-testid="stub-reminder-save"]').trigger("click");
@@ -111,12 +111,12 @@ describe("NewQuestForm", () => {
       },
     });
 
-    await wrapper.find('[data-testid="new-quest-title"]').setValue("Avoid duplicates");
+    await wrapper.find('[data-testid="chat-input"]').setValue("Avoid duplicates");
     await wrapper.find("form").trigger("submit");
     await wrapper.find("form").trigger("submit");
 
     expect(createQuest).toHaveBeenCalledTimes(1);
-    expect(wrapper.find('[data-testid="new-quest-submit"]').attributes("disabled")).toBeDefined();
+    expect(wrapper.find('[data-testid="chat-submit"]').attributes("disabled")).toBeDefined();
 
     resolveCreate();
     await nextTick();
@@ -133,7 +133,7 @@ describe("NewQuestForm", () => {
 
     spaceStoreState.selectedSpaceId = "2";
     await nextTick();
-    await wrapper.find('[data-testid="new-quest-title"]').setValue("Create in filtered space");
+    await wrapper.find('[data-testid="chat-input"]').setValue("Create in filtered space");
     await wrapper.find("form").trigger("submit");
 
     expect(createQuest).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary
- Replace the title-only Focus quest input with a richer draft composer.
- Add explicit Space selection during Quest creation without mutating the global Space filter.
- Reuse the existing `ReminderMenu` flow to set `due`, `due_time`, and `repeat_rule` before `createQuest`.
- Update `NewQuestForm` docs and add focused unit coverage for create payload behavior.

Closes #77.

## Verification
- `npm run test:unit -- NewQuestForm.spec.ts` ✅
- `git diff --check` ✅

Attempted broader checks:
- `npm run build` blocked before this component by missing local installs for `@tauri-apps/plugin-dialog` / `@tauri-apps/plugin-notification`.
- `npm run test:unit` blocked by the same local `@tauri-apps/plugin-dialog` resolution issue in existing backup tests.
- `npm ci` could not repair local dependencies because `node_modules` contains root-owned files (`EACCES` on `.bin/acorn`); `chown` is not permitted in this environment.

## Notes
- `QuestEditor` remains unchanged because it is currently persistence-oriented around an existing `Quest`. The create composer reuses its compact editor visual language and the real `ReminderMenu` date flow without widening edit behavior risk.
