### PR TITLE
Make New Quest title input single-line

### DIFF
--- a/specs/e2e/actors/tests/zz-personal-space-live-quest-sync.spec.ts
+++ b/specs/e2e/actors/tests/zz-personal-space-live-quest-sync.spec.ts
@@ -70,10 +70,13 @@ async function reopenFocus(actor: E2EActor): Promise<void> {
 async function submitQuest(actor: E2EActor, title: string): Promise<void> {
   await actor.page.evaluate(`(() => {
     const input = document.querySelector('[data-testid="chat-input"]');
-    if (!(input instanceof HTMLTextAreaElement)) {
-      throw new Error('chat input textarea not found');
+    if (!(input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement)) {
+      throw new Error('chat input text control not found');
     }
-    input.value = ${JSON.stringify(title)};
+    const prototype = input instanceof HTMLInputElement ? HTMLInputElement.prototype : HTMLTextAreaElement.prototype;
+    const setter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set;
+    if (!setter) throw new Error('chat input setter is unavailable');
+    setter.call(input, ${JSON.stringify(title)});
     input.dispatchEvent(new Event('input', { bubbles: true }));
   })()`);
   await actor.page.click('[data-testid="chat-submit"]');

--- a/specs/e2e/ui/tests/context-menu-accordion.spec.ts
+++ b/specs/e2e/ui/tests/context-menu-accordion.spec.ts
@@ -7,12 +7,13 @@ async function fillTextarea(
 ): Promise<void> {
   await tauriPage.evaluate(`(() => {
     const el = document.querySelector(${JSON.stringify(selector)});
-    if (!(el instanceof HTMLTextAreaElement)) {
-      throw new Error('textarea not found for selector: ' + ${JSON.stringify(selector)});
+    if (!(el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement)) {
+      throw new Error('text control not found for selector: ' + ${JSON.stringify(selector)});
     }
     el.focus();
-    const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
-    if (!setter) throw new Error('textarea setter is unavailable');
+    const prototype = el instanceof HTMLInputElement ? HTMLInputElement.prototype : HTMLTextAreaElement.prototype;
+    const setter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set;
+    if (!setter) throw new Error('text control setter is unavailable');
     setter.call(el, ${JSON.stringify(value)});
     el.dispatchEvent(new Event('input', { bubbles: true }));
     el.dispatchEvent(new Event('change', { bubbles: true }));

--- a/specs/e2e/ui/tests/reminder-flow.spec.ts
+++ b/specs/e2e/ui/tests/reminder-flow.spec.ts
@@ -40,12 +40,13 @@ async function fillTextarea(
 ): Promise<void> {
   await tauriPage.evaluate(`(() => {
     const el = document.querySelector(${JSON.stringify(selector)});
-    if (!(el instanceof HTMLTextAreaElement)) {
-      throw new Error('textarea not found for selector: ' + ${JSON.stringify(selector)});
+    if (!(el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement)) {
+      throw new Error('text control not found for selector: ' + ${JSON.stringify(selector)});
     }
     el.focus();
-    const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
-    if (!setter) throw new Error('textarea setter is unavailable');
+    const prototype = el instanceof HTMLInputElement ? HTMLInputElement.prototype : HTMLTextAreaElement.prototype;
+    const setter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set;
+    if (!setter) throw new Error('text control setter is unavailable');
     setter.call(el, ${JSON.stringify(value)});
     el.dispatchEvent(new Event('input', { bubbles: true }));
     el.dispatchEvent(new Event('change', { bubbles: true }));

--- a/specs/e2e/ui/tests/reminder-notification-actions.spec.ts
+++ b/specs/e2e/ui/tests/reminder-notification-actions.spec.ts
@@ -41,12 +41,13 @@ async function fillTextarea(
 ): Promise<void> {
   await tauriPage.evaluate(`(() => {
     const el = document.querySelector(${JSON.stringify(selector)});
-    if (!(el instanceof HTMLTextAreaElement)) {
-      throw new Error('textarea not found: ' + ${JSON.stringify(selector)});
+    if (!(el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement)) {
+      throw new Error('text control not found: ' + ${JSON.stringify(selector)});
     }
     el.focus();
-    const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
-    if (!setter) throw new Error('textarea setter is unavailable');
+    const prototype = el instanceof HTMLInputElement ? HTMLInputElement.prototype : HTMLTextAreaElement.prototype;
+    const setter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set;
+    if (!setter) throw new Error('text control setter is unavailable');
     setter.call(el, ${JSON.stringify(value)});
     el.dispatchEvent(new Event('input', { bubbles: true }));
     el.dispatchEvent(new Event('change', { bubbles: true }));

--- a/src/components/FocusView/NewQuestForm.vue
+++ b/src/components/FocusView/NewQuestForm.vue
@@ -20,7 +20,7 @@ const repeatRule = ref<string | null>(null);
 const reminderOpen = ref(false);
 const metadataExpanded = ref(false);
 const isSubmitting = ref(false);
-const titleInput = ref<HTMLTextAreaElement | null>(null);
+const titleInput = ref<HTMLInputElement | null>(null);
 
 const hasMetadataDraft = computed(
   () =>
@@ -164,7 +164,7 @@ function onReminderClose() {
 }
 
 function onTitleKeydown(event: KeyboardEvent) {
-  if (event.key === "Enter" && !event.shiftKey) {
+  if (event.key === "Enter") {
     event.preventDefault();
     void onSubmit();
   }
@@ -200,13 +200,13 @@ async function onSubmit() {
   <div class="chat-composer-bar fixed inset-x-0 bottom-0 z-50 w-full border-t border-base-300 bg-base-100 p-1">
     <form class="flex w-full flex-col gap-2 rounded-lg border border-base-300 bg-base-100 p-3 shadow-sm" @submit.prevent="onSubmit">
       <div class="flex items-start gap-2">
-        <textarea
+        <input
           ref="titleInput"
           v-model="title"
+          type="text"
           data-testid="chat-input"
-          class="textarea textarea-ghost min-h-0 flex-1 resize-none overflow-hidden p-0 text-base font-semibold leading-tight focus:outline-none"
+          class="input input-ghost min-h-0 flex-1 p-0 text-base font-semibold leading-tight focus:outline-none"
           placeholder="New quest"
-          rows="1"
           :disabled="isSubmitting"
           @keydown="onTitleKeydown"
         />
@@ -231,9 +231,6 @@ async function onSubmit() {
           :disabled="isSubmitting"
         />
 
-        <div class="flex flex-wrap items-center gap-3 text-xs text-base-content/70">
-          <span class="hidden text-base-content/50 sm:inline">Enter creates · Shift+Enter keeps a newline</span>
-        </div>
       </div>
 
       <div class="flex items-center justify-between gap-2 pt-1">

--- a/src/spec/components/NewQuestForm.spec.ts
+++ b/src/spec/components/NewQuestForm.spec.ts
@@ -91,6 +91,22 @@ describe("NewQuestForm", () => {
     expect(wrapper.find(".chat-composer-bar").exists()).toBe(true);
   });
 
+  it("uses a single-line title input for quest creation", () => {
+    const wrapper = mount(NewQuestForm, {
+      global: {
+        stubs: {
+          ReminderMenu: true,
+        },
+      },
+    });
+
+    const titleInput = wrapper.find('[data-testid="chat-input"]');
+
+    expect(titleInput.element.tagName).toBe("INPUT");
+    expect(titleInput.attributes("type")).toBe("text");
+    expect(wrapper.find('[data-testid="chat-input"] textarea').exists()).toBe(false);
+  });
+
   it("opens the bottom composer space menu upward", () => {
     const wrapper = mount(NewQuestForm, {
       global: {
@@ -101,6 +117,28 @@ describe("NewQuestForm", () => {
     });
 
     expect(wrapper.findComponent({ name: "SpacePicker" }).props("menuPlacement")).toBe("top");
+  });
+
+  it("creates a quest when Enter is pressed in the title input", async () => {
+    const wrapper = mount(NewQuestForm, {
+      global: {
+        stubs: {
+          ReminderMenu: true,
+        },
+      },
+    });
+
+    await wrapper.find('[data-testid="chat-input"]').setValue("Submit from keyboard");
+    await wrapper.find('[data-testid="chat-input"]').trigger("keydown", { key: "Enter" });
+
+    expect(createQuest).toHaveBeenCalledWith({
+      title: "Submit from keyboard",
+      description: null,
+      space_id: "1",
+      due: null,
+      due_time: null,
+      repeat_rule: null,
+    });
   });
 
   it("starts collapsed and expands metadata without losing the title draft", async () => {
@@ -123,7 +161,7 @@ describe("NewQuestForm", () => {
     expect(wrapper.find('[data-testid="new-quest-description"]').exists()).toBe(true);
     expect(wrapper.find('[data-testid="new-quest-focus-toggle"]').exists()).toBe(false);
     expect(wrapper.find('[data-testid="new-quest-keep-adding"]').exists()).toBe(false);
-    expect((wrapper.find('[data-testid="chat-input"]').element as HTMLTextAreaElement).value).toBe("Capture fast quest");
+    expect((wrapper.find('[data-testid="chat-input"]').element as HTMLInputElement).value).toBe("Capture fast quest");
   });
 
   it("creates a quest with explicit space, description, and reminder draft fields", async () => {


### PR DESCRIPTION
## Summary
- renders the New Quest title control as a single-line text input
- makes Enter submit the quest from the title field
- keeps longer notes in the expanded description area and removes title multiline helper copy

Closes #103

## Verification
- npm run test:unit -- NewQuestForm.spec.ts
- npm run build