### PR TITLE
Add WebKit compositing-mode guard and startup diagnostics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,13 @@ FINI_DEV_RUNNER_IMAGE ?= fini-dev-runner-ci
 FINI_E2E_CACHE_IMAGE_PREFIX ?=
 FINI_E2E_CACHE_PUSH ?= 0
 RELEASE_BUNDLES ?= deb,rpm
+# linuxdeploy vendors an older `strip` that cannot parse `.relr.dyn` sections
+# emitted by newer host toolchains (e.g. Fedora 44+), which aborts local Linux
+# bundling before it produces an AppImage. Skip stripping by default for local
+# builds; override with NO_STRIP=false if your toolchain doesn't need this.
+# CI release builds run `npm run tauri build` directly, not this target, so
+# this default has no effect on published release artifacts.
+NO_STRIP ?= true
 
 .PHONY: help require-container dev build play-store-screenshots pr-gate-fe-unit pr-gate-be-cache-key pr-gate-be-compile pr-gate-be-unit pr-gate-e2e pr-gate-e2e-cache-key pr-gate-e2e-build-dev-runner pr-gate-e2e-run pr-gate-e2e-artifacts pr-gate-e2e-cleanup e2e e2e-ci e2e-image e2e-build e2e-headed runtime-image runtime-smoke pre-release-check release android-connect android-dev android-build android-build-emulator-e2e android-sign-debug android-sign-release-local android-launch android-devices android-debug-deploy android-debug-deploy-debug android-release-deploy-local flatpak-install-local
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ make dev
 make build
 ```
 
+On newer Linux toolchains (e.g. Fedora 44+), local AppImage bundling defaults to
+`NO_STRIP=true` because `linuxdeploy` vendors an older `strip` that cannot parse
+`.relr.dyn` sections emitted by those toolchains; see `src-tauri/README.md` for
+details. This only affects local builds — CI release builds are unaffected.
+
 ### Release
 
 Release workflow is GitOps: pushing a signed annotated `v*` tag starts CI. The release command first commits the npm, Rust, and Tauri version metadata on `main`, then tags and pushes that exact commit. CI owns tests, builds, signing checks, packaging, and artifacts.

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -85,9 +85,14 @@ General notes:
 ## Platform notes
 
 - **Linux GUI**: Applies default WebKit startup guards before Tauri initializes:
-  `WEBKIT_DISABLE_DMABUF_RENDERER=1` for Wayland/mesa stability and
-  `WEBKIT_DISABLE_SANDBOX=1` for SELinux-enforcing AppImage hosts. Existing
-  environment values are preserved for explicit local diagnostics.
+  `WEBKIT_DISABLE_DMABUF_RENDERER=1` for Wayland/mesa stability,
+  `WEBKIT_DISABLE_SANDBOX=1` for SELinux-enforcing AppImage hosts, and
+  `WEBKIT_DISABLE_COMPOSITING_MODE=1` to force software compositing when the
+  bundled WebKitGTK's accelerated compositing path is unstable against the
+  host's mesa/DRM/GL stack. Existing environment values are preserved for
+  explicit local diagnostics. The resolved value of each guard is logged to
+  stderr at startup (`[webkit-runtime] KEY=value`) so a packaged AppImage
+  session can confirm which flags actually reached `WebKitWebProcess`.
 - **Desktop GUI**: `fini-app` is the bundled GUI binary and is built with `ui-plane,desktop-updater`
 - **CLI/runtime**: `fini` is the CLI-only binary and is built with `cli-plane`
 - **Android**: Built via `npm run tauri android build`; project lives in `gen/android/`
@@ -99,7 +104,8 @@ General notes:
 
 ## Linux AppImage WebKit crash reports
 
-Fini starts Linux WebKit with default guards from `src-tauri/src/webkit_runtime.rs`: `WEBKIT_DISABLE_DMABUF_RENDERER=1` and `WEBKIT_DISABLE_SANDBOX=1`.
+Fini starts Linux WebKit with default guards from `src-tauri/src/webkit_runtime.rs`: `WEBKIT_DISABLE_DMABUF_RENDERER=1`, `WEBKIT_DISABLE_SANDBOX=1`, and `WEBKIT_DISABLE_COMPOSITING_MODE=1`.
+Each guard's resolved value is logged to stderr at startup (`[webkit-runtime] KEY=value`) — capture those lines alongside any crash report to confirm the flags reached the AppImage's `WebKitWebProcess`.
 If `WebKitWebProcess` aborts in an AppImage build, capture a sanitized report that keeps the failure actionable without exposing host identifiers.
 
 Report only:
@@ -108,7 +114,7 @@ Report only:
 - Linux distro and session type (`Wayland` or `X11`)
 - The last user action before the abort
 - Whether the crash reproduces in a fresh Fini profile
-- Whether the crash still reproduces with the repo's default Linux WebKit guards in place
+- The `[webkit-runtime]` startup log lines showing the resolved guard values
 - A redacted `coredumpctl info` or journal excerpt that keeps the process name, signal, package/build, and stack summary
 
 Do not publish raw coredumps or any user, host, machine, boot, session, or transient mount identifiers.
@@ -123,7 +129,7 @@ Linux distro:
 Session type:
 Trigger action:
 Fresh profile repro:
-Default Linux guards present:
+webkit-runtime startup log lines:
 Sanitized coredump summary:
 Stack summary:
 ```

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -102,6 +102,28 @@ General notes:
   - local debug output is `bin/fini.apk`; local release-signed output is `bin/fini-release.apk`
 - **Flatpak**: Packaged via `com.fini.app.yml` at the repo root
 
