### PR TITLE
Refactor temporary workspace paths

### DIFF
--- a/.agents/skills/fini-dev/SKILL.md
+++ b/.agents/skills/fini-dev/SKILL.md
@@ -119,7 +119,7 @@ Never write absolute paths containing a username, home directory, or machine-spe
 
 - Use paths relative to the project root for anything inside the repo (`src-tauri/target/debug/fini`, not `/home/<user>/projects/fini/src-tauri/...`).
 - Use `~` for paths relative to the user's home directory (`~/.local/share/fini/fini.db`, not `/home/<user>/.local/...`).
-- Use `/var/tmp` for temporary files, not `/tmp` or any user-specific temp path.
+- Use a task-appropriate scoped scratch path, such as the repository's ignored `tmp/` directory or a platform-provided runtime directory. Do not prescribe a global scratch path.
 - When adding permission entries to `.claude/settings.local.json`, use relative or `~`-anchored paths only. The local config is project-specific and minimal; do not accumulate machine-specific one-off entries there.
 
 ## User-Agnostic Agent Instructions

--- a/.agents/skills/fini-release-prep/SKILL.md
+++ b/.agents/skills/fini-release-prep/SKILL.md
@@ -65,7 +65,7 @@ When adding light/dark variants, use explicit suffixes such as `01-focus-light.p
 ## Workflow
 
 1. Read `docs/play-store/listing.md` to keep captions aligned with the store positioning.
-2. Confirm the app state uses curated demo data. If the current runtime may contain personal data, stop and switch to an isolated `FINI_APP_DATA_DIR` under `/var/tmp`.
+2. Confirm the app state uses curated demo data. If the current runtime may contain personal data, stop and switch to an isolated, task-scoped `FINI_APP_DATA_DIR` under the repository's ignored `tmp/` directory.
 3. Drive the normal Fini app/runtime at the target viewport dimensions. Use the web/runtime path unless the user explicitly asks for Android device screenshots.
 4. Capture the core product flow in this order: Focus, History, Settings. Expand only if the user asks for more store panels.
 5. Compose store-ready artwork with stable captions when composition tooling is available. Preserve the product UI as the main visual; captions explain the value prop, not fictional functionality.

--- a/.agents/skills/fini-release/SKILL.md
+++ b/.agents/skills/fini-release/SKILL.md
@@ -49,7 +49,7 @@ Before creating a release metadata commit, pushing `main`, or pushing a release 
 make pre-release-check
 ```
 
-Treat this as mandatory release behavior, not optional preflight. The command must log its output to `/var/tmp/fini-pre-release/pre-release-check-*.log` by default so the release has a traceable local evidence artifact.
+Treat this as mandatory release behavior, not optional preflight. The command must log its output under the repository's ignored `tmp/fini-pre-release/` directory by default so the release has a traceable local evidence artifact.
 
 `make pre-release-check` must run the local equivalent of release-tag `Quality Gates` from `.github/workflows/release-tag.yml`. Keep the command list minimal and avoid duplicated expensive work when one target already includes another.
 

--- a/.agents/skills/fini-test/SKILL.md
+++ b/.agents/skills/fini-test/SKILL.md
@@ -168,9 +168,9 @@ Conventions:
 
 ## Writing single-actor UI e2e
 
-Layout: `specs/e2e/ui/tests/<feature>.spec.ts`. Fixture: `specs/e2e/ui/fixtures.ts` exports `test` and `expect` from `createTauriTest({ tauriCommand, mcpSocket: '/var/tmp/fini-playwright.sock' })`. The test receives a `tauriPage` that drives the real Fini window.
+Layout: `specs/e2e/ui/tests/<feature>.spec.ts`. Fixture: `specs/e2e/ui/fixtures.ts` exports `test` and `expect` from `createTauriTest` with a socket under the task-scoped E2E root. The test receives a `tauriPage` that drives the real Fini window.
 
