### PR TITLE
Disable android Mic permission on first boot

### DIFF
--- a/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <!-- Required for exact-time reminder scheduling on Android 12+ -->
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <!-- Required for re-arming AlarmManager reminders after device reboot -->

--- a/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <!-- Required for exact-time reminder scheduling on Android 12+ -->
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <!-- Required for re-arming AlarmManager reminders after device reboot -->

--- a/src-tauri/gen/android/app/src/main/java/com/fini/app/MainActivity.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/fini/app/MainActivity.kt
@@ -1,11 +1,7 @@
 package com.fini.app
 
-import android.Manifest
-import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.activity.enableEdgeToEdge
-import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
 import app.tauri.plugin.PluginManager
 
 class MainActivity : TauriActivity() {
@@ -15,9 +11,5 @@ class MainActivity : TauriActivity() {
     PluginManager.onActivityCreate(this)
     enableEdgeToEdge()
     super.onCreate(savedInstanceState)
-    if (ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO)
-        != PackageManager.PERMISSION_GRANTED) {
-      ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.RECORD_AUDIO), 1)
-    }
   }
 }


### PR DESCRIPTION
## Outcome

- Stop requesting Android microphone access during application startup.
- Remove the unused runtime permission imports and request code from `MainActivity`.

## Why

Fixes #10. A fresh Fini launch should not ask for microphone access when the application does not use microphone functionality during startup.

## Verification

- Reviewed the Android activity diff: the startup `RECORD_AUDIO` permission check and request are removed.
- The activity retains Tauri plugin initialization and edge-to-edge setup.

## Review focus

- Confirm a fresh Android install reaches the application without a microphone permission prompt.
- Confirm startup behavior outside permission handling is unchanged.

## Follow-up

None.

Fixes #10
