### PR TITLE
Stop release button from creating issues

### DIFF
--- a/.github/workflows/release-button.yml
+++ b/.github/workflows/release-button.yml
@@ -5,7 +5,6 @@ on:
 
 permissions:
   contents: write
-  issues: write
 
 concurrency:
   group: release-button-main
@@ -94,10 +93,8 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: false
 
-      - name: Tag and create issue
+      - name: Tag release
         if: steps.plan.outputs.should_release == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN || github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -105,5 +102,4 @@ jobs:
           git tag -s -a "$tag" -m "$tag"
           git tag -v "$tag"
           git push origin "$tag"
-          issue_url="$(gh issue create --title "Release $tag" --body "Release button created $tag from ${{ steps.plan.outputs.latest_tag }}. Triggered by: @${{ github.actor }}. Branch: ${{ steps.plan.outputs.branch }}. Workflow: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID")"
-          printf '\n## Release started\n\n- Tag: %s\n- Issue: %s\n- Release workflow: release-tag.yml starts from the tag push\n' "$tag" "$issue_url" >> "$GITHUB_STEP_SUMMARY"
+          printf '\n## Release started\n\n- Tag: %s\n- Release workflow: release-tag.yml starts from the tag push\n' "$tag" >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ make build
 
 Release workflow is GitOps: pushing a signed annotated `v*` tag starts CI. The release command first commits the npm, Rust, and Tauri version metadata on `main`, then tags and pushes that exact commit. CI owns tests, builds, signing checks, packaging, and artifacts.
 
-The one-click release path is the `Release Button` GitHub Actions workflow. It compares the latest `v*` tag with `origin/main`, chooses the next version from Conventional Commit subjects, creates one `chore: release vX.Y.Z` metadata commit, pushes `main` and a `release/vX.Y.Z` trace branch, creates a signed annotated tag, and opens a release issue. The tag push starts the release pipeline. If there are no commits since the latest release tag, it exits successfully as a skipped no-op and does not create an issue, commit, tag, or release pipeline run.
+The one-click release path is the `Release Button` GitHub Actions workflow. It compares the latest `v*` tag with `origin/main`, chooses the next version from Conventional Commit subjects, creates one `chore: release vX.Y.Z` metadata commit, pushes `main` and a `release/vX.Y.Z` trace branch, and creates a signed annotated tag. The tag push starts the release pipeline. If there are no commits since the latest release tag, it exits successfully as a skipped no-op and does not create a commit, tag, or release pipeline run.
 
 Because `main` is protected, the button needs an automation token that can update protected branches for the repository:
 


### PR DESCRIPTION
## Summary
- remove the Release Button workflow's GitHub issue creation step
- drop the no-longer-needed issues permission from the workflow
- update the README release section so it no longer promises release issues

## Root Cause
The one-click release workflow explicitly ran `gh issue create --title "Release $tag"` after pushing the signed release tag, so each release button run created a GitHub issue named after the release version.

## Validation
- `rg -n 'gh issue create|issues: write|release issue|opens a release issue|Issue:' .github/workflows/release-button.yml README.md` returned no matches
- `git diff --check` passed
- local `actionlint`/YAML parser tooling was unavailable on this host