### PR TITLE
diagnostics: record WebKit AppImage guard state

### DIFF
--- a/.github/ISSUE_TEMPLATE/linux-appimage-webkit-crash.yml
+++ b/.github/ISSUE_TEMPLATE/linux-appimage-webkit-crash.yml
@@ -1,0 +1,114 @@
+name: Linux AppImage WebKit crash
+description: Report a WebKitWebProcess crash from the Linux AppImage without leaking host identifiers.
+title: "Linux AppImage WebKitWebProcess crash"
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template only for Linux AppImage crashes where the crashed process is `WebKitWebProcess`.
+
+        Before posting publicly, remove user names, host names, exact process IDs, boot IDs, machine IDs, coredump storage paths, transient AppImage mount paths, local home-directory paths, and raw coredump data. Keep only the sanitized fields below.
+  - type: input
+    id: fini-version
+    attributes:
+      label: Fini version
+      description: Use the app version or release tag. Do not paste local build paths.
+      placeholder: "0.1.x"
+    validations:
+      required: true
+  - type: dropdown
+    id: install-channel
+    attributes:
+      label: Install channel
+      options:
+        - AppImage
+    validations:
+      required: true
+  - type: input
+    id: linux-environment
+    attributes:
+      label: Linux environment
+      description: Distro/version and session type only. Do not include host names or user names.
+      placeholder: "Fedora 44, Wayland"
+    validations:
+      required: true
+  - type: textarea
+    id: trigger-action
+    attributes:
+      label: Last user action before the abort
+      description: Describe the app action or screen that preceded the crash.
+      placeholder: "Opened Settings, switched to Focus, left the app idle, etc."
+    validations:
+      required: true
+  - type: dropdown
+    id: fresh-profile-repro
+    attributes:
+      label: Fresh profile reproduction
+      description: Test with a clean Fini data directory when possible.
+      options:
+        - Reproduces with a fresh profile
+        - Does not reproduce with a fresh profile
+        - Not tested
+    validations:
+      required: true
+  - type: textarea
+    id: startup-guards
+    attributes:
+      label: webkit-runtime startup guard lines
+      description: Paste only the `[webkit-runtime] KEY=value` lines from stderr. These lines are intentionally host-agnostic.
+      render: text
+      placeholder: |
+        [webkit-runtime] WEBKIT_DISABLE_DMABUF_RENDERER=1
+        [webkit-runtime] WEBKIT_DISABLE_SANDBOX=1
+        [webkit-runtime] WEBKIT_DISABLE_COMPOSITING_MODE=1
+    validations:
+      required: true
+  - type: textarea
+    id: sanitized-coredump-summary
+    attributes:
+      label: Sanitized coredump summary
+      description: Include process name, signal, architecture, package/build shape, and core size only. Do not include raw coredumps, paths, process IDs, boot IDs, machine IDs, host names, user names, or transient AppImage mount paths.
+      render: text
+      placeholder: |
+        Process: WebKitWebProcess
+        Signal: 6 (ABRT)
+        Executable shape: AppImage-mounted WebKitGTK WebKitWebProcess
+        Architecture: AMD x86-64
+        Core size: about 2 MB
+    validations:
+      required: true
+  - type: textarea
+    id: stack-summary
+    attributes:
+      label: Sanitized stack summary
+      description: Keep the stack shape and library names. Remove local paths and machine-specific identifiers.
+      render: text
+      placeholder: |
+        #0 __pthread_kill_implementation (libc.so.6)
+        #1 raise (libc.so.6)
+        #2 abort (libc.so.6)
+        #3..#20 unsymbolized WebKit/runtime frames
+    validations:
+      required: true
+  - type: textarea
+    id: rendering-comparison
+    attributes:
+      label: Rendering workaround comparison
+      description: If tested, compare default launch with explicit rendering overrides. Do not include local paths.
+      placeholder: |
+        Default guarded launch: reproduces / not reproduced
+        WEBKIT_DISABLE_COMPOSITING_MODE=0 launch: reproduces / not reproduced / not tested
+        Notes:
+    validations:
+      required: false
+  - type: checkboxes
+    id: privacy-checklist
+    attributes:
+      label: Privacy checklist
+      options:
+        - label: I removed user names, host names, exact process IDs, boot IDs, machine IDs, coredump storage paths, transient AppImage mount paths, local home-directory paths, and raw coredump data.
+          required: true
+        - label: I included only sanitized process, signal, environment, startup guard, and stack-shape details.
+          required: true

