### PR TITLE
fix: update Snyk action from node@master to node@v0.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         run: npm ci
 
       - name: Run Snyk checks
-        uses: snyk/actions/node@master
+        uses: snyk/actions/node@v0.4.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -291,3 +291,4 @@ jobs:
           emulator-options: -no-window -no-audio -gpu swiftshader_indirect -no-snapshot -no-metrics
           disable-animations: true
           script: bash scripts/android-e2e-assert.sh
+

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,8 +20,9 @@ jobs:
         run: npm ci
 
       - name: Run Snyk checks
-        uses: snyk/actions/node@master
+        uses: snyk/actions/node@v0.4.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           args: --file=package.json --severity-threshold=high
+


### PR DESCRIPTION
## What
Update Snyk GitHub Action from `snyk/actions/node@master` to `snyk/actions/node@v0.4.0` in both `ci.yml` and `security.yml`.

## Why
GitHub Actions has deprecated Node 20. Using `@master` pulls an unsupported version. Pinning to `@v0.4.0` ensures a stable, supported version.

## Changes
- `.github/workflows/ci.yml`: `@master` → `@v0.4.0`
- `.github/workflows/security.yml`: `@master` → `@v0.4.0`