### PR TITLE
Fix release button existing-version retry

### DIFF
--- a/.github/workflows/release-button.yml
+++ b/.github/workflows/release-button.yml
@@ -77,8 +77,12 @@ jobs:
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
           git add package.json package-lock.json src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json
-          git commit -m "chore: release ${{ steps.plan.outputs.tag }}"
-          git push origin "HEAD:refs/heads/main"
+          if git diff --cached --quiet; then
+            echo "Version metadata already matches ${{ steps.plan.outputs.version }}; reusing current main commit."
+          else
+            git commit -m "chore: release ${{ steps.plan.outputs.tag }}"
+            git push origin "HEAD:refs/heads/main"
+          fi
           git push origin "HEAD:refs/heads/${{ steps.plan.outputs.branch }}"
 
       - name: Import GPG key

--- a/.github/workflows/release-button.yml
+++ b/.github/workflows/release-button.yml
@@ -81,8 +81,8 @@ jobs:
             echo "Version metadata already matches ${{ steps.plan.outputs.version }}; reusing current main commit."
           else
             git commit -m "chore: release ${{ steps.plan.outputs.tag }}"
-            git push origin "HEAD:refs/heads/main"
           fi
+          git push origin "HEAD:refs/heads/main"
           git push origin "HEAD:refs/heads/${{ steps.plan.outputs.branch }}"
 
       - name: Import GPG key


### PR DESCRIPTION
## Summary
- allow Release Button to continue when planned version metadata already matches main
- skip the empty version-bump commit instead of failing with `nothing to commit`
- still push the release branch from current main so tag creation can proceed

## Evidence
- Failed run: https://github.com/VRuzhentsov/fini/actions/runs/28301212798
- Local no-op simulation: `cargo run --manifest-path xtask/Cargo.toml -- release-version 0.1.37 && git add package.json package-lock.json src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json && git diff --cached --quiet`
- `cargo check --manifest-path xtask/Cargo.toml`
- `git diff --check`