+## Local AppImage build failures on newer Linux toolchains
+
+`make build` (and `make flatpak-install-local`) default `NO_STRIP=true` (set in the
+root `Makefile`). Without it, local AppImage bundling on newer host toolchains
+(e.g. Fedora 44+, glibc/binutils new enough to emit `.relr.dyn` relocation
+sections) fails with:
+
+```text
+ERROR: Strip call failed: .../usr/bin/strip: <library>: unknown type [0x13] section `.relr.dyn'
+```
+
+`linuxdeploy` vendors its own `strip` binary, which predates RELR section
+support, and aborts bundling before producing an AppImage — the host's own
+(newer) `strip` is not used regardless of `PATH` or a `STRIP` env var, since
+linuxdeploy's bundled AppImage mounts its own `usr/bin/strip`. `NO_STRIP=true`
+skips the strip step entirely, at the cost of larger, unstripped local
+binaries. Override with `NO_STRIP=false` if your toolchain doesn't hit this.
+CI release builds (`.github/workflows/release-tag.yml`,
+`release-dry-run.yml`) call `npm run tauri build` directly on
+`ubuntu-latest`, not through this Makefile target, so this default has no
+effect on published release artifacts.
+
 ## Linux AppImage WebKit crash reports
 
 Fini starts Linux WebKit with default guards from `src-tauri/src/webkit_runtime.rs`: `WEBKIT_DISABLE_DMABUF_RENDERER=1`, `WEBKIT_DISABLE_SANDBOX=1`, and `WEBKIT_DISABLE_COMPOSITING_MODE=1`.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -166,7 +166,10 @@ pub fn run_cli() -> i32 {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     #[cfg(target_os = "linux")]
-    webkit_runtime::apply_startup_guards();
+    {
+        webkit_runtime::apply_startup_guards();
+        webkit_runtime::log_active_guards();
+    }
 
     let builder = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())

--- a/src-tauri/src/webkit_runtime.rs
+++ b/src-tauri/src/webkit_runtime.rs
@@ -1,14 +1,35 @@
 const WEBKIT_DISABLE_DMABUF_RENDERER: &str = "WEBKIT_DISABLE_DMABUF_RENDERER";
 const WEBKIT_DISABLE_SANDBOX: &str = "WEBKIT_DISABLE_SANDBOX";
+const WEBKIT_DISABLE_COMPOSITING_MODE: &str = "WEBKIT_DISABLE_COMPOSITING_MODE";
+
+const GUARD_KEYS: [&str; 3] = [
+    WEBKIT_DISABLE_DMABUF_RENDERER,
+    WEBKIT_DISABLE_SANDBOX,
+    WEBKIT_DISABLE_COMPOSITING_MODE,
+];
 
 pub fn apply_startup_guards() {
     set_default_env(WEBKIT_DISABLE_DMABUF_RENDERER, "1");
     set_default_env(WEBKIT_DISABLE_SANDBOX, "1");
+    set_default_env(WEBKIT_DISABLE_COMPOSITING_MODE, "1");
 }
 
 fn set_default_env(key: &str, value: &str) {
     if std::env::var_os(key).is_none() {
         std::env::set_var(key, value);
+    }
+}
+
+/// Logs the resolved value of each WebKit startup guard to stderr so a
+/// packaged AppImage session can confirm which flags actually reached
+/// `WebKitWebProcess`, without recording any host- or session-identifying
+/// data.
+pub fn log_active_guards() {
+    for key in GUARD_KEYS {
+        match std::env::var(key) {
+            Ok(value) => eprintln!("[webkit-runtime] {key}={value}"),
+            Err(_) => eprintln!("[webkit-runtime] {key}=<unset>"),
+        }
     }
 }
 
@@ -27,16 +48,20 @@ mod tests {
         F: FnOnce(),
     {
         let _guard = env_lock();
-        let dmabuf = std::env::var_os(WEBKIT_DISABLE_DMABUF_RENDERER);
-        let sandbox = std::env::var_os(WEBKIT_DISABLE_SANDBOX);
+        let saved: Vec<_> = GUARD_KEYS
+            .iter()
+            .map(|key| (*key, std::env::var_os(key)))
+            .collect();
 
-        std::env::remove_var(WEBKIT_DISABLE_DMABUF_RENDERER);
-        std::env::remove_var(WEBKIT_DISABLE_SANDBOX);
+        for key in GUARD_KEYS {
+            std::env::remove_var(key);
+        }
 
         test();
 
-        restore_env(WEBKIT_DISABLE_DMABUF_RENDERER, dmabuf);
-        restore_env(WEBKIT_DISABLE_SANDBOX, sandbox);
+        for (key, value) in saved {
+            restore_env(key, value);
+        }
     }
 
     fn restore_env(key: &str, value: Option<std::ffi::OsString>) {
@@ -53,6 +78,7 @@ mod tests {
 
             assert_eq!(std::env::var(WEBKIT_DISABLE_DMABUF_RENDERER).unwrap(), "1");
             assert_eq!(std::env::var(WEBKIT_DISABLE_SANDBOX).unwrap(), "1");
+            assert_eq!(std::env::var(WEBKIT_DISABLE_COMPOSITING_MODE).unwrap(), "1");
         });
     }
 
@@ -61,11 +87,13 @@ mod tests {
         with_env_guard(|| {
             std::env::set_var(WEBKIT_DISABLE_DMABUF_RENDERER, "0");
             std::env::set_var(WEBKIT_DISABLE_SANDBOX, "0");
+            std::env::set_var(WEBKIT_DISABLE_COMPOSITING_MODE, "0");
 
             apply_startup_guards();
 
             assert_eq!(std::env::var(WEBKIT_DISABLE_DMABUF_RENDERER).unwrap(), "0");
             assert_eq!(std::env::var(WEBKIT_DISABLE_SANDBOX).unwrap(), "0");
+            assert_eq!(std::env::var(WEBKIT_DISABLE_COMPOSITING_MODE).unwrap(), "0");
         });
     }
 }


### PR DESCRIPTION
## Summary

- Adds `WEBKIT_DISABLE_COMPOSITING_MODE=1` as a third default Linux WebKit startup guard in `src-tauri/src/webkit_runtime.rs`, alongside the existing `WEBKIT_DISABLE_DMABUF_RENDERER` and `WEBKIT_DISABLE_SANDBOX` guards from #81. This forces software compositing, the standard next-step mitigation for WebKitGTK/mesa AppImage aborts when the DMA-BUF guard alone isn't enough.
- Adds `log_active_guards()`, which logs each guard's resolved value to stderr (`[webkit-runtime] KEY=value`) at startup, so a future crash report can confirm which flags actually reached `WebKitWebProcess` in a packaged AppImage session — this was explicitly requested in the reopened issue.
- Updates `src-tauri/README.md`'s platform notes and crash-report template to document the new guard and ask for the startup log lines instead of a vague "guards present" checkbox.
- Extends the existing `webkit_runtime` regression tests to cover the new guard and explicit-override behavior.
- **Also fixes a local build-tooling bug found while reproducing this issue**: `make build`/`make flatpak-install-local` now default `NO_STRIP=true` (in the root `Makefile`) because `linuxdeploy` vendors its own `strip`, which cannot parse `.relr.dyn` relocation sections emitted by newer host toolchains (e.g. Fedora 44+). Without this, local AppImage bundling aborted with `Strip call failed` before producing an artifact, which blocked testing the exact packaged binary from this issue. CI release builds call `npm run tauri build` directly on `ubuntu-latest`, not through this Makefile target, so published release artifacts are unaffected. Documented in both `README.md` and `src-tauri/README.md`.

## Issue

Fixes https://github.com/VRuzhentsov/fini/issues/73

The issue was reopened because the PR #81 guards did not stop a repeat `WebKitWebProcess` SIGABRT on a Fedora 44-era AppImage session.

## Reproduction effort

I reproduced the investigation directly on a Fedora 44-era (Bazzite/Kinoite) machine matching the report's package versions (`libdrm-2.4.134`, `libglvnd-1.7.0`, `libX11-1.8.13`), which also runs **NVIDIA proprietary drivers** under Wayland — a known trigger for WebKitGTK compositor/DMA-BUF instability, consistent with this fix's direction.

1. **Source-compiled headed e2e**: `make e2e-headed` (21 Playwright tests covering UI flows, multi-actor device pairing, and live quest sync) against the dynamically-linked system WebKitGTK, with this branch's guards active. All 21 passed, no coredumps, no WebKit-related journal entries.
2. **Actual packaged AppImage**: after fixing the `NO_STRIP` build issue above, built and ran the real `Fini_0.1.37_amd64.AppImage` — confirmed via `/proc/<pid>/exe` that `WebKitWebProcess` was genuinely running from the AppImage's own FUSE-mounted `usr/libexec/webkit2gtk-4.1/WebKitWebProcess`, matching the original report's "AppImage-mounted WebKitGTK WebKitWebProcess" description. Startup logs confirmed all three guards resolved to `1`. Left it running idle for ~2.5 minutes (a dedicated crash-watch monitor on `journalctl` for ABRT/coredump signatures) — no crash.
3. **One artifact worth flagging honestly**: while tearing the AppImage down, I killed its parent process before its `WebKitWebProcess`/`WebKitNetworkProcess` children had exited, and both then hit **SIGBUS** (signal 7) coredumps. I inspected these (`coredumpctl info`) and they are a **teardown artifact, not a reproduction of the reported bug**: the stack frames are unsymbolized because the FUSE mount backing their mapped libraries was gone by the time of the crash, the signal differs from the report (SIGBUS vs. the reported SIGABRT/6), and the stack shape is ordinary poll/futex loops rather than the reported `abort()`-rooted stack. Noting this for the record so it isn't confused with a real repro.

Net result: routine navigation, multi-actor sync, and idle sessions don't trivially trigger the reported ABRT — even on matching hardware, with the real packaged AppImage, with the new guards active. That's useful negative evidence, but it doesn't by itself prove the original crash is fixed, since I couldn't force the exact conditions that produced the field report.

## Verification

- `cargo test --features ui-plane webkit_runtime --lib` — 2/2 passed.
- `cargo build --features ui-plane --lib` — clean.
- `cargo clippy --features ui-plane --lib -- -D warnings` — no findings in touched files (pre-existing unrelated warnings elsewhere untouched).
- `make e2e-headed` — 21/21 passed, no coredumps/WebKit crashes during the run.
- `make build` — now succeeds locally and produces `deb`/`rpm`/`AppImage` bundles (previously failed with `Strip call failed`).
- Ran the packaged AppImage directly; confirmed guard values via startup log and confirmed `WebKitWebProcess` was running from the AppImage's own mount (see reproduction section).

## Risk

- Low: existing guard behavior and override semantics are unchanged; this only adds one more default env var and non-blocking stderr logging, plus a local-only build default that CI doesn't use.
- Residual: without a fresh sanitized coredump from a packaged AppImage session experiencing the actual reported SIGABRT, this cannot prove every possible upstream WebKitGTK/mesa ABRT is eliminated — the startup diagnostic is intended to close that gap on the next report.