### PR TITLE
Upload Android native debug symbols for Play Console

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -460,6 +460,17 @@ jobs:
             "${ANDROID_KEY_ALIAS}"
           jarsigner -verify "$signed_aab"
 
+      - name: Collect Android native debug symbols
+        run: |
+          set -euo pipefail
+          symbols_zip="$(find src-tauri/gen/android/app/build/outputs/native-debug-symbols -name native-debug-symbols.zip | head -n 1)"
+          if [ -z "$symbols_zip" ]; then
+            echo "Android native debug symbols archive not found" >&2
+            exit 1
+          fi
+          short_sha="${GITHUB_SHA::7}"
+          cp "$symbols_zip" "fini-prep-${short_sha}-android-native-debug-symbols.zip"
+
       - name: Upload Android artifact
         uses: actions/upload-artifact@v4
         with:
@@ -467,6 +478,7 @@ jobs:
           path: |
             fini-prep-*-android.apk
             fini-prep-*-android.aab
+            fini-prep-*-android-native-debug-symbols.zip
           if-no-files-found: error
           retention-days: 7
 

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -463,13 +463,36 @@ jobs:
       - name: Collect Android native debug symbols
         run: |
           set -euo pipefail
-          symbols_zip="$(find src-tauri/gen/android/app/build/outputs/native-debug-symbols -name native-debug-symbols.zip | head -n 1)"
-          if [ -z "$symbols_zip" ]; then
-            echo "Android native debug symbols archive not found" >&2
-            exit 1
-          fi
           short_sha="${GITHUB_SHA::7}"
-          cp "$symbols_zip" "fini-prep-${short_sha}-android-native-debug-symbols.zip"
+          ANDROID_SYMBOLS_OUTPUT="fini-prep-${short_sha}-android-native-debug-symbols.zip" python3 <<'PY'
+          import os
+          import pathlib
+          import zipfile
+
+          root = pathlib.Path("src-tauri/target")
+          output = pathlib.Path(os.environ["ANDROID_SYMBOLS_OUTPUT"])
+          targets = {
+              "aarch64-linux-android": "arm64-v8a",
+              "armv7-linux-androideabi": "armeabi-v7a",
+              "i686-linux-android": "x86",
+              "x86_64-linux-android": "x86_64",
+          }
+
+          entries = []
+          for rust_target, abi in targets.items():
+              library = root / rust_target / "release" / "libfini_lib.so"
+              if library.exists():
+                  entries.append((library, f"{abi}/libfini_lib.so"))
+
+          if not entries:
+              raise SystemExit("Android native debug symbol libraries not found")
+
+          with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+              for library, archive_name in entries:
+                  archive.write(library, archive_name)
+
+          print(f"Wrote {output} with {len(entries)} native debug symbol libraries")
+          PY
 
       - name: Upload Android artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -616,7 +616,7 @@ jobs:
           for rust_target, abi in targets.items():
               library = root / rust_target / "release" / "libfini_lib.so"
               if library.exists():
-                  entries.append((library, f"lib/{abi}/libfini_lib.so"))
+                  entries.append((library, f"{abi}/libfini_lib.so"))
 
           if not entries:
               raise SystemExit("Android native debug symbol libraries not found")

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -612,7 +612,14 @@ jobs:
           path: |
             fini-${{ github.ref_name }}-android.apk
             fini-${{ github.ref_name }}-android.aab
-            fini-${{ github.ref_name }}-android-native-debug-symbols.zip
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload Android native debug symbols artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-native-debug-symbols
+          path: fini-${{ github.ref_name }}-android-native-debug-symbols.zip
           if-no-files-found: error
           retention-days: 14
 
@@ -732,6 +739,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: release-android
+          path: release-assets
+
+      - name: Download Android native debug symbols artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: android-native-debug-symbols
           path: release-assets
 
       - name: Validate Play publishing secret

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -595,6 +595,16 @@ jobs:
             "${ANDROID_KEY_ALIAS}"
           jarsigner -verify "$signed_aab"
 