--- a/.github/ISSUE_TEMPLATE/linux-appimage-webkit-crash.yml
+++ b/.github/ISSUE_TEMPLATE/linux-appimage-webkit-crash.yml
@@ -63,6 +63,7 @@ body:
         [webkit-runtime] WEBKIT_DISABLE_DMABUF_RENDERER=1
         [webkit-runtime] WEBKIT_DISABLE_SANDBOX=1
         [webkit-runtime] WEBKIT_DISABLE_COMPOSITING_MODE=1
+        [webkit-runtime] LIBGL_ALWAYS_SOFTWARE=1
     validations:
       required: true
   - type: textarea

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -86,13 +86,15 @@ General notes:
 
 - **Linux GUI**: Applies default WebKit startup guards before Tauri initializes:
   `WEBKIT_DISABLE_DMABUF_RENDERER=1` for Wayland/mesa stability,
-  `WEBKIT_DISABLE_SANDBOX=1` for SELinux-enforcing AppImage hosts, and
+  `WEBKIT_DISABLE_SANDBOX=1` for SELinux-enforcing AppImage hosts,
   `WEBKIT_DISABLE_COMPOSITING_MODE=1` to force software compositing when the
   bundled WebKitGTK's accelerated compositing path is unstable against the
-  host's mesa/DRM/GL stack. Existing environment values are preserved for
-  explicit local diagnostics. The resolved value of each guard is logged to
-  stderr at startup (`[webkit-runtime] KEY=value`) so a packaged AppImage
-  session can confirm which flags actually reached `WebKitWebProcess`.
+  host's mesa/DRM/GL stack, and `LIBGL_ALWAYS_SOFTWARE=1` as a stronger
+  Mesa-side fallback for repeated AppImage WebKit aborts on host GL drivers.
+  Existing environment values are preserved for explicit local diagnostics.
+  The resolved value of each guard is logged to stderr at startup
+  (`[webkit-runtime] KEY=value`) so a packaged AppImage session can confirm
+  which flags actually reached `WebKitWebProcess`.
 - **Desktop GUI**: `fini-app` is the bundled GUI binary and is built with `ui-plane,desktop-updater`
 - **CLI/runtime**: `fini` is the CLI-only binary and is built with `cli-plane`
 - **Android**: Built via `npm run tauri android build`; project lives in `gen/android/`
@@ -126,7 +128,7 @@ effect on published release artifacts.
 
 ## Linux AppImage WebKit crash reports
 
-Fini starts Linux WebKit with default guards from `src-tauri/src/webkit_runtime.rs`: `WEBKIT_DISABLE_DMABUF_RENDERER=1`, `WEBKIT_DISABLE_SANDBOX=1`, and `WEBKIT_DISABLE_COMPOSITING_MODE=1`.
+Fini starts Linux WebKit with default guards from `src-tauri/src/webkit_runtime.rs`: `WEBKIT_DISABLE_DMABUF_RENDERER=1`, `WEBKIT_DISABLE_SANDBOX=1`, `WEBKIT_DISABLE_COMPOSITING_MODE=1`, and `LIBGL_ALWAYS_SOFTWARE=1`.
 Each guard's resolved value is logged to stderr at startup (`[webkit-runtime] KEY=value`) — capture those lines alongside any crash report to confirm the flags reached the AppImage's `WebKitWebProcess`.
 If `WebKitWebProcess` aborts in an AppImage build, capture a sanitized report that keeps the failure actionable without exposing host identifiers.
 

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -142,7 +142,9 @@ Report only:
 Do not publish raw coredumps or any user, host, machine, boot, session, or transient mount identifiers.
 Do not include local core storage paths, AppImage mount paths, or usernames in public reports.
 
-Suggested template:
+For public GitHub reports, use `.github/ISSUE_TEMPLATE/linux-appimage-webkit-crash.yml`; it requires the same sanitized fields and includes a privacy checklist before submission.
+
+Suggested local notes template:
 
 ```text
 Fini version:
@@ -154,6 +156,7 @@ Fresh profile repro:
 webkit-runtime startup log lines:
 Sanitized coredump summary:
 Stack summary:
+Rendering workaround comparison:
 ```
 
 ## Postponed

--- a/src-tauri/src/webkit_runtime.rs
+++ b/src-tauri/src/webkit_runtime.rs
@@ -1,17 +1,20 @@
 const WEBKIT_DISABLE_DMABUF_RENDERER: &str = "WEBKIT_DISABLE_DMABUF_RENDERER";
 const WEBKIT_DISABLE_SANDBOX: &str = "WEBKIT_DISABLE_SANDBOX";
 const WEBKIT_DISABLE_COMPOSITING_MODE: &str = "WEBKIT_DISABLE_COMPOSITING_MODE";
