### PR TITLE
Guard Linux WebKit startup defaults

### DIFF
--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -94,6 +94,37 @@ General notes:
   - local debug output is `bin/fini.apk`; local release-signed output is `bin/fini-release.apk`
 - **Flatpak**: Packaged via `com.fini.app.yml` at the repo root
 
+## Linux AppImage WebKit crash reports
+
+Fini already starts Linux WebKit with `WEBKIT_DISABLE_DMABUF_RENDERER=1` and `WEBKIT_DISABLE_SANDBOX=1` in `src-tauri/src/lib.rs`.
+If `WebKitWebProcess` aborts in an AppImage build, capture a sanitized report that keeps the failure actionable without exposing host identifiers.
+
+Report only:
+
+- Fini version and install channel (`AppImage`)
+- Linux distro and session type (`Wayland` or `X11`)
+- The last user action before the abort
+- Whether the crash reproduces in a fresh Fini profile
+- Whether the crash still reproduces with the repo's default Linux WebKit guards in place
+- A redacted `coredumpctl info` or journal excerpt that keeps the process name, signal, package/build, and stack summary
+
+Do not publish raw coredumps or any user, host, machine, boot, session, or transient mount identifiers.
+Do not include local core storage paths, AppImage mount paths, or usernames in public reports.
+
+Suggested template:
+
+```text
+Fini version:
+Install channel: AppImage
+Linux distro:
+Session type:
+Trigger action:
+Fresh profile repro:
+Default Linux guards present:
+Sanitized coredump summary:
+Stack summary:
+```
+
 ## Postponed
 
 - **Voice / ASR** (`src/voice.rs`, `src/model_download.rs`) — offline speech recognition via sherpa-onnx. Code is present but not compiled or registered. Will be revisited after the core quest flow is stable.

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -84,7 +84,10 @@ General notes:
 
 ## Platform notes
 
-- **Linux**: Sets `WEBKIT_DISABLE_DMABUF_RENDERER=1` at startup to ensure Wayland compatibility
+- **Linux GUI**: Applies default WebKit startup guards before Tauri initializes:
+  `WEBKIT_DISABLE_DMABUF_RENDERER=1` for Wayland/mesa stability and
+  `WEBKIT_DISABLE_SANDBOX=1` for SELinux-enforcing AppImage hosts. Existing
+  environment values are preserved for explicit local diagnostics.
 - **Desktop GUI**: `fini-app` is the bundled GUI binary and is built with `ui-plane,desktop-updater`
 - **CLI/runtime**: `fini` is the CLI-only binary and is built with `cli-plane`
 - **Android**: Built via `npm run tauri android build`; project lives in `gen/android/`
@@ -96,7 +99,7 @@ General notes:
 
 ## Linux AppImage WebKit crash reports
 
-Fini already starts Linux WebKit with `WEBKIT_DISABLE_DMABUF_RENDERER=1` and `WEBKIT_DISABLE_SANDBOX=1` in `src-tauri/src/lib.rs`.
+Fini starts Linux WebKit with default guards from `src-tauri/src/webkit_runtime.rs`: `WEBKIT_DISABLE_DMABUF_RENDERER=1` and `WEBKIT_DISABLE_SANDBOX=1`.
 If `WebKitWebProcess` aborts in an AppImage build, capture a sanitized report that keeps the failure actionable without exposing host identifiers.
 
 Report only:

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod models;
 mod schema;
 mod services;
+#[cfg(all(feature = "ui-plane", target_os = "linux"))]
+mod webkit_runtime;
 // mod voice;       // postponed
 // mod model_download; // postponed
 
@@ -164,11 +166,7 @@ pub fn run_cli() -> i32 {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     #[cfg(target_os = "linux")]
-    {
-        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
-        // SELinux-enforcing distros (Fedora Kinoite, Silverblue) block the bwrap sandbox.
-        std::env::set_var("WEBKIT_DISABLE_SANDBOX", "1");
-    }
+    webkit_runtime::apply_startup_guards();
 
     let builder = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())

--- a/src-tauri/src/webkit_runtime.rs
+++ b/src-tauri/src/webkit_runtime.rs
@@ -1,0 +1,71 @@
+const WEBKIT_DISABLE_DMABUF_RENDERER: &str = "WEBKIT_DISABLE_DMABUF_RENDERER";
+const WEBKIT_DISABLE_SANDBOX: &str = "WEBKIT_DISABLE_SANDBOX";
+
+pub fn apply_startup_guards() {
+    set_default_env(WEBKIT_DISABLE_DMABUF_RENDERER, "1");
+    set_default_env(WEBKIT_DISABLE_SANDBOX, "1");
+}
+
+fn set_default_env(key: &str, value: &str) {
+    if std::env::var_os(key).is_none() {
+        std::env::set_var(key, value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    fn with_env_guard<F>(test: F)
+    where
+        F: FnOnce(),
+    {
+        let _guard = env_lock();
+        let dmabuf = std::env::var_os(WEBKIT_DISABLE_DMABUF_RENDERER);
+        let sandbox = std::env::var_os(WEBKIT_DISABLE_SANDBOX);
+
+        std::env::remove_var(WEBKIT_DISABLE_DMABUF_RENDERER);
+        std::env::remove_var(WEBKIT_DISABLE_SANDBOX);
+
+        test();
+
+        restore_env(WEBKIT_DISABLE_DMABUF_RENDERER, dmabuf);
+        restore_env(WEBKIT_DISABLE_SANDBOX, sandbox);
+    }
+
+    fn restore_env(key: &str, value: Option<std::ffi::OsString>) {
+        match value {
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
+        }
+    }
+
+    #[test]
+    fn applies_default_webkit_guards() {
+        with_env_guard(|| {
+            apply_startup_guards();
+
+            assert_eq!(std::env::var(WEBKIT_DISABLE_DMABUF_RENDERER).unwrap(), "1");
+            assert_eq!(std::env::var(WEBKIT_DISABLE_SANDBOX).unwrap(), "1");
+        });
+    }
+
+    #[test]
+    fn preserves_explicit_webkit_guard_overrides() {
+        with_env_guard(|| {
+            std::env::set_var(WEBKIT_DISABLE_DMABUF_RENDERER, "0");
+            std::env::set_var(WEBKIT_DISABLE_SANDBOX, "0");
+
+            apply_startup_guards();
+
+            assert_eq!(std::env::var(WEBKIT_DISABLE_DMABUF_RENDERER).unwrap(), "0");
+            assert_eq!(std::env::var(WEBKIT_DISABLE_SANDBOX).unwrap(), "0");
+        });
+    }
+}


### PR DESCRIPTION
## Outcome

- Move Linux WebKit startup defaults into a dedicated, testable runtime helper.
- Apply DMA-BUF renderer and sandbox guards before Tauri initializes while preserving explicit overrides.
- Add regression tests and privacy-safe AppImage crash-report guidance.

## Why

Refs #73. AppImage users affected by WebKitGTK/Mesa startup crashes need a low-risk mitigation with enough diagnostics to evaluate remaining failures.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml --features ui-plane webkit_runtime --lib` passed with 2 tests.
- `git diff --check` passed.
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check` was blocked by unrelated pre-existing formatting in `src-tauri/src/services/backup.rs`.

## Review focus

- Confirm startup guards are applied before WebKit initialization.
- Confirm explicit user overrides remain effective.
- Confirm crash guidance requests only privacy-safe evidence.

## Follow-up

- A fresh sanitized reproduction is still needed to determine whether every upstream WebKitGTK/Mesa ABRT path is covered.

Refs #73