-App data is isolated under `FINI_APP_DATA_DIR=/var/tmp/fini-e2e-ui` so the user's normal data directory is untouched. The app is launched with `--features devtools`.
+App data is isolated under the task-scoped `FINI_E2E_ROOT` (default: the repository's ignored `tmp/fini-e2e-ui/`) so the user's normal data directory is untouched. The app is launched with `--features devtools`.
 
 Skeleton from `specs/e2e/ui/tests/context-menu-submenu-hover.spec.ts`:
 

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -212,7 +212,7 @@ jobs:
         run: |
           set -euo pipefail
           desktop_binary="src-tauri/target/${{ matrix.rust_target }}/release/fini-app"
-          symbols_file="/var/tmp/fini-app-${{ matrix.arch }}-symbols.txt"
+          symbols_file="$RUNNER_TEMP/fini-app-${{ matrix.arch }}-symbols.txt"
 
           if [ ! -f "$desktop_binary" ]; then
             echo "Expected Linux desktop binary was not produced: $desktop_binary" >&2

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -315,7 +315,7 @@ jobs:
         run: |
           set -euo pipefail
           desktop_binary="src-tauri/target/${{ matrix.rust_target }}/release/fini-app"
-          symbols_file="/var/tmp/fini-app-${{ matrix.arch }}-symbols.txt"
+          symbols_file="$RUNNER_TEMP/fini-app-${{ matrix.arch }}-symbols.txt"
 
           if [ ! -f "$desktop_binary" ]; then
             echo "Expected Linux desktop binary was not produced: $desktop_binary" >&2

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ FINI_BE_UNIT_IMAGE ?= fini-be-unit-test
 FINI_BE_CACHE_IMAGE_PREFIX ?=
 FINI_BE_CACHE_PUSH ?= 0
 FINI_E2E_CI_RUN_ID ?= pr-gate
-FINI_E2E_CI_RUN_DIR ?= /var/tmp/fini-e2e-$(FINI_E2E_CI_RUN_ID)
+FINI_SCRATCH_DIR ?= $(CURDIR)/tmp
+FINI_E2E_CI_RUN_DIR ?= $(FINI_SCRATCH_DIR)/fini-e2e-$(FINI_E2E_CI_RUN_ID)
 FINI_E2E_CI_RESULTS_DIR ?= $(FINI_E2E_CI_RUN_DIR)/test-results
 FINI_E2E_CI_ACTORS ?= actor-a,actor-b
 FINI_E2E_CI_ACTOR_WAIT_SECS ?= 180
@@ -73,7 +74,8 @@ require-container:
 
 dev:
 	@set -eu; \
-	capability_backup="$$(mktemp /var/tmp/fini-default-capability.XXXXXX)"; \
+	mkdir -p "$(FINI_SCRATCH_DIR)"; \
+	capability_backup="$$(mktemp "$(FINI_SCRATCH_DIR)/fini-default-capability.XXXXXX")"; \
 	cp src-tauri/capabilities/default.json "$$capability_backup"; \
 	restore_capability() { cp "$$capability_backup" src-tauri/capabilities/default.json; rm -f "$$capability_backup"; }; \
 	trap restore_capability EXIT INT TERM; \
@@ -278,11 +280,12 @@ e2e-build:
 # Builds the local binaries, then lets the Playwright fixtures spawn the real app processes.
 e2e-headed:
 	@set -eu; \
-	run_root="$${FINI_E2E_ROOT:-/var/tmp/fini-e2e-headed}"; \
+	run_root="$${FINI_E2E_ROOT:-$(FINI_SCRATCH_DIR)/fini-e2e-headed}"; \
 	e2e_target_dir="$$(pwd)/src-tauri/target/debug-e2e"; \
 	app_bin_path="$$e2e_target_dir/debug/fini-app"; \
 	cli_bin_path="$$e2e_target_dir/debug/fini"; \
-	capability_backup="$$(mktemp /var/tmp/fini-default-capability.XXXXXX)"; \
+	mkdir -p "$(FINI_SCRATCH_DIR)"; \
+	capability_backup="$$(mktemp "$(FINI_SCRATCH_DIR)/fini-default-capability.XXXXXX")"; \
 	cp src-tauri/capabilities/default.json "$$capability_backup"; \
 	restore_capability() { cp "$$capability_backup" src-tauri/capabilities/default.json; rm -f "$$capability_backup"; }; \
 	trap restore_capability EXIT INT TERM; \
@@ -307,7 +310,7 @@ runtime-smoke:
 
 pre-release-check:
 	@set -eu; \
-	log_dir="$${PRE_RELEASE_LOG_DIR:-/var/tmp/fini-pre-release}"; \
+	log_dir="$${PRE_RELEASE_LOG_DIR:-$(FINI_SCRATCH_DIR)/fini-pre-release}"; \
 	mkdir -p "$$log_dir"; \
 	log_file="$$log_dir/pre-release-check-$$(date -u +%Y%m%dT%H%M%SZ).log"; \
 	printf 'Writing pre-release log: %s\n' "$$log_file"; \
@@ -415,7 +418,8 @@ android-sign-release-local:
 	    echo "Set ANDROID_KEYSTORE_PATH or ANDROID_KEYSTORE_BASE64 for local release signing"; \
 	    exit 1; \
 	  fi; \
-	  keystore_path="/var/tmp/fini-release.keystore"; \
+	  mkdir -p "$(FINI_SCRATCH_DIR)"; \
+	  keystore_path="$(FINI_SCRATCH_DIR)/fini-release.keystore"; \
 	  printf '%s' "$$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$$keystore_path"; \
 	fi; \
 	test -f "$$keystore_path" || (echo "Release keystore not found: $$keystore_path" && exit 1); \

--- a/skills/fini-setup/SKILL.md
+++ b/skills/fini-setup/SKILL.md
@@ -34,7 +34,7 @@ Let the current system decide the exact detection method: `uname`, PowerShell, e
 2. Resolve the target OS and architecture from the current environment.
 3. Open the latest release/API above, or the user-requested release.
 4. Select the matching standalone CLI asset and download URL.
-5. Download into `/var/tmp` or the platform's normal temporary directory.
+5. Download into a task-scoped staging directory, such as the repository's ignored `tmp/` directory or a platform-provided runtime directory.
 6. Do not treat `.sig` as verified unless the release also provides public verification material or instructions.
 7. Extract the archive and locate the actual executable path.
 8. Smoke-test the extracted executable with `--help`.

--- a/specs/e2e/actors/fixtures.ts
+++ b/specs/e2e/actors/fixtures.ts
@@ -8,7 +8,7 @@ import { resetActorsUi } from './helpers/teardown.ts';
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '../../..');
 const DEFAULT_APP_BINARY = join(REPO_ROOT, 'src-tauri/target/debug-e2e/debug/fini-app');
