### PR TITLE
Add automatic update Settings toggle

### DIFF
--- a/.agents/skills/fini-dev/SKILL.md
+++ b/.agents/skills/fini-dev/SKILL.md
@@ -90,6 +90,7 @@ For GitHub issue or ticket work, inspect the ticket labels before choosing the d
 | Validate Android behavior, prove Android navigation/state, or debug Android-only behavior | `fini-android-testing` |
 | Run, write, debug, or organize unit, integration, or e2e tests across frontend Jest, backend cargo, single-actor UI e2e, multi-actor e2e, or CLI e2e. For Android-only behavior, use `fini-android-testing` instead | `fini-test` |
 | Ticket has GitHub label `design`, or work designs/refines native Figma components, variants, screens, visual systems, or Fini UI surfaces | `fini-design` |
+| Change Vue frontend code under `src/`, especially view components, templates, conditional rendering, lists, or frontend tests | `fini-frontend`; also load `fini-test` for test authoring/execution |
 | First-run setup, bootstrap, install, or verification of required sibling project context such as `../fini-wiki/` | `fini-dev-install` |
 | Add or change Makefile targets, npm scripts, `xtask`, CI command orchestration, build tooling, packaging tooling, or repo-local automation architecture | `fini-scripting` |
 | Make a release, bump a release version for shipping, push a release tag, inspect release readiness, fix release automation, or verify release CI | `fini-release`; also load `fini-versioning` for metadata semantics and `fini-scripting` when automation changes are needed |
@@ -100,7 +101,7 @@ For GitHub issue or ticket work, inspect the ticket labels before choosing the d
 | QA a web/app flow and fix bugs found | `qa` |
 | QA report only, without fixes | `qa-only` |
 | Browser dogfooding, screenshots, forms, responsive checks, or live site interaction | `browse` or `gstack` |
-| Frontend UI construction or visual polish in code | `frontend-design`, then preserve existing Fini patterns |
+| Frontend UI construction or visual polish in code | `fini-frontend`, then `frontend-design` when visual design-system work is needed |
 | Code review or pre-landing diff review | `review` |
 | Ship, push, create PR, or prepare code for landing | `ship` |
 | Merge, deploy, or production verification | `land-and-deploy` or `canary` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Structure
 
-- Frontend (Vue 3): `src/` — see `src/README.md` and `skills/fini-frontend/SKILL.md`
+- Frontend (Vue 3): `src/` — see `src/README.md`
 - Backend (Rust + Tauri): `src-tauri/` — see `src-tauri/README.md`
 - Domain and feature specs: `specs/`
 - Repo automation: `Makefile` + `npm run` + `xtask/` — see `fini-scripting` skill

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,9 @@ When working inside that directory, load its `AGENTS.md` as the authoritative sc
 - Always load the `fini-dev` skill at the start of development work in this repo.
 - Use `fini-dev` to choose which repo-local or gstack skill applies, which Makefile target to run, and what evidence is required before reporting success.
 - `fini-dev` orchestrates workflow only; use the specialized skill for the actual domain work when it applies.
-- Do not commit implementation changes until the user has verified they work.
-- Docs and spec changes can be committed freely.
+- Use the pull request as the normal user review and verification surface for ticket/worktree implementation. After local checks pass, commit and push implementation changes to the active PR branch so they are reviewable there; do not leave verified implementation only in local working-tree state unless the user explicitly asks for local-only work.
+- If the user explicitly asks to manually verify a local build before review, pause before committing implementation changes and report the exact local state and verification command.
+- Docs, specs, and workflow-instruction changes can be committed freely.
 
 ## Command preference
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Structure
 
-- Frontend (Vue 3): `src/` — see `src/README.md`
+- Frontend (Vue 3): `src/` — see `src/README.md` and `skills/fini-frontend/SKILL.md`
 - Backend (Rust + Tauri): `src-tauri/` — see `src-tauri/README.md`
 - Domain and feature specs: `specs/`
 - Repo automation: `Makefile` + `npm run` + `xtask/` — see `fini-scripting` skill

