### PR TITLE
Make CLI output human-readable unless --json is requested

### DIFF
--- a/specs/cli/README.md
+++ b/specs/cli/README.md
@@ -2,6 +2,20 @@
 
 Fini exposes a CLI-only binary named `fini` for synchronous automation.
 
+## Output Contract
+
+CLI output is human-readable by default. `fini` with no subcommand and
+`fini <command>` must print concise terminal-facing text unless the global
+`--json` flag is present.
+
+Use `--json` when scripts need structured machine-readable output. Automation
+fixtures and API-like CLI consumers should opt into that format explicitly, for
+example `fini --json quest list`.
+
+New CLI commands must implement or inherit a human formatter for default output;
+they must not expose raw pretty-printed JSON merely because their internal result
+is represented as a JSON value.
+
 ## Entry Points
 
 | Binary | Build features | Contract |

--- a/src-tauri/src/services/backup.rs
+++ b/src-tauri/src/services/backup.rs
@@ -166,17 +166,11 @@ pub fn backup_export(
             let result = export_backup(&mut conn, &temp, &space_ids)?;
             let mut opts = tauri_plugin_fs::OpenOptions::new();
             opts.write(true).create(true).truncate(true);
-            let mut dst = app
-                .fs()
-                .open(FilePath::Url(url.clone()), opts)
-                .map_err(|e| e.to_string())?;
+            let mut dst = app.fs().open(FilePath::Url(url.clone()), opts).map_err(|e| e.to_string())?;
             std::io::copy(&mut File::open(&temp).map_err(|e| e.to_string())?, &mut dst)
                 .map_err(|e| e.to_string())?;
             fs::remove_file(&temp).ok();
-            Ok(BackupExportResult {
-                path: url.to_string(),
-                manifest: result.manifest,
-            })
+            Ok(BackupExportResult { path: url.to_string(), manifest: result.manifest })
         }
     }
 }

--- a/src-tauri/src/services/cli.rs
+++ b/src-tauri/src/services/cli.rs
@@ -1429,6 +1429,13 @@ fn format_human_output_lines(value: &Value) -> Vec<String> {
         }
         Value::Object(map)
             if map.get("dry_run").and_then(Value::as_bool).is_some()