-const DEFAULT_RUN_ROOT = '/var/tmp/fini-e2e-actors';
+const DEFAULT_RUN_ROOT = join(REPO_ROOT, 'tmp', 'fini-e2e-actors');
 const DEFAULT_ACTOR_WAIT_SECS = 60;
 const DEFAULT_BASE_DISCOVERY_PORT = 46_000 + Math.floor(Math.random() * 500);
 

--- a/specs/e2e/ui/fixtures.ts
+++ b/specs/e2e/ui/fixtures.ts
@@ -13,6 +13,8 @@
  *   leaves it unset) to keep the xvfb wrapper.
  */
 import { createTauriTest } from '@srsholmes/tauri-playwright';
+import { mkdirSync } from 'fs';
+import { join } from 'path';
 
 function pickRandomPort(envName: string, base: number, span: number): string {
   const fromEnv = process.env[envName];
@@ -20,7 +22,9 @@ function pickRandomPort(envName: string, base: number, span: number): string {
   return String(base + Math.floor(Math.random() * span));
 }
 
-const dataDir = process.env.FINI_APP_DATA_DIR ?? '/var/tmp/fini-e2e-ui';
+export const e2eUiRoot = process.env.FINI_E2E_ROOT ?? join(process.cwd(), 'tmp', 'fini-e2e-ui');
+mkdirSync(e2eUiRoot, { recursive: true });
+const dataDir = process.env.FINI_APP_DATA_DIR ?? e2eUiRoot;
 const discoveryPort = pickRandomPort('FINI_DISCOVERY_PORT', 47000, 500);
 const wsPort = pickRandomPort('FINI_SPACE_SYNC_WS_PORT', 47500, 500);
 const headful = process.env.FINI_E2E_HEADFUL === '1';
@@ -37,6 +41,6 @@ const tauriCommand = process.env.FINI_APP_BINARY
 export const { test, expect } = createTauriTest({
   tauriCommand,
   tauriCwd: process.cwd(),
-  mcpSocket: '/var/tmp/fini-playwright.sock',
+  mcpSocket: join(e2eUiRoot, 'fini-playwright.sock'),
   startTimeout: 240,
 });

--- a/specs/e2e/ui/tests/backup-flow.spec.ts
+++ b/specs/e2e/ui/tests/backup-flow.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect } from '../fixtures.ts';
+import { test, expect, e2eUiRoot } from '../fixtures.ts';
+import { join } from 'path';
 
 interface Space { id: string; name: string }
 interface PreflightResult { required_space_mappings: unknown[]; conflicts: unknown[] }
