### PR TITLE
Enable desktop auto updates

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -117,6 +117,9 @@ jobs:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          FINI_TAURI_UPDATER_PUBKEY: ${{ secrets.FINI_TAURI_UPDATER_PUBKEY }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
           set -euo pipefail
           required=(
@@ -124,6 +127,9 @@ jobs:
             ANDROID_KEYSTORE_PASSWORD
             ANDROID_KEY_ALIAS
             ANDROID_KEY_PASSWORD
+            FINI_TAURI_UPDATER_PUBKEY
+            TAURI_SIGNING_PRIVATE_KEY
+            TAURI_SIGNING_PRIVATE_KEY_PASSWORD
           )
           for key in "${required[@]}"; do
             if [ -z "${!key:-}" ]; then
@@ -299,6 +305,10 @@ jobs:
         run: npm ci
 
       - name: Build Linux bundles
+        env:
+          FINI_TAURI_UPDATER_PUBKEY: ${{ secrets.FINI_TAURI_UPDATER_PUBKEY }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm run tauri build -- --features ui-plane,desktop-updater --target ${{ matrix.rust_target }} --bundles appimage,deb,rpm -- --bin fini-app
 
       - name: Verify Linux desktop binary
@@ -436,6 +446,10 @@ jobs:
         run: npm ci
 
       - name: Build Windows bundles
+        env:
+          FINI_TAURI_UPDATER_PUBKEY: ${{ secrets.FINI_TAURI_UPDATER_PUBKEY }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm run tauri build -- --features ui-plane,desktop-updater,cli-plane --target ${{ matrix.rust_target }} --bundles nsis
 
       - name: Build Windows CLI
@@ -812,12 +826,26 @@ jobs:
       id-token: write
       attestations: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
       - name: Download built artifacts
         uses: actions/download-artifact@v4
         with:
           pattern: release-*
           path: release-assets
           merge-multiple: true
+
+      - name: Generate Tauri desktop updater manifest
+        run: |
+          set -euo pipefail
+          node scripts/generate-updater-manifest.mjs \
+            --assets-dir release-assets \
+            --repo "${GITHUB_REPOSITORY}" \
+            --tag "${GITHUB_REF_NAME}" \
+            --version "${GITHUB_REF_NAME#v}" \
+            --notes "See GitHub release notes for ${GITHUB_REF_NAME}." \
+            --output release-assets/latest.json
 
       - name: Create build provenance attestation
         uses: actions/attest-build-provenance@v2
@@ -838,10 +866,10 @@ jobs:
           fi
           for file in "${files[@]}"; do
             case "$file" in
-              *.sig) continue ;;
+              *.sig|*.cosign.sig) continue ;;
             esac
             cosign sign-blob --yes \
-              --output-signature "${file}.sig" \
+              --output-signature "${file}.cosign.sig" \
               "$file"
           done
 
@@ -871,12 +899,26 @@ jobs:
       id-token: write
       attestations: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
       - name: Download built artifacts
         uses: actions/download-artifact@v4
         with:
           pattern: release-*
           path: release-assets
           merge-multiple: true
+
+      - name: Generate Tauri desktop updater manifest
+        run: |
+          set -euo pipefail
+          node scripts/generate-updater-manifest.mjs \
+            --assets-dir release-assets \
+            --repo "${GITHUB_REPOSITORY}" \
+            --tag "${GITHUB_REF_NAME}" \
+            --version "${GITHUB_REF_NAME#v}" \
+            --notes "See GitHub release notes for ${GITHUB_REF_NAME}." \
+            --output release-assets/latest.json
 
       - name: Create build provenance attestation
         uses: actions/attest-build-provenance@v2
@@ -897,10 +939,10 @@ jobs:
           fi
           for file in "${files[@]}"; do
             case "$file" in
-              *.sig) continue ;;
+              *.sig|*.cosign.sig) continue ;;
             esac
             cosign sign-blob --yes \
-              --output-signature "${file}.sig" \
+              --output-signature "${file}.cosign.sig" \
               "$file"
           done
 