+      - name: Collect Android native debug symbols
+        run: |
+          set -euo pipefail
+          symbols_zip="$(find src-tauri/gen/android/app/build/outputs/native-debug-symbols -name native-debug-symbols.zip | head -n 1)"
+          if [ -z "$symbols_zip" ]; then
+            echo "Android native debug symbols archive not found" >&2
+            exit 1
+          fi
+          cp "$symbols_zip" "fini-${GITHUB_REF_NAME}-android-native-debug-symbols.zip"
+
       - name: Upload Android artifact
         uses: actions/upload-artifact@v4
         with:
@@ -602,6 +612,7 @@ jobs:
           path: |
             fini-${{ github.ref_name }}-android.apk
             fini-${{ github.ref_name }}-android.aab
+            fini-${{ github.ref_name }}-android-native-debug-symbols.zip
           if-no-files-found: error
           retention-days: 14
 
@@ -744,6 +755,7 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: com.fini.app
           releaseFiles: release-assets/fini-${{ github.ref_name }}-android.aab
+          debugSymbols: release-assets/fini-${{ github.ref_name }}-android-native-debug-symbols.zip
           tracks: internal
           releaseName: ${{ github.ref_name }}
           status: completed

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -598,12 +598,35 @@ jobs:
       - name: Collect Android native debug symbols
         run: |
           set -euo pipefail
-          symbols_zip="$(find src-tauri/gen/android/app/build/outputs/native-debug-symbols -name native-debug-symbols.zip | head -n 1)"
-          if [ -z "$symbols_zip" ]; then
-            echo "Android native debug symbols archive not found" >&2
-            exit 1
-          fi
-          cp "$symbols_zip" "fini-${GITHUB_REF_NAME}-android-native-debug-symbols.zip"
+          python3 <<'PY'
+          import os
+          import pathlib
+          import zipfile
+
+          root = pathlib.Path("src-tauri/target")
+          output = pathlib.Path(f"fini-{os.environ['GITHUB_REF_NAME']}-android-native-debug-symbols.zip")
+          targets = {
+              "aarch64-linux-android": "arm64-v8a",
+              "armv7-linux-androideabi": "armeabi-v7a",
+              "i686-linux-android": "x86",
+              "x86_64-linux-android": "x86_64",
+          }
+
+          entries = []
+          for rust_target, abi in targets.items():
+              library = root / rust_target / "release" / "libfini_lib.so"
+              if library.exists():
+                  entries.append((library, f"lib/{abi}/libfini_lib.so"))
+
+          if not entries:
+              raise SystemExit("Android native debug symbol libraries not found")
+
+          with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+              for library, archive_name in entries:
+                  archive.write(library, archive_name)
+
+          print(f"Wrote {output} with {len(entries)} native debug symbol libraries")
+          PY
 
       - name: Upload Android artifact
         uses: actions/upload-artifact@v4

