### PR TITLE
Remove Fini exposed MCP surface; keep Tauri runtime tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ podman run --rm fini-runtime
 
 # explicit CLI commands
 podman run --rm fini-runtime --help
-podman run --rm -v fini-data:/data fini-runtime app
+podman run --rm -v fini-data:/data fini-runtime space list
 ```
 
 The published container image is CLI-first and uses the release binary. The e2e image is built from a separate `test` target and is not published as the runtime artifact.

--- a/specs/cli/README.md
+++ b/specs/cli/README.md
@@ -1,6 +1,8 @@
 # CLI Binary Contract
 
-Fini exposes a CLI-only binary named `fini` for synchronous automation.
+Fini exposes a CLI-only binary named `fini` for synchronous automation. The CLI
+is the supported Fini automation interface; Fini does not expose a supported
+app-facing MCP command or server surface.
 
 ## Entry Points
 
@@ -19,6 +21,11 @@ Fini exposes a CLI-only binary named `fini` for synchronous automation.
 - Desktop app builds enable only `ui-plane`; local automation uses the separate `fini` CLI binary.
 - Docker runtime builds enable only `cli-plane` and expose the CLI binary by default.
 - Mobile builds enable only `ui-plane`; adding `cli-plane` to mobile builds violates this contract.
+
+Tauri runtime-control hooks used by the E2E harness, including third-party
+Playwright socket terminology such as `mcpSocket`, are test tooling only. They
+are separate from Fini's supported CLI automation boundary and must not be
+documented as a user-facing Fini MCP interface.
 
 ## Release Artifacts
 

--- a/specs/e2e/ui/fixtures.ts
+++ b/specs/e2e/ui/fixtures.ts
@@ -41,6 +41,7 @@ const tauriCommand = process.env.FINI_APP_BINARY
 export const { test, expect } = createTauriTest({
   tauriCommand,
   tauriCwd: process.cwd(),
+  // Third-party tauri-playwright runtime-control terminology; not a supported Fini MCP surface.
   mcpSocket: join(e2eUiRoot, 'fini-playwright.sock'),
   startTimeout: 240,
 });

--- a/src-tauri/src/services/cli.rs
+++ b/src-tauri/src/services/cli.rs
@@ -1223,6 +1223,7 @@ fn print_output(value: &Value, json: bool) -> Result<(), String> {
 mod tests {
     use super::*;
     use crate::services::db::temp_db_path;
+    use clap::CommandFactory;
     use std::path::Path;
 
     fn seed_unknown_schema_migration_db(db_path: &Path) {
@@ -1245,6 +1246,24 @@ mod tests {
     }
 
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn cli_help_does_not_expose_mcp_command() {
+        let help = Cli::command().render_help().to_string();
+
+        assert!(!help.contains("mcp"));
+        assert!(!help.contains("MCP"));
+    }
+
+    #[test]
+    fn cli_rejects_mcp_command() {
+        let err = match Cli::try_parse_from(["fini", "mcp"]) {
+            Ok(_) => panic!("mcp is not a CLI command"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), clap::error::ErrorKind::InvalidSubcommand);
+    }
 
     #[test]
     fn cli_auto_update_is_disabled_for_debug_test_builds() {


### PR DESCRIPTION
## Outcome

- clarify supported CLI automation surface

## Why

Addresses #40: Remove Fini exposed MCP surface; keep Tauri runtime tooling.

## Verification

- [ ] Record repository-level verification results before marking this pull request ready.

## Review focus

- Confirm the outcome satisfies the acceptance examples in #40.

## Follow-up

None.

Fixes #40