--- a/scripts/generate-updater-manifest.mjs
+++ b/scripts/generate-updater-manifest.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const ARCHES = new Map([
+  ['x64', 'x86_64'],
+  ['arm64', 'aarch64'],
+]);
+
+const LINUX_SUFFIXES = new Map([
+  ['.AppImage', 'appimage'],
+  ['.deb', 'deb'],
+  ['.rpm', 'rpm'],
+]);
+
+export async function generateUpdaterManifest({
+  assetsDir,
+  repo,
+  tag,
+  version,
+  notes = '',
+  output,
+  pubDate = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+}) {
+  const platforms = {};
+  const entries = await readdir(assetsDir, { withFileTypes: true });
+
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (!entry.isFile() || entry.name.endsWith('.sig') || entry.name.endsWith('.json')) {
+      continue;
+    }
+
+    const target = platformTarget(entry.name);
+    if (!target) {
+      continue;
+    }
+
+    const sigPath = join(assetsDir, `${entry.name}.sig`);
+    let signature;
+    try {
+      signature = (await readFile(sigPath, 'utf8')).trim();
+    } catch (error) {
+      if (error?.code === 'ENOENT') {
+        throw new Error(`missing Tauri updater signature for ${entry.name}: expected ${basename(sigPath)}`);
+      }
+      throw error;
+    }
+
+    if (!signature) {
+      throw new Error(`empty Tauri updater signature for ${entry.name}: ${basename(sigPath)}`);
+    }
+
+    const manifestEntry = {
+      signature,
+      url: githubReleaseDownloadUrl(repo, tag, entry.name),
+    };
+    platforms[target] = manifestEntry;
+
+    const fallback = fallbackTarget(target);
+    if (fallback && !platforms[fallback]) {
+      platforms[fallback] = manifestEntry;
+    }
+  }
+
+  if (Object.keys(platforms).length === 0) {
+    throw new Error(`no supported signed desktop updater artifacts found in ${assetsDir}`);
+  }
+
+  const manifest = {
+    version,
+    notes,
+    pub_date: pubDate,
+    platforms: Object.fromEntries(Object.entries(platforms).sort(([a], [b]) => a.localeCompare(b))),
+  };
+
+  await writeFile(output, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+  return manifest;
+}
+
+export function platformTarget(filename) {
+  for (const [archLabel, arch] of ARCHES) {
+    if (filename.includes(`-linux-${archLabel}`)) {
+      for (const [suffix, installer] of LINUX_SUFFIXES) {
+        if (filename.endsWith(suffix)) {
+          return `linux-${arch}-${installer}`;
+        }
+      }
+    }
+
+    if (filename.endsWith(`-windows-${archLabel}-setup.exe`)) {
+      return `windows-${arch}-nsis`;
+    }
+  }
+
+  return null;
+}
+
+export function fallbackTarget(target) {
+  if (target.endsWith('-appimage') || target.endsWith('-nsis')) {
+    return target.slice(0, target.lastIndexOf('-'));
+  }
+  return null;
+}
+
+function githubReleaseDownloadUrl(repo, tag, filename) {
+  return `https://github.com/${repo}/releases/download/${encodeURIComponent(tag)}/${encodeURIComponent(filename)}`;
+}
+
+function parseCliArgs(argv) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith('--') || value === undefined) {
+      throw new Error(`invalid arguments near ${key ?? '<end>'}`);
+    }
+    parsed[key.slice(2)] = value;
+  }
+
+  for (const required of ['assets-dir', 'repo', 'tag', 'version', 'output']) {
+    if (!parsed[required]) {
+      throw new Error(`missing required --${required}`);
+    }
+  }
+
+  return {
+    assetsDir: parsed['assets-dir'],
+    repo: parsed.repo,
+    tag: parsed.tag,
+    version: parsed.version,
+    notes: parsed.notes ?? '',
+    output: parsed.output,
+    pubDate: parsed['pub-date'],
+  };
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    await generateUpdaterManifest(parseCliArgs(process.argv.slice(2)));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/generate-updater-manifest.test.mjs
+++ b/scripts/generate-updater-manifest.test.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { generateUpdaterManifest, platformTarget } from './generate-updater-manifest.mjs';
+
+async function withAssets(files, fn) {
+  const dir = await mkdtemp(join(tmpdir(), 'fini-updater-manifest-'));
+  try {
+    for (const [name, signature] of Object.entries(files)) {
+      await writeFile(join(dir, name), 'artifact', 'utf8');
+      await writeFile(join(dir, `${name}.sig`), signature, 'utf8');
+    }
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('generates static updater manifest for desktop bundles', async () => {
+  await withAssets(
+    {
+      'fini-v1.2.3-linux-x64.AppImage': 'sig-appimage-x64',
+      'fini-v1.2.3-linux-x64.deb': 'sig-deb-x64',
+      'fini-v1.2.3-linux-x64.rpm': 'sig-rpm-x64',
+      'fini-v1.2.3-linux-arm64.AppImage': 'sig-appimage-arm64',
+      'fini-v1.2.3-windows-x64-setup.exe': 'sig-windows-x64',
+      'fini-v1.2.3-windows-arm64-setup.exe': 'sig-windows-arm64',
+      'fini-v1.2.3-linux-x64-cli.tar.gz': 'ignored-cli-signature',
+    },
+    async (assetsDir) => {
+      const output = join(assetsDir, 'latest.json');
+      await generateUpdaterManifest({
+        assetsDir,
+        repo: 'VRuzhentsov/fini',
+        tag: 'v1.2.3',
+        version: '1.2.3',
+        notes: 'test notes',
+        output,
+        pubDate: '2026-07-07T00:00:00Z',
+      });
+
+      const manifest = JSON.parse(await readFile(output, 'utf8'));
+      assert.equal(manifest.version, '1.2.3');
+      assert.equal(manifest.notes, 'test notes');
+      assert.equal(manifest.pub_date, '2026-07-07T00:00:00Z');
+
+      assert.deepEqual(manifest.platforms['linux-x86_64-appimage'], {
+        signature: 'sig-appimage-x64',
+        url: 'https://github.com/VRuzhentsov/fini/releases/download/v1.2.3/fini-v1.2.3-linux-x64.AppImage',
+      });
+      assert.equal(manifest.platforms['linux-x86_64-deb'].signature, 'sig-deb-x64');
+      assert.equal(manifest.platforms['linux-x86_64-rpm'].signature, 'sig-rpm-x64');
+      assert.equal(manifest.platforms['linux-aarch64-appimage'].signature, 'sig-appimage-arm64');
+      assert.equal(manifest.platforms['windows-x86_64-nsis'].signature, 'sig-windows-x64');
+      assert.equal(manifest.platforms['windows-aarch64-nsis'].signature, 'sig-windows-arm64');
+
+      assert.deepEqual(manifest.platforms['linux-x86_64'], manifest.platforms['linux-x86_64-appimage']);
+      assert.deepEqual(manifest.platforms['windows-x86_64'], manifest.platforms['windows-x86_64-nsis']);
+      assert.equal(manifest.platforms['cli-linux-x86_64'], undefined);
+    },
+  );
+});
+
+test('fails when a supported desktop artifact is missing its Tauri updater signature', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'fini-updater-manifest-'));
+  try {
+    await writeFile(join(dir, 'fini-v1.2.3-linux-x64.AppImage'), 'artifact', 'utf8');
+    await assert.rejects(
+      () => generateUpdaterManifest({
+        assetsDir: dir,
+        repo: 'VRuzhentsov/fini',
+        tag: 'v1.2.3',
+        version: '1.2.3',
+        notes: '',
+        output: join(dir, 'latest.json'),
+        pubDate: '2026-07-07T00:00:00Z',
+      }),
+      /missing Tauri updater signature/,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('recognizes only GUI installer artifacts as updater platforms', () => {
+  assert.equal(platformTarget('fini-v1.2.3-linux-x64.AppImage'), 'linux-x86_64-appimage');
+  assert.equal(platformTarget('fini-v1.2.3-linux-x64-cli.tar.gz'), null);
+  assert.equal(platformTarget('fini-v1.2.3-android.apk'), null);
+});

--- a/specs/cli/README.md
+++ b/specs/cli/README.md
@@ -61,6 +61,24 @@ Release builds should embed the Tauri updater public key with
 `FINI_UPDATE_PUBKEY` at runtime. `FINI_UPDATE_ENDPOINT` may override the default
 manifest endpoint for staging channels.
 
+## Desktop Updates
+
+Desktop app updates are automatic at startup for release desktop builds compiled
+with `ui-plane,desktop-updater`. They use Tauri's signed updater artifacts and a
+separate GUI manifest so desktop installers do not share CLI updater targets:
+
+```text
+https://github.com/VRuzhentsov/fini/releases/latest/download/latest.json
+```
+
+The manifest publishes desktop bundle targets such as `linux-x86_64-appimage`,
+`linux-x86_64-deb`, `linux-x86_64-rpm`, and `windows-x86_64-nsis`, with generic
+fallbacks for AppImage and NSIS targets. Release builds must provide
+`FINI_TAURI_UPDATER_PUBKEY` plus Tauri signing secrets so the app can verify and
+install updates. `FINI_DISABLE_AUTO_UPDATE=1` disables the startup check for
+diagnostics; `FINI_DESKTOP_UPDATE_ENDPOINT` and `FINI_DESKTOP_UPDATE_PUBKEY`
+override the release channel for staging.
+
 ## Verification
 
 Use these checks when changing the binary contract:

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -72,7 +72,7 @@ notify-rust = "4"
 [features]
 default = []
 ui-plane = []
-desktop-updater = ["dep:tauri-plugin-updater"]
+desktop-updater = ["dep:tauri-plugin-updater", "dep:url"]
 cli-plane = ["dep:clap", "dep:tauri-plugin-updater", "dep:url"]
 # Enable developer/test control-plane hooks. Off by default; production builds
 # must not ship this because it exposes an in-process Playwright socket bridge.

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -95,7 +95,13 @@ General notes:
   The resolved value of each guard is logged to stderr at startup
   (`[webkit-runtime] KEY=value`) so a packaged AppImage session can confirm
   which flags actually reached `WebKitWebProcess`.
-- **Desktop GUI**: `fini-app` is the bundled GUI binary and is built with `ui-plane,desktop-updater`
+- **Desktop GUI**: `fini-app` is the bundled GUI binary and is built with `ui-plane,desktop-updater`.
+  Release builds embed the Tauri updater public key with `FINI_TAURI_UPDATER_PUBKEY`,
+  publish the signed desktop updater manifest at
+  `https://github.com/VRuzhentsov/fini/releases/latest/download/latest.json`, and
+  check it automatically at startup. Set `FINI_DISABLE_AUTO_UPDATE=1` to skip the
+  startup check, or `FINI_DESKTOP_UPDATE_ENDPOINT` / `FINI_DESKTOP_UPDATE_PUBKEY`
+  for staging channels.
 - **CLI/runtime**: `fini` is the CLI-only binary and is built with `cli-plane`
 - **Android**: Built via `npm run tauri android build`; project lives in `gen/android/`
   - Android builds must pass `--features ui-plane` only so CLI modules and dependencies are excluded from the mobile bundle

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -201,6 +201,8 @@ pub fn run() {
         .setup(|app| {
             let app_handle = app.handle();
 
+            services::desktop_update::spawn_startup_auto_update(&app_handle);
+
             match try_open_db(&app_handle) {
                 Ok(conn) => {
                     app.manage(StartupRecoveryState(std::sync::Mutex::new(None)));

--- a/src-tauri/src/services/desktop_update.rs
+++ b/src-tauri/src/services/desktop_update.rs
@@ -1,0 +1,190 @@
+#[cfg(all(
+    feature = "desktop-updater",
+    any(target_os = "linux", target_os = "macos", target_os = "windows"),
+    not(debug_assertions)
+))]
+use tauri_plugin_updater::UpdaterExt;
+#[cfg(all(
+    feature = "desktop-updater",
+    any(target_os = "linux", target_os = "macos", target_os = "windows"),
+    not(debug_assertions)
+))]
+use url::Url;
+
+#[cfg(all(
+    feature = "desktop-updater",
+    any(target_os = "linux", target_os = "macos", target_os = "windows"),
+    not(debug_assertions)
+))]
+const DEFAULT_DESKTOP_UPDATE_ENDPOINT: &str =
+    "https://github.com/VRuzhentsov/fini/releases/latest/download/latest.json";
+#[cfg(all(
+    feature = "desktop-updater",
+    any(target_os = "linux", target_os = "macos", target_os = "windows"),
+    not(debug_assertions)
+))]
+const COMPILED_UPDATE_PUBKEY: Option<&str> = option_env!("FINI_TAURI_UPDATER_PUBKEY");
+#[cfg(all(
+    feature = "desktop-updater",
+    any(target_os = "linux", target_os = "macos", target_os = "windows"),
+    not(debug_assertions)
+))]
+const DISABLE_AUTO_UPDATE_ENV: &str = "FINI_DISABLE_AUTO_UPDATE";
+
+#[cfg(all(
+    feature = "desktop-updater",
+    any(target_os = "linux", target_os = "macos", target_os = "windows"),
+    not(debug_assertions)
+))]
+pub fn spawn_startup_auto_update(app: &tauri::AppHandle) {
+    if auto_update_disabled_from_env() {
+        eprintln!("[desktop-updater] startup auto-update disabled by {DISABLE_AUTO_UPDATE_ENV}");
+        return;
+    }
+
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        if let Err(error) = run_startup_auto_update(app).await {
+            eprintln!("[desktop-updater] startup auto-update skipped: {error}");
+        }
+    });
+}
+
+#[cfg(not(all(
+    feature = "desktop-updater",
+    any(target_os = "linux", target_os = "macos", target_os = "windows"),
+    not(debug_assertions)
+)))]
+pub fn spawn_startup_auto_update(_app: &tauri::AppHandle) {}
+
+#[cfg(all(
+    feature = "desktop-updater",
+    any(target_os = "linux", target_os = "macos", target_os = "windows"),
+    not(debug_assertions)
+))]
+async fn run_startup_auto_update(app: tauri::AppHandle) -> Result<(), String> {
+    let config = resolve_desktop_update_config()?;
+    let updater = app
+        .updater_builder()
+        .pubkey(config.pubkey.clone())
+        .endpoints(vec![config.endpoint.clone()])
+        .map_err(|error| format!("failed to configure updater endpoint: {error}"))?
+        .build()
+        .map_err(|error| format!("failed to build updater: {error}"))?;
+
+    let Some(update) = updater
+        .check()
+        .await
+        .map_err(|error| format!("failed to check for updates: {error}"))?
+    else {
+        eprintln!("[desktop-updater] no update available");
+        return Ok(());
+    };
+
+    eprintln!(
+        "[desktop-updater] installing update {} -> {}",
+        update.current_version, update.version
+    );
+
+    update
+        .download_and_install(
+            |downloaded, total| {
+                if let Some(total) = total {
+                    eprintln!("[desktop-updater] downloaded {downloaded}/{total} bytes");
+                } else {
+                    eprintln!("[desktop-updater] downloaded {downloaded} bytes");
+                }
+            },
+            || eprintln!("[desktop-updater] download finished"),
+        )
+        .await
+        .map_err(|error| format!("failed to install update: {error}"))?;
+
+    eprintln!("[desktop-updater] update installed; restarting");
+    app.restart();
+}
+
+#[cfg(all(
+    feature = "desktop-updater",
+    any(target_os = "linux", target_os = "macos", target_os = "windows"),
+    not(debug_assertions)
+))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DesktopUpdateConfig {
+    endpoint: Url,
+    pubkey: String,
+}
+
+#[cfg(all(
+    feature = "desktop-updater",
+    any(target_os = "linux", target_os = "macos", target_os = "windows"),
+    not(debug_assertions)
+))]
+fn resolve_desktop_update_config() -> Result<DesktopUpdateConfig, String> {
+    let endpoint = std::env::var("FINI_DESKTOP_UPDATE_ENDPOINT")
+        .or_else(|_| std::env::var("FINI_UPDATE_ENDPOINT"))
+        .unwrap_or_else(|_| DEFAULT_DESKTOP_UPDATE_ENDPOINT.to_string())
+        .parse::<Url>()
+        .map_err(|error| format!("invalid desktop updater endpoint: {error}"))?;
+    let pubkey = std::env::var("FINI_DESKTOP_UPDATE_PUBKEY")
+        .or_else(|_| std::env::var("FINI_UPDATE_PUBKEY"))
+        .ok()
+        .or_else(|| COMPILED_UPDATE_PUBKEY.map(str::to_string))
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            "missing Tauri updater public key; set FINI_DESKTOP_UPDATE_PUBKEY, FINI_UPDATE_PUBKEY, or build with FINI_TAURI_UPDATER_PUBKEY".to_string()
+        })?;
+
+    Ok(DesktopUpdateConfig { endpoint, pubkey })
+}
+
+#[cfg(all(
+    feature = "desktop-updater",
+    any(target_os = "linux", target_os = "macos", target_os = "windows"),
+    not(debug_assertions)
+))]
+fn auto_update_disabled_from_env() -> bool {
+    std::env::var(DISABLE_AUTO_UPDATE_ENV)
+        .map(|value| auto_update_disabled_value(&value))
+        .unwrap_or(false)
+}
+
+#[cfg(any(
+    test,
+    all(
+        feature = "desktop-updater",
+        any(target_os = "linux", target_os = "macos", target_os = "windows"),
+        not(debug_assertions)
+    )
+))]
+fn auto_update_disabled_value(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_truthy_auto_update_disable_values() {
+        for value in ["1", "true", "TRUE", " yes ", "on"] {
+            assert!(
+                auto_update_disabled_value(value),
+                "{value:?} should disable updates"
+            );
+        }
+    }
+
+    #[test]
+    fn ignores_falsey_auto_update_disable_values() {
+        for value in ["", "0", "false", "no", "off", "anything-else"] {
+            assert!(
+                !auto_update_disabled_value(value),
+                "{value:?} should not disable updates"
+            );
+        }
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -6,6 +6,8 @@ pub mod cli;
 #[cfg(feature = "cli-plane")]
 pub mod cli_update;
 pub mod db;
+#[cfg(feature = "ui-plane")]
+pub mod desktop_update;
 pub mod device_connection;
 pub mod due_time;
 #[cfg(any(feature = "ui-plane", test))]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,7 +25,7 @@
   },
   "bundle": {
     "active": true,
-    "createUpdaterArtifacts": false,
+    "createUpdaterArtifacts": true,
     "targets": "all",
     "icon": [
       "icons/icon.png",


### PR DESCRIPTION
## Summary
- add release-only desktop startup updater using Tauri signed update manifests
- generate and publish a desktop latest.json manifest from release artifacts
- pass Tauri updater signing env/secrets through release builds and keep cosign signatures separate from Tauri .sig files
- document desktop update endpoint/key overrides and disable switch

## Test Plan
- node --test scripts/generate-updater-manifest.test.mjs
- cargo check --manifest-path src-tauri/Cargo.toml --bin fini-app --features ui-plane,desktop-updater
- cargo check --release --manifest-path src-tauri/Cargo.toml --bin fini-app --features ui-plane,desktop-updater
- cargo test --manifest-path src-tauri/Cargo.toml --lib --features ui-plane,desktop-updater desktop_update
- cargo check --manifest-path src-tauri/Cargo.toml --bin fini --features cli-plane
- npm ci && npm run build
- rustfmt --edition 2021 --check src-tauri/src/services/desktop_update.rs
- node --check scripts/generate-updater-manifest.mjs
- node --check scripts/generate-updater-manifest.test.mjs
- git diff --check

Note: actionlint was not available in this local environment.