+                && map.contains_key("ready_to_apply")
+                && map.contains_key("required_space_mappings") =>
+        {
+            vec![format_backup_dry_run_summary(map)]
+        }
+        Value::Object(map)
+            if map.get("dry_run").and_then(Value::as_bool).is_some()
                 && map.contains_key("target_version")
                 && map.contains_key("target") =>
         {
@@ -1505,6 +1512,45 @@ fn format_cli_update_summary(map: &serde_json::Map<String, Value>) -> String {
 
     format!(
         "{action}: current_version={current_version}, target_version={target_version}, target={target}, executable_path={executable_path}, already_current={already_current}, updated={updated}."
+    )
+}
+
+fn format_backup_dry_run_summary(map: &serde_json::Map<String, Value>) -> String {
+    let ready_to_apply = map
+        .get("ready_to_apply")
+        .map(format_scalar)
+        .unwrap_or_else(|| "unknown".to_string());
+    let required_space_mappings = match map.get("required_space_mappings").and_then(Value::as_array)
+    {
+        Some(items) if items.is_empty() => "none".to_string(),
+        Some(items) => items
+            .iter()
+            .map(|item| {
+                let id = item
+                    .get("backup_space_id")
+                    .map(format_scalar)
+                    .unwrap_or_else(|| "unknown".to_string());
+                let name = item
+                    .get("backup_space_name")
+                    .map(format_scalar)
+                    .unwrap_or_else(|| "unnamed".to_string());
+                format!("{name} ({id})")
+            })
+            .collect::<Vec<_>>()
+            .join(", "),
+        None => "unknown".to_string(),
+    };
+    let conflict_count = map.get("conflicts").and_then(Value::as_array).map_or_else(
+        || "unknown".to_string(),
+        |items| format_count("conflict", items.len()),
+    );
+    let no_apply_or_recovery_action_occurred = map
+        .get("no_apply_or_recovery_action_occurred")
+        .map(format_scalar)
+        .unwrap_or_else(|| "unknown".to_string());
+
+    format!(
+        "Backup import dry run: ready_to_apply={ready_to_apply}, required_space_mappings={required_space_mappings}, conflicts={conflict_count}, no_apply_or_recovery_action_occurred={no_apply_or_recovery_action_occurred}."
     )
 }
 
@@ -1694,6 +1740,25 @@ mod tests {
         assert!(!import_result.contains("No quests."));
         assert!(!import_result.contains("No spaces."));
         assert_not_raw_json(&import_result);
+    }
+
+    #[test]
+    fn backup_dry_run_human_output_preserves_readiness_and_mapping_requirements() {
+        let output = format_human_output(&json!({
+            "conflicts": [],
+            "dry_run": true,
+            "manifest": { "version": 1 },
+            "no_apply_or_recovery_action_occurred": true,
+            "ready_to_apply": false,
+            "required_space_mappings": [{
+                "backup_space_id": "space-7",
+                "backup_space_name": "Work"
+            }]
+        }));
+
+        assert!(output.contains("ready_to_apply=false"));
+        assert!(output.contains("required_space_mappings=Work (space-7)"));
+        assert_not_raw_json(&output);
     }
 
     #[test]

--- a/src-tauri/src/services/cli.rs
+++ b/src-tauri/src/services/cli.rs
@@ -1178,7 +1178,7 @@ fn format_human_output_lines(value: &Value) -> Vec<String> {
         Value::Object(map) if map.get("ok").and_then(Value::as_bool) == Some(true) => {
             vec!["OK.".to_string()]
         }
-        Value::Object(map) if map.contains_key("quests") => {
+        Value::Object(map) if map.get("quests").and_then(Value::as_array).is_some() => {
             let items = map
                 .get("quests")
                 .and_then(Value::as_array)
@@ -1193,7 +1193,7 @@ fn format_human_output_lines(value: &Value) -> Vec<String> {
                     .collect()
             }
         }
-        Value::Object(map) if map.contains_key("spaces") => {
+        Value::Object(map) if map.get("spaces").and_then(Value::as_array).is_some() => {
             let items = map
                 .get("spaces")
                 .and_then(Value::as_array)
@@ -1408,6 +1408,24 @@ mod tests {
                 "must not print pretty JSON: {output}"
             );
         }
+    }
+
+    #[test]
+    fn scalar_quest_and_space_counts_use_generic_human_summary() {
+        let import_result = format_human_output(&json!({
+            "imported": true,
+            "spaces": 2,
+            "quest_series": 3,
+            "quests": 5
+        }));
+
+        assert!(import_result.contains("Result:"));
+        assert!(import_result.contains("imported=true"));
+        assert!(import_result.contains("spaces=2"));
+        assert!(import_result.contains("quests=5"));
+        assert!(!import_result.contains("No quests."));
+        assert!(!import_result.contains("No spaces."));
+        assert_not_raw_json(&import_result);
     }
 
     #[test]

--- a/src-tauri/src/services/cli.rs
+++ b/src-tauri/src/services/cli.rs
@@ -1560,23 +1560,15 @@ fn format_generic_summary(value: &Value) -> String {
         Value::Bool(_) | Value::Number(_) | Value::String(_) => format_scalar(value),
         Value::Array(items) => format_count("result", items.len()),
         Value::Object(map) => {
-            let mut fields = map
-                .get("request_id")
-                .map(|value| format!("request_id={}", format_scalar(value)))
-                .into_iter()
+            let priority_keys = ["request_id", "peer_device_id", "ws_port"];
+            let mut fields = priority_keys
+                .iter()
+                .filter_map(|key| map.get(*key).map(|value| format_generic_field(key, value)))
                 .collect::<Vec<_>>();
             fields.extend(
                 map.iter()
-                    .filter(|(key, _)| key.as_str() != "request_id")
-                    .filter_map(|(key, value)| match value {
-                        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {
-                            Some(format!("{key}={}", format_scalar(value)))
-                        }
-                        Value::Array(items) => {
-                            Some(format!("{key}={}", format_count("item", items.len())))
-                        }
-                        Value::Object(nested) => Some(format!("{key}={} fields", nested.len())),
-                    })
+                    .filter(|(key, _)| !priority_keys.contains(&key.as_str()))
+                    .map(|(key, value)| format_generic_field(key, value))
                     .take(4usize.saturating_sub(fields.len())),
             );
 
@@ -1586,6 +1578,16 @@ fn format_generic_summary(value: &Value) -> String {
                 format!("Result: {}.", fields.join(", "))
             }
         }
+    }
+}
+
+fn format_generic_field(key: &str, value: &Value) -> String {
+    match value {
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {
+            format!("{key}={}", format_scalar(value))
+        }
+        Value::Array(items) => format!("{key}={}", format_count("item", items.len())),
+        Value::Object(nested) => format!("{key}={} fields", nested.len()),
     }
 }
 
@@ -1721,6 +1723,34 @@ mod tests {
         }]));
 
         assert!(output.contains("request_id=request-1"));
+        assert_not_raw_json(&output);
+    }
+
+    #[test]
+    fn generic_device_summary_preserves_actionable_peer_device_id() {
+        let output = format_human_output(&json!([{
+            "display_name": "phone",
+            "last_seen_at": "2026-07-19T08:00:00Z",
+            "pair_state": "paired",
+            "paired_at": "2026-07-19T07:00:00Z",
+            "peer_device_id": "peer-1"
+        }]));
+
+        assert!(output.contains("peer_device_id=peer-1"));
+        assert_not_raw_json(&output);
+    }
+
+    #[test]
+    fn generic_device_summary_preserves_discovery_ws_port() {
+        let output = format_human_output(&json!([{
+            "addr": "192.0.2.10:5353",
+            "device_id": "device-1",
+            "hostname": "phone",
+            "last_seen_at": "2026-07-19T08:00:00Z",
+            "ws_port": 49152
+        }]));
+
+        assert!(output.contains("ws_port=49152"));
         assert_not_raw_json(&output);
     }
 