--- a/src-tauri/gen/android/README.md
+++ b/src-tauri/gen/android/README.md
@@ -39,7 +39,8 @@ This compiles the Rust backend for all Android targets (`aarch64`, `armv7`, `i68
 Output:
 - **APK**: `app/build/outputs/apk/universal/release/app-universal-release-unsigned.apk`
 - **AAB**: `app/build/outputs/bundle/universalRelease/app-universal-release.aab`
-- **Native debug symbols**: `app/build/outputs/native-debug-symbols/universalRelease/native-debug-symbols.zip`
+- **Native debug symbols**: release workflow artifact
+  `fini-<tag>-android-native-debug-symbols.zip`
 
 ## Native debug symbols
 
@@ -50,12 +51,12 @@ to the Android `arm64-v8a` ABI; a full local build can also produce
 
 Unstripped Rust libraries are produced under
 `src-tauri/target/<android-rust-target>/release/libfini_lib.so` before Gradle
-packages them into the AAB. The release build type sets
-`ndk.debugSymbolLevel = "FULL"`, so Android Gradle Plugin also writes the
-Play Console-compatible archive at:
+packages stripped libraries into the AAB. The release workflow zips those
+unstripped libraries separately for Play Console upload instead of enabling
+Android Gradle Plugin debug-symbol metadata on the public release AAB:
 
 ```text
-src-tauri/gen/android/app/build/outputs/native-debug-symbols/universalRelease/native-debug-symbols.zip
+fini-<tag>-android-native-debug-symbols.zip
 ```
 
 The release GitHub workflow uploads that archive with the AAB through the

--- a/src-tauri/gen/android/README.md
+++ b/src-tauri/gen/android/README.md
@@ -39,6 +39,31 @@ This compiles the Rust backend for all Android targets (`aarch64`, `armv7`, `i68
 Output:
 - **APK**: `app/build/outputs/apk/universal/release/app-universal-release-unsigned.apk`
 - **AAB**: `app/build/outputs/bundle/universalRelease/app-universal-release.aab`
+- **Native debug symbols**: `app/build/outputs/native-debug-symbols/universalRelease/native-debug-symbols.zip`
+
+## Native debug symbols
+
+The Android bundle contains the Rust `cdylib` from `src-tauri/Cargo.toml` as
+`libfini_lib.so`. Release builds currently target `aarch64`, which Gradle maps
+to the Android `arm64-v8a` ABI; a full local build can also produce
+`armeabi-v7a`, `x86`, and `x86_64` when those targets are requested.
+
+Unstripped Rust libraries are produced under
+`src-tauri/target/<android-rust-target>/release/libfini_lib.so` before Gradle
+packages them into the AAB. The release build type sets
+`ndk.debugSymbolLevel = "FULL"`, so Android Gradle Plugin also writes the
+Play Console-compatible archive at:
+
+```text
+src-tauri/gen/android/app/build/outputs/native-debug-symbols/universalRelease/native-debug-symbols.zip
+```
+
+The release GitHub workflow uploads that archive with the AAB through the
+Google Play action's `debugSymbols` input. If a release is uploaded manually,
+upload the same `native-debug-symbols.zip` file in Play Console so native crash
+and ANR stack traces can be symbolicated. Verify the Play Console release
+candidate no longer shows the native debug symbols warning after the symbols are
+attached.
 
 ## Install on a connected device
 

--- a/src-tauri/gen/android/app/build.gradle.kts
+++ b/src-tauri/gen/android/app/build.gradle.kts
@@ -33,7 +33,8 @@ android {
             isDebuggable = true
             isJniDebuggable = true
             isMinifyEnabled = false
-            packaging {                jniLibs.keepDebugSymbols.add("*/arm64-v8a/*.so")
+            packaging {
+                jniLibs.keepDebugSymbols.add("*/arm64-v8a/*.so")
                 jniLibs.keepDebugSymbols.add("*/armeabi-v7a/*.so")
                 jniLibs.keepDebugSymbols.add("*/x86/*.so")
                 jniLibs.keepDebugSymbols.add("*/x86_64/*.so")
@@ -41,6 +42,9 @@ android {
         }
         getByName("release") {
             isMinifyEnabled = true
+            ndk {
+                debugSymbolLevel = "FULL"
+            }
             proguardFiles(
                 *fileTree(".") { include("**/*.pro") }
                     .plus(getDefaultProguardFile("proguard-android-optimize.txt"))

--- a/src-tauri/gen/android/app/build.gradle.kts
+++ b/src-tauri/gen/android/app/build.gradle.kts
@@ -42,9 +42,6 @@ android {
         }
         getByName("release") {
             isMinifyEnabled = true
-            ndk {
-                debugSymbolLevel = "FULL"
-            }
             proguardFiles(
                 *fileTree(".") { include("**/*.pro") }
                     .plus(getDefaultProguardFile("proguard-android-optimize.txt"))


### PR DESCRIPTION
## Outcome

- Generate full native debug symbols for Android release builds.
- Package symbols using the ABI directory layout expected by Google Play.
- Upload the symbol archive to Play Internal publishing without adding it to public GitHub release assets or the public AAB.
- Keep the dry-run workflow aligned with the release workflow.

## Why

Fixes #96. Play Console needs native symbols to deobfuscate Android crash reports while public release artifacts should contain only distributable application assets.

## Verification

- `npm ci` passed.
- `npm run build` passed.
- Static release workflow and Gradle assertions passed.
- `git diff --check` passed.
- Final CI passed: frontend tests, backend tests and compile, E2E, Android emulator E2E, and security checks.

## Review focus

- Confirm symbol zip paths begin with ABI directories.
- Confirm Play publishing downloads the symbols explicitly while public release collection excludes them.

## Follow-up

None.

Fixes #96