@@ -59,7 +60,7 @@ test('Settings page renders backup section with export and import rows', async (
 });
 
 test('export: dialog opens, select-all enables Export button, export completes with toast', async ({ tauriPage }) => {
-  const exportPath = '/var/tmp/fini-e2e-export-ui.zip';
+  const exportPath = join(e2eUiRoot, 'fini-e2e-export-ui.zip');
 
   await navigateToSettings(tauriPage);
   await setDialogPath(tauriPage, { save: exportPath });
@@ -110,7 +111,7 @@ test('export: dialog opens, select-all enables Export button, export completes w
 });
 
 test('import: picking a backup with no conflicts auto-applies and shows toast', async ({ tauriPage }) => {
-  const backupPath = '/var/tmp/fini-e2e-import-ui.zip';
+  const backupPath = join(e2eUiRoot, 'fini-e2e-import-ui.zip');
   const spaces = await invokeTauri<Space[]>(tauriPage, 'get_spaces');
   await invokeTauri<void>(tauriPage, 'backup_export', { path: backupPath, spaceIds: spaces.map(s => s.id) });
 

--- a/src-tauri/src/services/appimage_desktop.rs
+++ b/src-tauri/src/services/appimage_desktop.rs
@@ -150,9 +150,9 @@ mod tests {
 
     #[test]
     fn desktop_entry_quotes_appimage_path() {
-        let entry = desktop_entry_for(Path::new("/var/tmp/Fini Folder/Fini.AppImage"));
+        let entry = desktop_entry_for(Path::new("Fini Folder/Fini.AppImage"));
 
-        assert!(entry.contains("Exec=\"/var/tmp/Fini Folder/Fini.AppImage\" %U"));
+        assert!(entry.contains("Exec=\"Fini Folder/Fini.AppImage\" %U"));
         assert!(entry.contains("Icon=fini-app"));
         assert!(entry.contains("StartupWMClass=fini-app"));
         assert!(entry.contains("Categories=Utility;"));
@@ -160,9 +160,9 @@ mod tests {
 
     #[test]
     fn desktop_entry_escapes_percent_in_appimage_path() {
-        let entry = desktop_entry_for(Path::new("/var/tmp/Fini%20Folder/Fini.AppImage"));
+        let entry = desktop_entry_for(Path::new("Fini%20Folder/Fini.AppImage"));
 
-        assert!(entry.contains("Exec=\"/var/tmp/Fini%%20Folder/Fini.AppImage\" %U"));
+        assert!(entry.contains("Exec=\"Fini%%20Folder/Fini.AppImage\" %U"));
     }
 
     #[test]
@@ -202,7 +202,7 @@ mod tests {
     }
 
     fn test_dir(name: &str) -> PathBuf {
-        let path = PathBuf::from("/var/tmp").join(format!(
+        let path = std::env::temp_dir().join(format!(
             "fini-appimage-desktop-{}-{name}",
             std::process::id()
         ));

--- a/src-tauri/src/services/cli_update.rs
+++ b/src-tauri/src/services/cli_update.rs
@@ -147,7 +147,7 @@ mod tests {
 
     #[test]
     fn update_config_uses_runtime_options() {
-        let executable_path = PathBuf::from("/var/tmp/fini-test-bin");
+        let executable_path = PathBuf::from("fini-test-bin");
         let config = resolve_update_config(UpdateOptions {
             dry_run: true,
             endpoint: Some("https://example.test/latest-cli.json".to_string()),
@@ -173,7 +173,7 @@ mod tests {
             endpoint: Some("https://example.test/latest-cli.json".to_string()),
             pubkey: Some(" ".to_string()),
             target: Some("cli-linux-x86_64".to_string()),
-            executable_path: Some(PathBuf::from("/var/tmp/fini-test-bin")),
+            executable_path: Some(PathBuf::from("fini-test-bin")),
         });
 
         assert!(result
@@ -195,7 +195,7 @@ mod tests {
             ),
             pubkey: Some("test-public-key".to_string()),
             target: Some("cli-linux-x86_64".to_string()),
-            executable_path: Some(PathBuf::from("/var/tmp/fini-test-bin")),
+            executable_path: Some(PathBuf::from("fini-test-bin")),
         })
         .expect("resolved update config");
 

--- a/src/spec/composables/useBackupImport.spec.ts
+++ b/src/spec/composables/useBackupImport.spec.ts
@@ -39,7 +39,7 @@ const baseQuestStore = {
   fetchQuests: jest.fn().mockResolvedValue(undefined),
   fetchActiveQuest: jest.fn().mockResolvedValue(undefined),
 };
-const FILE_PATH = "/var/tmp/test-backup.zip";
+const FILE_PATH = "test-backup.zip";
 
 describe("useBackupImport", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Outcome

- scope temporary workspace paths

## Why

Addresses #108: Clean up /var/tmp scratch-path rule.

## Verification

- git grep confirms no tracked /var/tmp references remain.
- npm run test:unit -- useBackupImport (5 passed).
- npm run build (passed).
- cargo test --manifest-path src-tauri/Cargo.toml appimage_desktop::tests (4 passed).
- Node syntax checks and Makefile dry expansion passed.

## Review focus

- Confirm every repository-owned /var/tmp default is replaced with a task-scoped alternative.
- Confirm E2E fixture roots and CI runner temporary paths remain isolated and writable.

## Follow-up

- The full cargo fmt check remains blocked by pre-existing formatting drift in src-tauri/src/services/backup.rs.

Fixes #108