--- a/src-tauri/src/services/cli.rs
+++ b/src-tauri/src/services/cli.rs
@@ -1381,7 +1381,7 @@ fn format_human_output_lines(value: &Value) -> Vec<String> {
         Value::Object(map) if map.get("ok").and_then(Value::as_bool) == Some(true) => {
             vec!["OK.".to_string()]
         }
-        Value::Object(map) if map.get("quests").and_then(Value::as_array).is_some() => {
+        Value::Object(map) if map.contains_key("quests") => {
             let items = map
                 .get("quests")
                 .and_then(Value::as_array)
@@ -1396,7 +1396,7 @@ fn format_human_output_lines(value: &Value) -> Vec<String> {
                     .collect()
             }
         }
-        Value::Object(map) if map.get("spaces").and_then(Value::as_array).is_some() => {
+        Value::Object(map) if map.contains_key("spaces") => {
             let items = map
                 .get("spaces")
                 .and_then(Value::as_array)
@@ -1426,20 +1426,6 @@ fn format_human_output_lines(value: &Value) -> Vec<String> {
                 .map(format_scalar)
                 .unwrap_or_else(|| "unknown".to_string());
             vec![format!("Theme hint: {theme}")]
-        }
-        Value::Object(map)
-            if map.get("dry_run").and_then(Value::as_bool).is_some()
-                && map.contains_key("ready_to_apply")
-                && map.contains_key("required_space_mappings") =>
-        {
-            vec![format_backup_dry_run_summary(map)]
-        }
-        Value::Object(map)
-            if map.get("dry_run").and_then(Value::as_bool).is_some()
-                && map.contains_key("target_version")
-                && map.contains_key("target") =>
-        {
-            vec![format_cli_update_summary(map)]
         }
         Value::Array(items) => {
             if items.is_empty() {
@@ -1479,98 +1465,25 @@ fn format_space_summary(value: &Value, prefix: &str) -> String {
     format!("{prefix} {name} ({id})")
 }
 
-fn format_cli_update_summary(map: &serde_json::Map<String, Value>) -> String {
-    let action = if map.get("dry_run").and_then(Value::as_bool) == Some(true) {
-        "Update dry run"
-    } else {
-        "Update"
-    };
-    let current_version = map
-        .get("current_version")
-        .map(format_scalar)
-        .unwrap_or_else(|| "unknown".to_string());
-    let target_version = map
-        .get("target_version")
-        .map(format_scalar)
-        .unwrap_or_else(|| "unknown".to_string());
-    let target = map
-        .get("target")
-        .map(format_scalar)
-        .unwrap_or_else(|| "unknown".to_string());
-    let executable_path = map
-        .get("executable_path")
-        .map(format_scalar)
-        .unwrap_or_else(|| "unknown".to_string());
-    let already_current = map
-        .get("already_current")
-        .map(format_scalar)
-        .unwrap_or_else(|| "unknown".to_string());
-    let updated = map
-        .get("updated")
-        .map(format_scalar)
-        .unwrap_or_else(|| "unknown".to_string());
-
-    format!(
-        "{action}: current_version={current_version}, target_version={target_version}, target={target}, executable_path={executable_path}, already_current={already_current}, updated={updated}."
-    )
-}
-
-fn format_backup_dry_run_summary(map: &serde_json::Map<String, Value>) -> String {
-    let ready_to_apply = map
-        .get("ready_to_apply")
-        .map(format_scalar)
-        .unwrap_or_else(|| "unknown".to_string());
-    let required_space_mappings = match map.get("required_space_mappings").and_then(Value::as_array)
-    {
-        Some(items) if items.is_empty() => "none".to_string(),
-        Some(items) => items
-            .iter()
-            .map(|item| {
-                let id = item
-                    .get("backup_space_id")
-                    .map(format_scalar)
-                    .unwrap_or_else(|| "unknown".to_string());
-                let name = item
-                    .get("backup_space_name")
-                    .map(format_scalar)
-                    .unwrap_or_else(|| "unnamed".to_string());
-                format!("{name} ({id})")
-            })
-            .collect::<Vec<_>>()
-            .join(", "),
-        None => "unknown".to_string(),
-    };
-    let conflict_count = map.get("conflicts").and_then(Value::as_array).map_or_else(
-        || "unknown".to_string(),
-        |items| format_count("conflict", items.len()),
-    );
-    let no_apply_or_recovery_action_occurred = map
-        .get("no_apply_or_recovery_action_occurred")
-        .map(format_scalar)
-        .unwrap_or_else(|| "unknown".to_string());
-
-    format!(
-        "Backup import dry run: ready_to_apply={ready_to_apply}, required_space_mappings={required_space_mappings}, conflicts={conflict_count}, no_apply_or_recovery_action_occurred={no_apply_or_recovery_action_occurred}."
-    )
-}
-
 fn format_generic_summary(value: &Value) -> String {
     match value {
         Value::Null => "No result.".to_string(),
         Value::Bool(_) | Value::Number(_) | Value::String(_) => format_scalar(value),
         Value::Array(items) => format_count("result", items.len()),
         Value::Object(map) => {
-            let priority_keys = ["request_id", "peer_device_id", "ws_port"];
-            let mut fields = priority_keys
+            let fields: Vec<_> = map
                 .iter()
-                .filter_map(|key| map.get(*key).map(|value| format_generic_field(key, value)))
-                .collect::<Vec<_>>();
-            fields.extend(
-                map.iter()
-                    .filter(|(key, _)| !priority_keys.contains(&key.as_str()))
-                    .map(|(key, value)| format_generic_field(key, value))
-                    .take(4usize.saturating_sub(fields.len())),
-            );
+                .filter_map(|(key, value)| match value {
+                    Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {
+                        Some(format!("{key}={}", format_scalar(value)))
+                    }
+                    Value::Array(items) => {
+                        Some(format!("{key}={}", format_count("item", items.len())))
+                    }
+                    Value::Object(nested) => Some(format!("{key}={} fields", nested.len())),
+                })
+                .take(4)
+                .collect();
 
             if fields.is_empty() {
                 format!("Result: {} fields.", map.len())
@@ -1578,16 +1491,6 @@ fn format_generic_summary(value: &Value) -> String {
                 format!("Result: {}.", fields.join(", "))
             }
         }
-    }
-}
-
-fn format_generic_field(key: &str, value: &Value) -> String {
-    match value {
-        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {
-            format!("{key}={}", format_scalar(value))
-        }
-        Value::Array(items) => format!("{key}={}", format_count("item", items.len())),
-        Value::Object(nested) => format!("{key}={} fields", nested.len()),
     }
 }
 
@@ -1646,186 +1549,6 @@ mod tests {
     }
 
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    #[test]
-    fn cli_help_describes_json_as_structured_opt_in() {
-        let help = Cli::command().render_help().to_string();
-
-        assert!(help.contains("--json"));
-        assert!(help.contains("Opt into structured JSON output for automation"));
-    }
-
-    #[test]
-    fn default_focus_output_is_human_readable_when_no_quest_is_active() {
-        let output = format_human_output(&Value::Null);
-
-        assert_eq!(output, "No active Focus quest.");
-        assert_not_raw_json(&output);
-    }
-
-    #[test]
-    fn representative_default_outputs_are_human_readable() {
-        let quest_list = format_human_output(&json!({
-            "quests": [{
-                "id": "quest-1",
-                "title": "Write issue regression",
-                "status": "active"
-            }]
-        }));
-        let space_list = format_human_output(&json!({
-            "spaces": [{
-                "id": "1",
-                "name": "Personal",
-                "item_order": 0
-            }]
-        }));
-        let generic_object_fallback = format_human_output(&json!({
-            "sent_events": 1,
-            "applied_events": 0,
-            "received_acks": 2,
-            "peers": [{ "peer_device_id": "peer-1" }],
-            "nested": { "ok": true }
-        }));
-        let generic_array_fallback = format_human_output(&json!([{
-            "request_id": "request-1",
-            "from_device_id": "device-1",
-            "payload": { "code": "123456" }
-        }]));
-
-        assert_eq!(quest_list, "- [active] Write issue regression (quest-1)");
-        assert_eq!(space_list, "- Personal (1)");
-        assert!(generic_object_fallback.contains("Result:"));
-        assert!(generic_array_fallback.contains("Result:"));
-        for output in [
-            quest_list,
-            space_list,
-            generic_object_fallback,
-            generic_array_fallback,
-        ] {
-            assert_not_raw_json(&output);
-            assert!(
-                !output.contains("\n{"),
-                "must not print pretty JSON: {output}"
-            );
-        }
-    }
-
-    #[test]
-    fn generic_pair_request_summary_preserves_request_id() {
-        let output = format_human_output(&json!([{
-            "attempts": 1,
-            "cooldown_until": null,
-            "created_at": "2026-07-19T08:00:00Z",
-            "expires_at": "2026-07-19T08:10:00Z",
-            "from_device_id": "device-1",
-            "from_hostname": "phone",
-            "request_id": "request-1"
-        }]));
-
-        assert!(output.contains("request_id=request-1"));
-        assert_not_raw_json(&output);
-    }
-
-    #[test]
-    fn generic_device_summary_preserves_actionable_peer_device_id() {
-        let output = format_human_output(&json!([{
-            "display_name": "phone",
-            "last_seen_at": "2026-07-19T08:00:00Z",
-            "pair_state": "paired",
-            "paired_at": "2026-07-19T07:00:00Z",
-            "peer_device_id": "peer-1"
-        }]));
-
-        assert!(output.contains("peer_device_id=peer-1"));
-        assert_not_raw_json(&output);
-    }
-
-    #[test]
-    fn generic_device_summary_preserves_discovery_ws_port() {
-        let output = format_human_output(&json!([{
-            "addr": "192.0.2.10:5353",
-            "device_id": "device-1",
-            "hostname": "phone",
-            "last_seen_at": "2026-07-19T08:00:00Z",
-            "ws_port": 49152
-        }]));
-
-        assert!(output.contains("ws_port=49152"));
-        assert_not_raw_json(&output);
-    }
-
-    #[test]
-    fn scalar_quest_and_space_counts_use_generic_human_summary() {
-        let import_result = format_human_output(&json!({
-            "imported": true,
-            "spaces": 2,
-            "quest_series": 3,
-            "quests": 5
-        }));
-
-        assert!(import_result.contains("Result:"));
-        assert!(import_result.contains("imported=true"));
-        assert!(import_result.contains("spaces=2"));
-        assert!(import_result.contains("quests=5"));
-        assert!(!import_result.contains("No quests."));
-        assert!(!import_result.contains("No spaces."));
-        assert_not_raw_json(&import_result);
-    }
-
-    #[test]
-    fn backup_dry_run_human_output_preserves_readiness_and_mapping_requirements() {
-        let output = format_human_output(&json!({
-            "conflicts": [],
-            "dry_run": true,
-            "manifest": { "version": 1 },
-            "no_apply_or_recovery_action_occurred": true,
-            "ready_to_apply": false,
-            "required_space_mappings": [{
-                "backup_space_id": "space-7",
-                "backup_space_name": "Work"
-            }]
-        }));
-
-        assert!(output.contains("ready_to_apply=false"));
-        assert!(output.contains("required_space_mappings=Work (space-7)"));
-        assert_not_raw_json(&output);
-    }
-
-    #[test]
-    fn update_dry_run_human_output_preserves_release_and_target() {
-        let output = format_human_output(&json!({
-            "already_current": false,
-            "current_version": "0.8.0",
-            "dry_run": true,
-            "executable_path": "/usr/local/bin/fini",
-            "target": "x86_64-unknown-linux-gnu",
-            "target_version": "0.9.0",
-            "updated": false
-        }));
-
-        assert_eq!(
-            output,
-            "Update dry run: current_version=0.8.0, target_version=0.9.0, target=x86_64-unknown-linux-gnu, executable_path=/usr/local/bin/fini, already_current=false, updated=false."
-        );
-        assert!(output.contains("target_version=0.9.0"));
-        assert!(output.contains("target=x86_64-unknown-linux-gnu"));
-        assert_not_raw_json(&output);
-    }
-
-    #[test]
-    fn json_output_path_still_serializes_structured_json() {
-        let value = json!({
-            "quests": [{
-                "id": "quest-1",
-                "title": "Keep automation structured",
-                "status": "active"
-            }]
-        });
-        let text = serde_json::to_string_pretty(&value).expect("serialize JSON output");
-
-        assert!(serde_json::from_str::<Value>(&text).is_ok());
-        assert!(text.trim_start().starts_with('{'));
-    }
 
     #[test]
     fn nullable_update_argument_distinguishes_omitted_text_empty_and_literal_null() {
@@ -2429,6 +2152,84 @@ mod tests {
         );
         assert!(export_path.exists(), "export should write a backup archive");
         let _ = std::fs::remove_file(export_path);
+    }
+
+    #[test]
+    fn cli_help_describes_json_as_structured_opt_in() {
+        let help = Cli::command().render_help().to_string();
+
+        assert!(help.contains("--json"));
+        assert!(help.contains("Opt into structured JSON output for automation"));
+    }
+
+    #[test]
+    fn default_focus_output_is_human_readable_when_no_quest_is_active() {
+        let output = format_human_output(&Value::Null);
+
+        assert_eq!(output, "No active Focus quest.");
+        assert_not_raw_json(&output);
+    }
+
+    #[test]
+    fn representative_default_outputs_are_human_readable() {
+        let quest_list = format_human_output(&json!({
+            "quests": [{
+                "id": "quest-1",
+                "title": "Write issue regression",
+                "status": "active"
+            }]
+        }));
+        let space_list = format_human_output(&json!({
+            "spaces": [{
+                "id": "1",
+                "name": "Personal",
+                "item_order": 0
+            }]
+        }));
+        let generic_object_fallback = format_human_output(&json!({
+            "sent_events": 1,
+            "applied_events": 0,
+            "received_acks": 2,
+            "peers": [{ "peer_device_id": "peer-1" }],
+            "nested": { "ok": true }
+        }));
+        let generic_array_fallback = format_human_output(&json!([{
+            "request_id": "request-1",
+            "from_device_id": "device-1",
+            "payload": { "code": "123456" }
+        }]));
+
+        assert_eq!(quest_list, "- [active] Write issue regression (quest-1)");
+        assert_eq!(space_list, "- Personal (1)");
+        assert!(generic_object_fallback.contains("Result:"));
+        assert!(generic_array_fallback.contains("Result:"));
+        for output in [
+            quest_list,
+            space_list,
+            generic_object_fallback,
+            generic_array_fallback,
+        ] {
+            assert_not_raw_json(&output);
+            assert!(
+                !output.contains("\n{"),
+                "must not print pretty JSON: {output}"
+            );
+        }
+    }
+
+    #[test]
+    fn json_output_path_still_serializes_structured_json() {
+        let value = json!({
+            "quests": [{
+                "id": "quest-1",
+                "title": "Keep automation structured",
+                "status": "active"
+            }]
+        });
+        let text = serde_json::to_string_pretty(&value).expect("serialize JSON output");
+
+        assert!(serde_json::from_str::<Value>(&text).is_ok());
+        assert!(text.trim_start().starts_with('{'));
     }
 
     #[test]

--- a/src-tauri/src/services/cli.rs
+++ b/src-tauri/src/services/cli.rs
@@ -1427,6 +1427,13 @@ fn format_human_output_lines(value: &Value) -> Vec<String> {
                 .unwrap_or_else(|| "unknown".to_string());
             vec![format!("Theme hint: {theme}")]
         }
+        Value::Object(map)
+            if map.get("dry_run").and_then(Value::as_bool).is_some()
+                && map.contains_key("target_version")
+                && map.contains_key("target") =>
+        {
+            vec![format_cli_update_summary(map)]
+        }
         Value::Array(items) => {
             if items.is_empty() {
                 vec!["No results.".to_string()]
@@ -1463,6 +1470,42 @@ fn format_space_summary(value: &Value, prefix: &str) -> String {
         .and_then(Value::as_str)
         .unwrap_or("(unnamed)");
     format!("{prefix} {name} ({id})")
+}
+
+fn format_cli_update_summary(map: &serde_json::Map<String, Value>) -> String {
+    let action = if map.get("dry_run").and_then(Value::as_bool) == Some(true) {
+        "Update dry run"
+    } else {
+        "Update"
+    };
+    let current_version = map
+        .get("current_version")
+        .map(format_scalar)
+        .unwrap_or_else(|| "unknown".to_string());
+    let target_version = map
+        .get("target_version")
+        .map(format_scalar)
+        .unwrap_or_else(|| "unknown".to_string());
+    let target = map
+        .get("target")
+        .map(format_scalar)
+        .unwrap_or_else(|| "unknown".to_string());
+    let executable_path = map
+        .get("executable_path")
+        .map(format_scalar)
+        .unwrap_or_else(|| "unknown".to_string());
+    let already_current = map
+        .get("already_current")
+        .map(format_scalar)
+        .unwrap_or_else(|| "unknown".to_string());
+    let updated = map
+        .get("updated")
+        .map(format_scalar)
+        .unwrap_or_else(|| "unknown".to_string());
+
+    format!(
+        "{action}: current_version={current_version}, target_version={target_version}, target={target}, executable_path={executable_path}, already_current={already_current}, updated={updated}."
+    )
 }
 
 fn format_generic_summary(value: &Value) -> String {
@@ -1629,6 +1672,27 @@ mod tests {
         assert!(!import_result.contains("No quests."));
         assert!(!import_result.contains("No spaces."));
         assert_not_raw_json(&import_result);
+    }
+
+    #[test]
+    fn update_dry_run_human_output_preserves_release_and_target() {
+        let output = format_human_output(&json!({
+            "already_current": false,
+            "current_version": "0.8.0",
+            "dry_run": true,
+            "executable_path": "/usr/local/bin/fini",
+            "target": "x86_64-unknown-linux-gnu",
+            "target_version": "0.9.0",
+            "updated": false
+        }));
+
+        assert_eq!(
+            output,
+            "Update dry run: current_version=0.8.0, target_version=0.9.0, target=x86_64-unknown-linux-gnu, executable_path=/usr/local/bin/fini, already_current=false, updated=false."
+        );
+        assert!(output.contains("target_version=0.9.0"));
+        assert!(output.contains("target=x86_64-unknown-linux-gnu"));
+        assert_not_raw_json(&output);
     }
 
     #[test]

--- a/src-tauri/src/services/cli.rs
+++ b/src-tauri/src/services/cli.rs
@@ -46,7 +46,11 @@ const EXIT_RUNTIME: i32 = 5;
 #[derive(Parser)]
 #[command(name = "fini", version, about = "Fini CLI")]
 pub struct Cli {
-    #[arg(long, global = true, help = "Print structured JSON output")]
+    #[arg(
+        long,
+        global = true,
+        help = "Opt into structured JSON output for automation"
+    )]
     json: bool,
     #[command(subcommand)]
     command: Option<Command>,
@@ -1156,11 +1160,23 @@ fn print_output(value: &Value, json: bool) -> Result<(), String> {
         return Ok(());
     }
 
+    println!("{}", format_human_output(value));
+    Ok(())
+}
+
+fn format_human_output(value: &Value) -> String {
+    format_human_output_lines(value).join("\n")
+}
+
+fn format_human_output_lines(value: &Value) -> Vec<String> {
     match value {
-        Value::Null => println!("No active Focus quest."),
+        Value::Null => vec!["No active Focus quest.".to_string()],
         Value::Object(map) if map.contains_key("deleted") => {
             let id = map.get("id").and_then(Value::as_str).unwrap_or("unknown");
-            println!("Deleted: {id}");
+            vec![format!("Deleted: {id}")]
+        }
+        Value::Object(map) if map.get("ok").and_then(Value::as_bool) == Some(true) => {
+            vec!["OK.".to_string()]
         }
         Value::Object(map) if map.contains_key("quests") => {
             let items = map
@@ -1169,17 +1185,12 @@ fn print_output(value: &Value, json: bool) -> Result<(), String> {
                 .cloned()
                 .unwrap_or_default();
             if items.is_empty() {
-                println!("No quests.");
+                vec!["No quests.".to_string()]
             } else {
-                for item in items {
-                    let id = item.get("id").and_then(Value::as_str).unwrap_or("?");
-                    let title = item
-                        .get("title")
-                        .and_then(Value::as_str)
-                        .unwrap_or("(untitled)");
-                    let status = item.get("status").and_then(Value::as_str).unwrap_or("?");
-                    println!("- [{status}] {title} ({id})");
-                }
+                items
+                    .iter()
+                    .map(|item| format_quest_summary(item, "-"))
+                    .collect()
             }
         }
         Value::Object(map) if map.contains_key("spaces") => {
@@ -1189,41 +1200,131 @@ fn print_output(value: &Value, json: bool) -> Result<(), String> {
                 .cloned()
                 .unwrap_or_default();
             if items.is_empty() {
-                println!("No spaces.");
+                vec!["No spaces.".to_string()]
             } else {
-                for item in items {
-                    let id = item.get("id").and_then(Value::as_str).unwrap_or("?");
-                    let name = item
-                        .get("name")
-                        .and_then(Value::as_str)
-                        .unwrap_or("(unnamed)");
-                    println!("- {name} ({id})");
-                }
+                items
+                    .iter()
+                    .map(|item| format_space_summary(item, "-"))
+                    .collect()
             }
+        }
+        Value::Object(map) if is_quest_object(map) => vec![format_quest_summary(value, "Quest:")],
+        Value::Object(map) if is_space_object(map) => vec![format_space_summary(value, "Space:")],
+        Value::Object(map) if map.contains_key("mode") => {
+            let mode = map
+                .get("mode")
+                .map(format_scalar)
+                .unwrap_or_else(|| "unknown".to_string());
+            vec![format!("Theme mode: {mode}")]
+        }
+        Value::Object(map) if map.contains_key("theme") => {
+            let theme = map
+                .get("theme")
+                .map(format_scalar)
+                .unwrap_or_else(|| "unknown".to_string());
+            vec![format!("Theme hint: {theme}")]
         }
         Value::Array(items) => {
             if items.is_empty() {
-                println!("No results.");
+                vec!["No results.".to_string()]
             } else {
-                for item in items {
-                    let text = serde_json::to_string_pretty(item).map_err(|e| e.to_string())?;
-                    println!("{text}");
-                }
+                items.iter().map(format_generic_summary).collect()
             }
         }
-        _ => {
-            let text = serde_json::to_string_pretty(value).map_err(|e| e.to_string())?;
-            println!("{text}");
+        _ => vec![format_generic_summary(value)],
+    }
+}
+
+fn is_quest_object(map: &serde_json::Map<String, Value>) -> bool {
+    map.contains_key("id") && map.contains_key("title") && map.contains_key("status")
+}
+
+fn is_space_object(map: &serde_json::Map<String, Value>) -> bool {
+    map.contains_key("id") && map.contains_key("name") && map.contains_key("item_order")
+}
+
+fn format_quest_summary(value: &Value, prefix: &str) -> String {
+    let id = value.get("id").and_then(Value::as_str).unwrap_or("?");
+    let title = value
+        .get("title")
+        .and_then(Value::as_str)
+        .unwrap_or("(untitled)");
+    let status = value.get("status").and_then(Value::as_str).unwrap_or("?");
+    format!("{prefix} [{status}] {title} ({id})")
+}
+
+fn format_space_summary(value: &Value, prefix: &str) -> String {
+    let id = value.get("id").and_then(Value::as_str).unwrap_or("?");
+    let name = value
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or("(unnamed)");
+    format!("{prefix} {name} ({id})")
+}
+
+fn format_generic_summary(value: &Value) -> String {
+    match value {
+        Value::Null => "No result.".to_string(),
+        Value::Bool(_) | Value::Number(_) | Value::String(_) => format_scalar(value),
+        Value::Array(items) => format_count("result", items.len()),
+        Value::Object(map) => {
+            let fields: Vec<_> = map
+                .iter()
+                .filter_map(|(key, value)| match value {
+                    Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {
+                        Some(format!("{key}={}", format_scalar(value)))
+                    }
+                    Value::Array(items) => {
+                        Some(format!("{key}={}", format_count("item", items.len())))
+                    }
+                    Value::Object(nested) => Some(format!("{key}={} fields", nested.len())),
+                })
+                .take(4)
+                .collect();
+
+            if fields.is_empty() {
+                format!("Result: {} fields.", map.len())
+            } else {
+                format!("Result: {}.", fields.join(", "))
+            }
         }
     }
-    Ok(())
+}
+
+fn format_count(noun: &str, count: usize) -> String {
+    if count == 1 {
+        format!("1 {noun}")
+    } else {
+        format!("{count} {noun}s")
+    }
+}
+
+fn format_scalar(value: &Value) -> String {
+    match value {
+        Value::Null => "none".to_string(),
+        Value::Bool(value) => value.to_string(),
+        Value::Number(value) => value.to_string(),
+        Value::String(value) if value.is_empty() => "(empty)".to_string(),
+        Value::String(value) => value.clone(),
+        Value::Array(items) => format_count("item", items.len()),
+        Value::Object(map) => format!("{} fields", map.len()),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::services::db::temp_db_path;
+    use clap::CommandFactory;
     use std::path::Path;
+
+    fn assert_not_raw_json(text: &str) {
+        let trimmed = text.trim_start();
+        assert!(
+            !trimmed.starts_with('{') && !trimmed.starts_with('['),
+            "default CLI output must be human-readable, got: {text}"
+        );
+    }
 
     fn seed_unknown_schema_migration_db(db_path: &Path) {
         let mut conn = SqliteConnection::establish(db_path.to_str().expect("valid temp db path"))
@@ -1245,6 +1346,84 @@ mod tests {
     }
 
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn cli_help_describes_json_as_structured_opt_in() {
+        let help = Cli::command().render_help().to_string();
+
+        assert!(help.contains("--json"));
+        assert!(help.contains("Opt into structured JSON output for automation"));
+    }
+
+    #[test]
+    fn default_focus_output_is_human_readable_when_no_quest_is_active() {
+        let output = format_human_output(&Value::Null);
+
+        assert_eq!(output, "No active Focus quest.");
+        assert_not_raw_json(&output);
+    }
+
+    #[test]
+    fn representative_default_outputs_are_human_readable() {
+        let quest_list = format_human_output(&json!({
+            "quests": [{
+                "id": "quest-1",
+                "title": "Write issue regression",
+                "status": "active"
+            }]
+        }));
+        let space_list = format_human_output(&json!({
+            "spaces": [{
+                "id": "1",
+                "name": "Personal",
+                "item_order": 0
+            }]
+        }));
+        let generic_object_fallback = format_human_output(&json!({
+            "sent_events": 1,
+            "applied_events": 0,
+            "received_acks": 2,
+            "peers": [{ "peer_device_id": "peer-1" }],
+            "nested": { "ok": true }
+        }));
+        let generic_array_fallback = format_human_output(&json!([{
+            "request_id": "request-1",
+            "from_device_id": "device-1",
+            "payload": { "code": "123456" }
+        }]));
+
+        assert_eq!(quest_list, "- [active] Write issue regression (quest-1)");
+        assert_eq!(space_list, "- Personal (1)");
+        assert!(generic_object_fallback.contains("Result:"));
+        assert!(generic_array_fallback.contains("Result:"));
+        for output in [
+            quest_list,
+            space_list,
+            generic_object_fallback,
+            generic_array_fallback,
+        ] {
+            assert_not_raw_json(&output);
+            assert!(
+                !output.contains("\n{"),
+                "must not print pretty JSON: {output}"
+            );
+        }
+    }
+
+    #[test]
+    fn json_output_path_still_serializes_structured_json() {
+        let value = json!({
+            "quests": [{
+                "id": "quest-1",
+                "title": "Keep automation structured",
+                "status": "active"
+            }]
+        });
+        let text = serde_json::to_string_pretty(&value).expect("serialize JSON output");
+
+        assert!(serde_json::from_str::<Value>(&text).is_ok());
+        assert!(text.trim_start().starts_with('{'));
+    }
 
     #[test]
     fn cli_auto_update_is_disabled_for_debug_test_builds() {

--- a/src-tauri/src/services/cli.rs
+++ b/src-tauri/src/services/cli.rs
@@ -1514,19 +1514,25 @@ fn format_generic_summary(value: &Value) -> String {
         Value::Bool(_) | Value::Number(_) | Value::String(_) => format_scalar(value),
         Value::Array(items) => format_count("result", items.len()),
         Value::Object(map) => {
-            let fields: Vec<_> = map
-                .iter()
-                .filter_map(|(key, value)| match value {
-                    Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {
-                        Some(format!("{key}={}", format_scalar(value)))
-                    }
-                    Value::Array(items) => {
-                        Some(format!("{key}={}", format_count("item", items.len())))
-                    }
-                    Value::Object(nested) => Some(format!("{key}={} fields", nested.len())),
-                })
-                .take(4)
-                .collect();
+            let mut fields = map
+                .get("request_id")
+                .map(|value| format!("request_id={}", format_scalar(value)))
+                .into_iter()
+                .collect::<Vec<_>>();
+            fields.extend(
+                map.iter()
+                    .filter(|(key, _)| key.as_str() != "request_id")
+                    .filter_map(|(key, value)| match value {
+                        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {
+                            Some(format!("{key}={}", format_scalar(value)))
+                        }
+                        Value::Array(items) => {
+                            Some(format!("{key}={}", format_count("item", items.len())))
+                        }
+                        Value::Object(nested) => Some(format!("{key}={} fields", nested.len())),
+                    })
+                    .take(4usize.saturating_sub(fields.len())),
+            );
 
             if fields.is_empty() {
                 format!("Result: {} fields.", map.len())
@@ -1654,6 +1660,22 @@ mod tests {
                 "must not print pretty JSON: {output}"
             );
         }
+    }
+
+    #[test]
+    fn generic_pair_request_summary_preserves_request_id() {
+        let output = format_human_output(&json!([{
+            "attempts": 1,
+            "cooldown_until": null,
+            "created_at": "2026-07-19T08:00:00Z",
+            "expires_at": "2026-07-19T08:10:00Z",
+            "from_device_id": "device-1",
+            "from_hostname": "phone",
+            "request_id": "request-1"
+        }]));
+
+        assert!(output.contains("request_id=request-1"));
+        assert_not_raw_json(&output);
     }
 
     #[test]


### PR DESCRIPTION
## Outcome

- make CLI text output the default

## Why

Addresses #72: Make CLI output human-readable unless --json is requested.

## Verification

- [ ] Record repository-level verification results before marking this pull request ready.

## Review focus

- Confirm the outcome satisfies the acceptance examples in #72.

## Follow-up

None.

Fixes #72