+const LIBGL_ALWAYS_SOFTWARE: &str = "LIBGL_ALWAYS_SOFTWARE";
 
-const GUARD_KEYS: [&str; 3] = [
+const GUARD_KEYS: [&str; 4] = [
     WEBKIT_DISABLE_DMABUF_RENDERER,
     WEBKIT_DISABLE_SANDBOX,
     WEBKIT_DISABLE_COMPOSITING_MODE,
+    LIBGL_ALWAYS_SOFTWARE,
 ];
 
 pub fn apply_startup_guards() {
     set_default_env(WEBKIT_DISABLE_DMABUF_RENDERER, "1");
     set_default_env(WEBKIT_DISABLE_SANDBOX, "1");
     set_default_env(WEBKIT_DISABLE_COMPOSITING_MODE, "1");
+    set_default_env(LIBGL_ALWAYS_SOFTWARE, "1");
 }
 
 fn set_default_env(key: &str, value: &str) {
@@ -79,6 +82,7 @@ mod tests {
             assert_eq!(std::env::var(WEBKIT_DISABLE_DMABUF_RENDERER).unwrap(), "1");
             assert_eq!(std::env::var(WEBKIT_DISABLE_SANDBOX).unwrap(), "1");
             assert_eq!(std::env::var(WEBKIT_DISABLE_COMPOSITING_MODE).unwrap(), "1");
+            assert_eq!(std::env::var(LIBGL_ALWAYS_SOFTWARE).unwrap(), "1");
         });
     }
 
@@ -88,12 +92,14 @@ mod tests {
             std::env::set_var(WEBKIT_DISABLE_DMABUF_RENDERER, "0");
             std::env::set_var(WEBKIT_DISABLE_SANDBOX, "0");
             std::env::set_var(WEBKIT_DISABLE_COMPOSITING_MODE, "0");
+            std::env::set_var(LIBGL_ALWAYS_SOFTWARE, "0");
 
             apply_startup_guards();
 
             assert_eq!(std::env::var(WEBKIT_DISABLE_DMABUF_RENDERER).unwrap(), "0");
             assert_eq!(std::env::var(WEBKIT_DISABLE_SANDBOX).unwrap(), "0");
             assert_eq!(std::env::var(WEBKIT_DISABLE_COMPOSITING_MODE).unwrap(), "0");
+            assert_eq!(std::env::var(LIBGL_ALWAYS_SOFTWARE).unwrap(), "0");
         });
     }
 }


### PR DESCRIPTION
## Status: **diagnostic mitigation only — not the root fix**

This PR was merged before the affected Fedora/Kinoite workstation result established that the official Ubuntu-built AppImage still aborts during initial EGL display creation even when all runtime guards are present.

The later evidence isolates the actual problem to the AppImage packaging/runtime combination:

- official Ubuntu-built AppImage + Fedora 44 Mesa/EGL/Wayland → `EGL_BAD_PARAMETER` and `WebKitWebProcess` abort;
- Fedora-toolbox-built AppImage on the same host Mesa/EGL stack → launches successfully;
- the WebKit environment guards reach the child process but do not alter that early EGL failure.

## What this PR contributed

- Added `LIBGL_ALWAYS_SOFTWARE=1` as an overrideable fallback guard.
- Added a privacy-safe WebKit/AppImage crash issue form.
- Added diagnostics that record the effective runtime guards.

## What it does **not** solve

It does not make the Ubuntu-built release AppImage compatible with Fedora 44/Mesa 26. Do not treat this PR as closing #73.

## Follow-up required

The root-fix work is tracked in #73: repair the release AppImage packaging (likely post-build removal of incompatible bundled Wayland/GLib/GStreamer infrastructure plus a Fedora/Wayland/Mesa smoke gate), while RPM remains the immediate Fedora/Kinoite install path.

## Verification performed in this PR

- `cargo test --manifest-path src-tauri/Cargo.toml webkit_runtime --features ui-plane --lib` — passed, 2 tests.
- `git diff --check` — passed.
- CI checks passed at merge time.

## Reference evidence

- [Fini #73 — Fedora/Kinoite affected-workstation result](https://github.com/VRuzhentsov/fini/issues/73)
- [Tauri #15665 — current AppImage bundler/Mesa 25+ failure](https://github.com/tauri-apps/tauri/issues/15665)