--- a/skills/fini-frontend/SKILL.md
+++ b/skills/fini-frontend/SKILL.md
@@ -32,8 +32,11 @@ const renderFlags = computed(() => ({
 Rules:
 
 - Every non-trivial `v-if`, `v-show`, or conditional template section should use a named `renderFlags` key.
+- `renderFlags` is not the source of all component state. It is only the template render contract: each key answers whether a specific UI section or element should render.
+- Keep domain state, loading state, form state, selected entities, fetched data, and user input in their normal refs, stores, or computed values outside `renderFlags`.
+- Let `renderFlags` derive from those state sources instead of replacing them.
 - Each key should describe the UI section or element being rendered, not the low-level implementation detail.
-- Keep product/platform logic in the computed flag, not in the template.
+- Keep product/platform render logic in the computed flag, not in the template.
 - Prefer names like `automaticUpdatesSection`, `emptyState`, `deviceList`, or `restoreNotice` over names like `isDesktopAndEnabled`.
 - Simple local DOM-only toggles may stay inline only when the condition is self-evident and not product/platform logic.
 

--- a/skills/fini-frontend/SKILL.md
+++ b/skills/fini-frontend/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: fini-frontend
+description: "Fini Vue frontend implementation conventions for views, templates, rendering decisions, and tests."
+---
+
+# Fini Frontend Workflow
+
+Use this skill when creating or changing Vue frontend code under `src/`, especially view components, templates, conditional rendering, lists, and frontend tests.
+
+## Template Rendering Rules
+
+### Centralize render decisions in `renderFlags`
+
+Avoid embedding render decision logic directly in Vue templates with ad hoc expressions such as:
+
+```vue
+<section v-if="startupAutoUpdateSupported && !loading">
+```
+
+Instead, expose a computed `renderFlags` object from the component and bind template conditionals to named flags:
+
+```ts
+const renderFlags = computed(() => ({
+  automaticUpdatesSection: startupAutoUpdateSupported.value,
+}));
+```
+
+```vue
+<section v-if="renderFlags.automaticUpdatesSection">
+```
+
+Rules:
+
+- Every non-trivial `v-if`, `v-show`, or conditional template section should use a named `renderFlags` key.
+- Each key should describe the UI section or element being rendered, not the low-level implementation detail.
+- Keep product/platform logic in the computed flag, not in the template.
+- Prefer names like `automaticUpdatesSection`, `emptyState`, `deviceList`, or `restoreNotice` over names like `isDesktopAndEnabled`.
+- Simple local DOM-only toggles may stay inline only when the condition is self-evident and not product/platform logic.
+
+### Centralize list sources for `v-for`
+
+For non-trivial lists, avoid filtering, sorting, or mapping directly inside `v-for`.
+
+Prefer a named computed list source:
+
+```ts
+const renderLists = computed(() => ({
+  visibleDevices: devices.value.filter((device) => device.visible),
+}));
+```
+
+```vue
+<DeviceRow
+  v-for="device in renderLists.visibleDevices"
+  :key="device.id"
+  :device="device"
+/>
+```
+
+Rules:
+
+- `v-for` should normally iterate over a named source that is already filtered and ordered.
+- Keep data shaping and eligibility logic outside the template.
+- Use stable keys derived from domain IDs when available.
+
+## Testing Expectations
+
+When adding or changing render flags:
+
+- Add or update component tests for both visible and hidden states when the condition is product/platform behavior.
+- Prefer assertions on user-visible labels or test IDs, not internal computed names.
+- Include at least one test that would fail if the section rendered unconditionally.
+
+## Review Checklist
+
+Before handing off frontend template changes, check:
+
+- Template conditionals use `renderFlags` for product/platform rendering decisions.
+- Non-trivial list rendering uses a named computed list source.
+- Tests cover important visible and hidden render states.
+- `npm run build` or the relevant frontend test target passes.

--- a/specs/cli/README.md
+++ b/specs/cli/README.md
@@ -75,9 +75,11 @@ The manifest publishes desktop bundle targets such as `linux-x86_64-appimage`,
 `linux-x86_64-deb`, `linux-x86_64-rpm`, and `windows-x86_64-nsis`, with generic
 fallbacks for AppImage and NSIS targets. Release builds must provide
 `FINI_TAURI_UPDATER_PUBKEY` plus Tauri signing secrets so the app can verify and
-install updates. `FINI_DISABLE_AUTO_UPDATE=1` disables the startup check for
-diagnostics; `FINI_DESKTOP_UPDATE_ENDPOINT` and `FINI_DESKTOP_UPDATE_PUBKEY`
-override the release channel for staging.
+install updates when Settings -> Updates -> Automatic updates is enabled.
+Turning that setting off skips the next startup auto-update check.
+`FINI_DISABLE_AUTO_UPDATE=1` disables the startup check for diagnostics;
+`FINI_DESKTOP_UPDATE_ENDPOINT` and `FINI_DESKTOP_UPDATE_PUBKEY` override the
+release channel for staging.
 
 ## Verification
 

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -99,9 +99,10 @@ General notes:
   Release builds embed the Tauri updater public key with `FINI_TAURI_UPDATER_PUBKEY`,
   publish the signed desktop updater manifest at
   `https://github.com/VRuzhentsov/fini/releases/latest/download/latest.json`, and
-  check it automatically at startup. Set `FINI_DISABLE_AUTO_UPDATE=1` to skip the
-  startup check, or `FINI_DESKTOP_UPDATE_ENDPOINT` / `FINI_DESKTOP_UPDATE_PUBKEY`
-  for staging channels.
+  check it automatically at startup when Settings -> Updates -> Automatic updates
+  is enabled. Turning that setting off skips the next startup auto-update check;
+  set `FINI_DISABLE_AUTO_UPDATE=1` to skip the startup check for diagnostics, or
+  `FINI_DESKTOP_UPDATE_ENDPOINT` / `FINI_DESKTOP_UPDATE_PUBKEY` for staging channels.
 - **CLI/runtime**: `fini` is the CLI-only binary and is built with `cli-plane`
 - **Android**: Built via `npm run tauri android build`; project lives in `gen/android/`
   - Android builds must pass `--features ui-plane` only so CLI modules and dependencies are excluded from the mobile bundle

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -153,6 +153,23 @@ fn theme_hint(db: tauri::State<AppDbConnection>) -> String {
 
 #[cfg(feature = "ui-plane")]
 #[tauri::command]
+fn get_auto_update_enabled(db: tauri::State<AppDbConnection>) -> Result<bool, String> {
+    let mut conn = db.0.lock().unwrap();
+    settings::automatic_updates_enabled(&mut conn)
+}
+
+#[cfg(feature = "ui-plane")]
+#[tauri::command]
+fn set_auto_update_enabled(
+    db: tauri::State<AppDbConnection>,
+    enabled: bool,
+) -> Result<bool, String> {
+    let mut conn = db.0.lock().unwrap();
+    settings::set_automatic_updates_enabled(&mut conn, enabled)
+}
+
+#[cfg(feature = "ui-plane")]
+#[tauri::command]
 fn sync_native_theme(app: AppHandle, theme: String) {
     settings::apply_native_theme(&app, &theme);
 }
@@ -201,12 +218,19 @@ pub fn run() {
         .setup(|app| {
             let app_handle = app.handle();
 
-            services::desktop_update::spawn_startup_auto_update(&app_handle);
-
             match try_open_db(&app_handle) {
                 Ok(conn) => {
                     app.manage(StartupRecoveryState(std::sync::Mutex::new(None)));
                     app.manage(AppDbConnection(std::sync::Mutex::new(conn)));
+                    let auto_updates_enabled = {
+                        let db = app.state::<AppDbConnection>();
+                        let mut conn = db.0.lock().unwrap();
+                        settings::automatic_updates_enabled(&mut conn).unwrap_or(true)
+                    };
+                    services::desktop_update::spawn_startup_auto_update(
+                        &app_handle,
+                        auto_updates_enabled,
+                    );
                     #[cfg(target_os = "linux")]
                     if let Err(error) =
                         services::appimage_desktop::self_register_appimage_desktop_entry()
@@ -303,6 +327,8 @@ pub fn run() {
             space_sync_tick,
             space_sync_status,
             theme_hint,
+            get_auto_update_enabled,
+            set_auto_update_enabled,
             get_theme_mode,
             set_theme_mode,
             sync_native_theme,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -240,6 +240,7 @@ pub fn run() {
                 }
                 Err(error) => match unsupported_schema_startup_recovery(error.clone()) {
                     Some(recovery) => {
+                        services::desktop_update::spawn_startup_auto_update(&app_handle, true);
                         app.manage(StartupRecoveryState(std::sync::Mutex::new(Some(recovery))));
                         return Ok(());
                     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod models;
 mod schema;
 mod services;
+mod utils;
 #[cfg(all(feature = "ui-plane", target_os = "linux"))]
 mod webkit_runtime;
 // mod voice;       // postponed

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -171,6 +171,12 @@ fn set_auto_update_enabled(
 
 #[cfg(feature = "ui-plane")]
 #[tauri::command]
+fn startup_auto_update_supported() -> bool {
+    services::desktop_update::startup_auto_update_supported()
+}
+
+#[cfg(feature = "ui-plane")]
+#[tauri::command]
 fn sync_native_theme(app: AppHandle, theme: String) {
     settings::apply_native_theme(&app, &theme);
 }
@@ -331,6 +337,7 @@ pub fn run() {
             theme_hint,
             get_auto_update_enabled,
             set_auto_update_enabled,
+            startup_auto_update_supported,
             get_theme_mode,
             set_theme_mode,
             sync_native_theme,

--- a/src-tauri/src/services/desktop_update.rs
+++ b/src-tauri/src/services/desktop_update.rs
@@ -36,7 +36,12 @@ const DISABLE_AUTO_UPDATE_ENV: &str = "FINI_DISABLE_AUTO_UPDATE";
     any(target_os = "linux", target_os = "macos", target_os = "windows"),
     not(debug_assertions)
 ))]
-pub fn spawn_startup_auto_update(app: &tauri::AppHandle) {
+pub fn spawn_startup_auto_update(app: &tauri::AppHandle, automatic_updates_enabled: bool) {
+    if !automatic_updates_enabled {
+        eprintln!("[desktop-updater] startup auto-update disabled by Settings");
+        return;
+    }
+
     if auto_update_disabled_from_env() {
         eprintln!("[desktop-updater] startup auto-update disabled by {DISABLE_AUTO_UPDATE_ENV}");
         return;
@@ -55,7 +60,7 @@ pub fn spawn_startup_auto_update(app: &tauri::AppHandle) {
     any(target_os = "linux", target_os = "macos", target_os = "windows"),
     not(debug_assertions)
 )))]
-pub fn spawn_startup_auto_update(_app: &tauri::AppHandle) {}
+pub fn spawn_startup_auto_update(_app: &tauri::AppHandle, _automatic_updates_enabled: bool) {}
 
 #[cfg(all(
     feature = "desktop-updater",

--- a/src-tauri/src/services/desktop_update.rs
+++ b/src-tauri/src/services/desktop_update.rs
@@ -62,6 +62,18 @@ pub fn spawn_startup_auto_update(app: &tauri::AppHandle, automatic_updates_enabl
 )))]
 pub fn spawn_startup_auto_update(_app: &tauri::AppHandle, _automatic_updates_enabled: bool) {}
 
+pub fn startup_auto_update_supported() -> bool {
+    cfg!(all(
+        feature = "desktop-updater",
+        any(
+            target_os = "linux",
+            target_os = "macos",
+            target_os = "windows"
+        ),
+        not(debug_assertions)
+    ))
+}
+
 #[cfg(all(
     feature = "desktop-updater",
     any(target_os = "linux", target_os = "macos", target_os = "windows"),

--- a/src-tauri/src/services/settings.rs
+++ b/src-tauri/src/services/settings.rs
@@ -7,6 +7,7 @@ use crate::models::{Setting, UpsertSettingInput};
 use crate::schema::settings;
 #[cfg(all(feature = "ui-plane", target_os = "linux"))]
 use crate::services::db::AppDbConnection;
+use crate::utils::text::{bool_to_str, parse_bool};
 #[cfg(all(feature = "ui-plane", target_os = "linux"))]
 use gtk::prelude::GtkSettingsExt;
 #[cfg(feature = "ui-plane")]
@@ -92,28 +93,16 @@ pub fn set_theme_mode(conn: &mut SqliteConnection, mode: ThemeMode) -> Result<Th
     Ok(mode)
 }
 
-fn bool_setting_value(value: bool) -> &'static str {
-    if value {
-        "true"
-    } else {
-        "false"
-    }
-}
-
 fn parse_bool_setting(value: &str, default: bool) -> bool {
-    match value.trim().to_ascii_lowercase().as_str() {
-        "true" | "1" | "yes" | "on" => true,
-        "false" | "0" | "no" | "off" => false,
-        _ => default,
-    }
+    parse_bool(value).unwrap_or(default)
 }
 
 pub fn automatic_updates_enabled(conn: &mut SqliteConnection) -> Result<bool, String> {
     let value = match load_setting(conn, AUTO_UPDATE_ENABLED_KEY)? {
         Some(value) => value,
         None => {
-            upsert_setting(conn, AUTO_UPDATE_ENABLED_KEY, bool_setting_value(true))?;
-            bool_setting_value(true).to_string()
+            upsert_setting(conn, AUTO_UPDATE_ENABLED_KEY, bool_to_str(true))?;
+            bool_to_str(true).to_string()
         }
     };
 
@@ -124,7 +113,7 @@ pub fn set_automatic_updates_enabled(
     conn: &mut SqliteConnection,
     enabled: bool,
 ) -> Result<bool, String> {
-    upsert_setting(conn, AUTO_UPDATE_ENABLED_KEY, bool_setting_value(enabled))?;
+    upsert_setting(conn, AUTO_UPDATE_ENABLED_KEY, bool_to_str(enabled))?;
     Ok(enabled)
 }
 

--- a/src-tauri/src/services/settings.rs
+++ b/src-tauri/src/services/settings.rs
@@ -15,6 +15,7 @@ use tauri::{AppHandle, Theme};
 use tauri::{Emitter, Manager};
 
 const THEME_KEY: &str = "theme";
+const AUTO_UPDATE_ENABLED_KEY: &str = "automatic_updates_enabled";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ThemeMode {
@@ -88,6 +89,42 @@ pub fn theme_mode(conn: &mut SqliteConnection) -> Result<ThemeMode, String> {
 pub fn set_theme_mode(conn: &mut SqliteConnection, mode: ThemeMode) -> Result<ThemeMode, String> {
     upsert_setting(conn, THEME_KEY, mode.as_str())?;
     Ok(mode)
+}
+
+fn bool_setting_value(value: bool) -> &'static str {
+    if value {
+        "true"
+    } else {
+        "false"
+    }
+}
+
+fn parse_bool_setting(value: &str, default: bool) -> bool {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" | "on" => true,
+        "false" | "0" | "no" | "off" => false,
+        _ => default,
+    }
+}
+
+pub fn automatic_updates_enabled(conn: &mut SqliteConnection) -> Result<bool, String> {
+    let value = match load_setting(conn, AUTO_UPDATE_ENABLED_KEY)? {
+        Some(value) => value,
+        None => {
+            upsert_setting(conn, AUTO_UPDATE_ENABLED_KEY, bool_setting_value(true))?;
+            bool_setting_value(true).to_string()
+        }
+    };
+
+    Ok(parse_bool_setting(&value, true))
+}
+
+pub fn set_automatic_updates_enabled(
+    conn: &mut SqliteConnection,
+    enabled: bool,
+) -> Result<bool, String> {
+    upsert_setting(conn, AUTO_UPDATE_ENABLED_KEY, bool_setting_value(enabled))?;
+    Ok(enabled)
 }
 
 #[cfg(feature = "ui-plane")]
@@ -260,6 +297,22 @@ mod tests {
         assert_eq!(ThemeMode::parse("light"), Some(ThemeMode::Light));
         assert_eq!(ThemeMode::parse("dark"), Some(ThemeMode::Dark));
         assert_eq!(ThemeMode::parse("wat"), None);
+    }
+
+    #[test]
+    fn parses_bool_settings_with_safe_default() {
+        use super::parse_bool_setting;
+
+        for value in ["true", "1", " yes ", "ON"] {
+            assert!(parse_bool_setting(value, false));
+        }
+
+        for value in ["false", "0", " no ", "OFF"] {
+            assert!(!parse_bool_setting(value, true));
+        }
+
+        assert!(parse_bool_setting("unexpected", true));
+        assert!(!parse_bool_setting("unexpected", false));
     }
 
     #[cfg(feature = "ui-plane")]

--- a/src-tauri/src/services/settings.rs
+++ b/src-tauri/src/services/settings.rs
@@ -3,7 +3,7 @@ use diesel::sqlite::SqliteConnection;
 #[cfg(all(feature = "ui-plane", target_os = "linux"))]
 use std::thread;
 
-use crate::models::UpsertSettingInput;
+use crate::models::{Setting, UpsertSettingInput};
 use crate::schema::settings;
 #[cfg(all(feature = "ui-plane", target_os = "linux"))]
 use crate::services::db::AppDbConnection;
@@ -68,9 +68,10 @@ pub(crate) fn load_setting(
 ) -> Result<Option<String>, String> {
     settings::table
         .filter(settings::key.eq(key))
-        .select(settings::value)
-        .first::<String>(conn)
+        .select(Setting::as_select())
+        .first::<Setting>(conn)
         .optional()
+        .map(|setting| setting.map(|setting| setting.value))
         .map_err(|e| e.to_string())
 }
 

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod text;

--- a/src-tauri/src/utils/text.rs
+++ b/src-tauri/src/utils/text.rs
@@ -1,0 +1,51 @@
+pub fn bool_to_str(value: bool) -> &'static str {
+    if value {
+        "true"
+    } else {
+        "false"
+    }
+}
+
+pub fn parse_bool(value: &str) -> Option<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" | "on" => Some(true),
+        "false" | "0" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{bool_to_str, parse_bool};
+
+    #[test]
+    fn encodes_bools_as_lowercase_text() {
+        assert_eq!(bool_to_str(true), "true");
+        assert_eq!(bool_to_str(false), "false");
+    }
+
+    #[test]
+    fn parses_common_boolean_text_values() {
+        assert_eq!(parse_bool("true"), Some(true));
+        assert_eq!(parse_bool("1"), Some(true));
+        assert_eq!(parse_bool("yes"), Some(true));
+        assert_eq!(parse_bool("on"), Some(true));
+        assert_eq!(parse_bool("false"), Some(false));
+        assert_eq!(parse_bool("0"), Some(false));
+        assert_eq!(parse_bool("no"), Some(false));
+        assert_eq!(parse_bool("off"), Some(false));
+    }
+
+    #[test]
+    fn parses_boolean_text_case_insensitively_and_trims_whitespace() {
+        assert_eq!(parse_bool(" TRUE "), Some(true));
+        assert_eq!(parse_bool(" Off\n"), Some(false));
+    }
+
+    #[test]
+    fn rejects_unknown_boolean_text() {
+        assert_eq!(parse_bool(""), None);
+        assert_eq!(parse_bool("maybe"), None);
+        assert_eq!(parse_bool("enabled"), None);
+    }
+}

--- a/src/spec/views/SettingsView.spec.ts
+++ b/src/spec/views/SettingsView.spec.ts
@@ -121,12 +121,15 @@ describe("SettingsView automatic updates", () => {
   });
 
   it("renders the automatic updates toggle from persisted settings", async () => {
-    (invoke as jest.Mock).mockResolvedValueOnce(false);
+    (invoke as jest.Mock)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
 
     const wrapper = mountSettingsView();
     await flushUi();
 
     const toggle = wrapper.find('[data-testid="automatic-updates-toggle"]');
+    expect(invoke).toHaveBeenCalledWith("startup_auto_update_supported");
     expect(invoke).toHaveBeenCalledWith("get_auto_update_enabled");
     expect(wrapper.text()).toContain("Automatic updates");
     expect(wrapper.text()).toContain("When this is off, Fini will not install updates automatically on the next restart.");
@@ -135,6 +138,7 @@ describe("SettingsView automatic updates", () => {
 
   it("persists automatic updates toggle changes", async () => {
     (invoke as jest.Mock)
+      .mockResolvedValueOnce(true)
       .mockResolvedValueOnce(true)
       .mockResolvedValueOnce(false);
 
@@ -149,5 +153,16 @@ describe("SettingsView automatic updates", () => {
 
     expect(invoke).toHaveBeenLastCalledWith("set_auto_update_enabled", { enabled: false });
     expect((toggle.element as HTMLInputElement).checked).toBe(false);
+  });
+
+  it("hides automatic updates settings when startup updates are unsupported", async () => {
+    (invoke as jest.Mock).mockResolvedValueOnce(false);
+
+    const wrapper = mountSettingsView();
+    await flushUi();
+
+    expect(wrapper.find('[data-testid="settings-updates"]').exists()).toBe(false);
+    expect(invoke).toHaveBeenCalledWith("startup_auto_update_supported");
+    expect(invoke).not.toHaveBeenCalledWith("get_auto_update_enabled");
   });
 });

--- a/src/spec/views/SettingsView.spec.ts
+++ b/src/spec/views/SettingsView.spec.ts
@@ -1,0 +1,153 @@
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import { invoke } from "@tauri-apps/api/core";
+import SettingsView from "../../views/SettingsView.vue";
+import { useSpaceStore } from "../../stores/space";
+import { useDeviceStore } from "../../stores/device";
+
+jest.mock("@tauri-apps/api/core", () => ({
+  invoke: jest.fn(),
+}));
+
+jest.mock("../../package.json", () => ({
+  __esModule: true,
+  default: { version: "0.1.41" },
+  version: "0.1.41",
+}), { virtual: true });
+
+jest.mock("../../../package.json", () => ({
+  __esModule: true,
+  default: { version: "0.1.41" },
+  version: "0.1.41",
+}));
+
+jest.mock("@heroicons/vue/24/outline", () => ({
+  PencilIcon: { name: "PencilIcon", template: "<span />" },
+  TrashIcon: { name: "TrashIcon", template: "<span />" },
+}));
+
+jest.mock("../../stores/space", () => ({
+  useSpaceStore: jest.fn(),
+  isBuiltinSpace: (id: string) => ["1", "2", "3"].includes(id),
+}));
+
+jest.mock("../../stores/device", () => ({
+  useDeviceStore: jest.fn(),
+}));
+
+jest.mock("../../composables/useContextMenu", () => ({
+  useContextMenu: () => ({ open: jest.fn() }),
+}));
+
+jest.mock("../../composables/useBackupImport", () => ({
+  useBackupImport: () => ({
+    startImport: jest.fn(),
+    cancelImport: jest.fn(),
+    confirmMapping: jest.fn(),
+    applyImport: jest.fn(),
+    error: { value: null },
+    activeMapping: { value: null },
+    selectableSpaces: { value: [] },
+    mappingIndex: { value: 0 },
+    totalMappings: { value: 0 },
+    showConflicts: { value: false },
+    conflicts: { value: [] },
+  }),
+}));
+
+jest.mock("../../components/SettingsView/AboutCard.vue", () => ({
+  name: "AboutCard",
+  template: "<section data-testid='about-card-stub' />",
+}));
+
+jest.mock("../../components/SettingsView/ExportSpacesDialog.vue", () => ({
+  name: "ExportSpacesDialog",
+  template: "<section data-testid='export-spaces-dialog-stub' />",
+}));
+
+jest.mock("../../components/SettingsView/ImportSpaceMappingDialog.vue", () => ({
+  name: "ImportSpaceMappingDialog",
+  template: "<section data-testid='import-space-mapping-dialog-stub' />",
+}));
+
+jest.mock("../../components/SettingsView/MergeConflictDialog.vue", () => ({
+  name: "MergeConflictDialog",
+  template: "<section data-testid='merge-conflict-dialog-stub' />",
+}));
+
+jest.mock("../../components/SettingsView/ThemeSelector.vue", () => ({
+  name: "ThemeSelector",
+  template: "<section data-testid='theme-selector-stub' />",
+}));
+
+async function flushUi() {
+  for (let i = 0; i < 4; i += 1) {
+    await Promise.resolve();
+    await nextTick();
+  }
+}
+
+function mountSettingsView() {
+  return mount(SettingsView, {
+    global: {
+      stubs: {
+        "router-link": { template: "<a><slot /></a>" },
+        ThemeSelector: { template: "<section data-testid='theme-selector-stub' />" },
+        AboutCard: { template: "<section data-testid='about-card-stub' />", props: ["version", "sourceUrl"] },
+        ExportSpacesDialog: true,
+        ImportSpaceMappingDialog: true,
+        MergeConflictDialog: true,
+      },
+    },
+  });
+}
+
+describe("SettingsView automatic updates", () => {
+  beforeEach(() => {
+    (useSpaceStore as unknown as jest.Mock).mockReturnValue({
+      spaces: [],
+      error: null,
+      fetchSpaces: jest.fn().mockResolvedValue(undefined),
+      createSpace: jest.fn().mockResolvedValue(undefined),
+      updateSpace: jest.fn().mockResolvedValue(undefined),
+      deleteSpace: jest.fn().mockResolvedValue(undefined),
+    });
+    (useDeviceStore as unknown as jest.Mock).mockReturnValue({
+      pairedDevices: [],
+      hydrate: jest.fn().mockResolvedValue(undefined),
+      isDeviceOnline: jest.fn().mockReturnValue(false),
+    });
+    (invoke as jest.Mock).mockReset();
+  });
+
+  it("renders the automatic updates toggle from persisted settings", async () => {
+    (invoke as jest.Mock).mockResolvedValueOnce(false);
+
+    const wrapper = mountSettingsView();
+    await flushUi();
+
+    const toggle = wrapper.find('[data-testid="automatic-updates-toggle"]');
+    expect(invoke).toHaveBeenCalledWith("get_auto_update_enabled");
+    expect(wrapper.text()).toContain("Automatic updates");
+    expect(wrapper.text()).toContain("When this is off, Fini will not install updates automatically on the next restart.");
+    expect((toggle.element as HTMLInputElement).checked).toBe(false);
+  });
+
+  it("persists automatic updates toggle changes", async () => {
+    (invoke as jest.Mock)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+
+    const wrapper = mountSettingsView();
+    await flushUi();
+
+    const toggle = wrapper.find('[data-testid="automatic-updates-toggle"]');
+    expect((toggle.element as HTMLInputElement).checked).toBe(true);
+
+    await toggle.setValue(false);
+    await flushUi();
+
+    expect(invoke).toHaveBeenLastCalledWith("set_auto_update_enabled", { enabled: false });
+    expect((toggle.element as HTMLInputElement).checked).toBe(false);
+  });
+});

--- a/src/views/SettingsView.md
+++ b/src/views/SettingsView.md
@@ -39,7 +39,7 @@ Device connection entry point. See `specs/device-connect/README.md` and `specs/s
 
 Desktop automatic update behavior.
 
-- Rendered inline on `/settings` using [[SettingsListGroup]] and [[SettingsListItem]]
+- Rendered inline on `/settings` using [[SettingsListGroup]] and [[SettingsListItem]] only when startup desktop updates are supported by the current build
 - `Automatic updates` toggle is enabled by default to preserve existing startup updater behavior
 - Toggle state persists in the app settings table
 - When disabled, the next app restart skips startup automatic update install/check

--- a/src/views/SettingsView.md
+++ b/src/views/SettingsView.md
@@ -35,6 +35,16 @@ Device connection entry point. See `specs/device-connect/README.md` and `specs/s
 - Device rows show display name plus `Online`/`Offline`; UUIDs stay out of visible Settings list rows
 - Device detail view owns mapped-space configuration and visible sync status per paired device
 
+### Updates
+
+Desktop automatic update behavior.
+
+- Rendered inline on `/settings` using [[SettingsListGroup]] and [[SettingsListItem]]
+- `Automatic updates` toggle is enabled by default to preserve existing startup updater behavior
+- Toggle state persists in the app settings table
+- When disabled, the next app restart skips startup automatic update install/check
+- UI copy must say disabling automatic updates prevents automatic install on the next restart
+
 ### Backup
 
 Portable backup import/export. See `specs/backup/README.md`.

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { invoke } from "@tauri-apps/api/core";
-import { ref, onMounted } from "vue";
+import { computed, ref, onMounted } from "vue";
 import packageJson from "../../package.json";
 import AboutCard from "../components/SettingsView/AboutCard.vue";
 import ExportSpacesDialog from "../components/SettingsView/ExportSpacesDialog.vue";
@@ -42,6 +42,23 @@ const autoUpdatesSaving = ref(false);
 const autoUpdatesError = ref<string | null>(null);
 const appVersion = packageJson.version;
 const sourceUrl = "https://github.com/VRuzhentsov/fini";
+
+const renderFlags = computed(() => ({
+  spacesError: Boolean(spaceStore.error),
+  spaceEditor: (spaceId: string) => editingId.value === spaceId,
+  emptyPairedDevices: deviceStore.pairedDevices.length === 0,
+  automaticUpdatesSection: autoUpdatesSupported.value,
+  automaticUpdatesError: Boolean(autoUpdatesError.value),
+  backupImportError: Boolean(backupImport.error.value),
+  backupExportDialog: showBackupExport.value,
+  backupImportMappingDialog: Boolean(backupImport.activeMapping.value),
+  backupMergeConflictDialog: Boolean(backupImport.showConflicts.value),
+}));
+
+const renderLists = computed(() => ({
+  spaces: spaceStore.spaces,
+  pairedDevices: deviceStore.pairedDevices,
+}));
 
 onMounted(() => {
   spaceStore.fetchSpaces();
@@ -120,10 +137,10 @@ function devicePresenceLabel(device: PairedDevice) {
     <section class="rounded-xl bg-base-200 p-3">
       <h2 class="mb-3 text-sm font-semibold uppercase tracking-wide opacity-70">Spaces</h2>
       <div class="flex flex-col gap-3">
-        <div v-if="spaceStore.error" class="text-error text-sm">{{ spaceStore.error }}</div>
+        <div v-if="renderFlags.spacesError" class="text-error text-sm">{{ spaceStore.error }}</div>
         <SettingsListGroup>
-          <template v-for="space in spaceStore.spaces" :key="space.id">
-            <SettingsListItem v-if="editingId === space.id">
+          <template v-for="space in renderLists.spaces" :key="space.id">
+            <SettingsListItem v-if="renderFlags.spaceEditor(space.id)">
               <template #start>
                 <input
                   v-model="editingName"
@@ -172,7 +189,7 @@ function devicePresenceLabel(device: PairedDevice) {
       <h2 class="mb-3 text-sm font-semibold uppercase tracking-wide opacity-70">Devices</h2>
       <SettingsListGroup>
         <SettingsListItem
-          v-for="device in deviceStore.pairedDevices"
+          v-for="device in renderLists.pairedDevices"
           :key="device.peer_device_id"
           :to="`/settings/device/${device.peer_device_id}`"
           data-testid="paired-device-row"
@@ -195,7 +212,7 @@ function devicePresenceLabel(device: PairedDevice) {
           </template>
         </SettingsListItem>
         <SettingsListItem
-          v-if="deviceStore.pairedDevices.length === 0"
+          v-if="renderFlags.emptyPairedDevices"
         >
           <span class="opacity-70">No paired devices yet.</span>
         </SettingsListItem>
@@ -215,7 +232,7 @@ function devicePresenceLabel(device: PairedDevice) {
 
     <ThemeSelector />
 
-    <section v-if="autoUpdatesSupported" class="rounded-xl bg-base-200 p-3" data-testid="settings-updates">
+    <section v-if="renderFlags.automaticUpdatesSection" class="rounded-xl bg-base-200 p-3" data-testid="settings-updates">
       <h2 class="mb-3 text-sm font-semibold uppercase tracking-wide opacity-70">Updates</h2>
       <SettingsListGroup>
         <SettingsListItem>
@@ -240,7 +257,7 @@ function devicePresenceLabel(device: PairedDevice) {
           </template>
         </SettingsListItem>
       </SettingsListGroup>
-      <div v-if="autoUpdatesError" class="mt-2 text-xs text-error">{{ autoUpdatesError }}</div>
+      <div v-if="renderFlags.automaticUpdatesError" class="mt-2 text-xs text-error">{{ autoUpdatesError }}</div>
     </section>
 
     <section class="rounded-xl bg-base-200 p-3" data-testid="settings-backup">
@@ -276,16 +293,16 @@ function devicePresenceLabel(device: PairedDevice) {
           </template>
         </SettingsListItem>
       </SettingsListGroup>
-      <div v-if="backupImport.error.value" class="mt-2 text-xs text-error">{{ backupImport.error.value }}</div>
+      <div v-if="renderFlags.backupImportError" class="mt-2 text-xs text-error">{{ backupImport.error.value }}</div>
     </section>
 
     <AboutCard :version="appVersion" :source-url="sourceUrl" />
 
-    <ExportSpacesDialog v-if="showBackupExport" @close="showBackupExport = false" />
+    <ExportSpacesDialog v-if="renderFlags.backupExportDialog" @close="showBackupExport = false" />
 
     <ImportSpaceMappingDialog
-      v-if="backupImport.activeMapping.value"
-      :incoming="backupImport.activeMapping.value"
+      v-if="renderFlags.backupImportMappingDialog"
+      :incoming="backupImport.activeMapping.value!"
       :local-spaces="backupImport.selectableSpaces.value"
       :index="backupImport.mappingIndex.value"
       :total="backupImport.totalMappings.value"
@@ -294,7 +311,7 @@ function devicePresenceLabel(device: PairedDevice) {
     />
 
     <MergeConflictDialog
-      v-if="backupImport.showConflicts.value"
+      v-if="renderFlags.backupMergeConflictDialog"
       :conflicts="backupImport.conflicts.value"
       @cancel="backupImport.cancelImport()"
       @apply="(r) => void backupImport.applyImport(r)"

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { invoke } from "@tauri-apps/api/core";
 import { ref, onMounted } from "vue";
 import packageJson from "../../package.json";
 import AboutCard from "../components/SettingsView/AboutCard.vue";
@@ -34,13 +35,49 @@ const newSpaceName = ref("");
 const editingId = ref<string | null>(null);
 const editingName = ref("");
 const showBackupExport = ref(false);
+const autoUpdatesEnabled = ref(true);
+const autoUpdatesLoading = ref(false);
+const autoUpdatesSaving = ref(false);
+const autoUpdatesError = ref<string | null>(null);
 const appVersion = packageJson.version;
 const sourceUrl = "https://github.com/VRuzhentsov/fini";
 
 onMounted(() => {
   spaceStore.fetchSpaces();
   void deviceStore.hydrate();
+  void loadAutoUpdatePreference();
 });
+
+async function loadAutoUpdatePreference() {
+  autoUpdatesLoading.value = true;
+  autoUpdatesError.value = null;
+  try {
+    autoUpdatesEnabled.value = await invoke<boolean>("get_auto_update_enabled");
+  } catch (error) {
+    autoUpdatesError.value = String(error);
+  } finally {
+    autoUpdatesLoading.value = false;
+  }
+}
+
+async function setAutoUpdatesEnabled(event: Event) {
+  const target = event.target as HTMLInputElement;
+  const previous = autoUpdatesEnabled.value;
+  const enabled = target.checked;
+
+  autoUpdatesEnabled.value = enabled;
+  autoUpdatesSaving.value = true;
+  autoUpdatesError.value = null;
+
+  try {
+    autoUpdatesEnabled.value = await invoke<boolean>("set_auto_update_enabled", { enabled });
+  } catch (error) {
+    autoUpdatesEnabled.value = previous;
+    autoUpdatesError.value = String(error);
+  } finally {
+    autoUpdatesSaving.value = false;
+  }
+}
 
 async function addSpace() {
   const name = newSpaceName.value.trim();
@@ -169,6 +206,34 @@ function devicePresenceLabel(device: PairedDevice) {
     </section>
 
     <ThemeSelector />
+
+    <section class="rounded-xl bg-base-200 p-3" data-testid="settings-updates">
+      <h2 class="mb-3 text-sm font-semibold uppercase tracking-wide opacity-70">Updates</h2>
+      <SettingsListGroup>
+        <SettingsListItem>
+          <template #start>
+            <div>
+              <span class="block font-medium">Automatic updates</span>
+              <span class="block text-xs opacity-60">
+                When this is off, Fini will not install updates automatically on the next restart.
+              </span>
+            </div>
+          </template>
+          <template #end>
+            <input
+              type="checkbox"
+              class="toggle toggle-primary"
+              data-testid="automatic-updates-toggle"
+              aria-label="Automatic updates"
+              :checked="autoUpdatesEnabled"
+              :disabled="autoUpdatesLoading || autoUpdatesSaving"
+              @change="setAutoUpdatesEnabled"
+            />
+          </template>
+        </SettingsListItem>
+      </SettingsListGroup>
+      <div v-if="autoUpdatesError" class="mt-2 text-xs text-error">{{ autoUpdatesError }}</div>
+    </section>
 
     <section class="rounded-xl bg-base-200 p-3" data-testid="settings-backup">
       <h2 class="mb-3 text-sm font-semibold uppercase tracking-wide opacity-70">Backup</h2>

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -35,6 +35,7 @@ const newSpaceName = ref("");
 const editingId = ref<string | null>(null);
 const editingName = ref("");
 const showBackupExport = ref(false);
+const autoUpdatesSupported = ref(false);
 const autoUpdatesEnabled = ref(true);
 const autoUpdatesLoading = ref(false);
 const autoUpdatesSaving = ref(false);
@@ -45,19 +46,26 @@ const sourceUrl = "https://github.com/VRuzhentsov/fini";
 onMounted(() => {
   spaceStore.fetchSpaces();
   void deviceStore.hydrate();
-  void loadAutoUpdatePreference();
+  void loadAutoUpdateSettings();
 });
 
-async function loadAutoUpdatePreference() {
+async function loadAutoUpdateSettings() {
   autoUpdatesLoading.value = true;
   autoUpdatesError.value = null;
   try {
-    autoUpdatesEnabled.value = await invoke<boolean>("get_auto_update_enabled");
+    autoUpdatesSupported.value = await invoke<boolean>("startup_auto_update_supported");
+    if (autoUpdatesSupported.value) {
+      await loadAutoUpdatePreference();
+    }
   } catch (error) {
     autoUpdatesError.value = String(error);
   } finally {
     autoUpdatesLoading.value = false;
   }
+}
+
+async function loadAutoUpdatePreference() {
+  autoUpdatesEnabled.value = await invoke<boolean>("get_auto_update_enabled");
 }
 
 async function setAutoUpdatesEnabled(event: Event) {
@@ -207,7 +215,7 @@ function devicePresenceLabel(device: PairedDevice) {
 
     <ThemeSelector />
 
-    <section class="rounded-xl bg-base-200 p-3" data-testid="settings-updates">
+    <section v-if="autoUpdatesSupported" class="rounded-xl bg-base-200 p-3" data-testid="settings-updates">
       <h2 class="mb-3 text-sm font-semibold uppercase tracking-wide opacity-70">Updates</h2>
       <SettingsListGroup>
         <SettingsListItem>


### PR DESCRIPTION
## Summary
- adds a Settings → Updates automatic updates toggle with persisted app setting
- wires startup desktop auto-update through the stored preference so disabled skips the next restart update check/install
- documents the updater behavior and adds frontend/backend coverage

Closes #101

## Verification
- npm run test:unit -- SettingsView.spec.ts
- npm run build
- cargo test --manifest-path src-tauri/Cargo.toml --features ui-plane
- cargo check --manifest-path src-tauri/Cargo.toml --bin fini-app --features ui-plane,desktop-updater