### PR TITLE
Detect completed quests before context-based status changes

### DIFF
--- a/skills/fini/SKILL.md
+++ b/skills/fini/SKILL.md
@@ -67,6 +67,16 @@ Users may rename built-ins or create custom spaces. Always fetch fresh data via 
 - Set `repeat_rule` for recurring quests (e.g. `daily`, `weekly`, `monthly`)
 - Repeating quests track `series_id` and `period_key` automatically
 
+### Quest Mutation Safety
+
+Apply this workflow before every quest mutation: create, update, complete, abandon, restore, or delete.
+
+1. Determine the normalized title: use the proposed title for create or title updates; otherwise fetch the target quest by ID and use its current title. Normalize by trimming leading and trailing whitespace and comparing case-insensitively.
+2. Query all retained quests—active, completed, and abandoned—with that exact normalized title. For an existing target, exclude that target from the candidate set. Do not treat quests with the same non-empty `series_id` as duplicates; they are intentional recurring occurrences.
+3. If duplicate candidates remain, stop the mutation and show their IDs, statuses, and `created_at` values. Require an explicit resolution: retain the oldest record and delete others, target an existing record by ID, proceed intentionally with the requested mutation, or cancel.
+4. When recommending consolidation, recommend retaining the oldest record by `created_at`. Preserve it unchanged unless the user explicitly chooses fields to copy from another record; never delete a duplicate automatically.
+5. After the user approves a mutation, read the target record back and rerun the exact-title duplicate query to verify the intended result. Report the verification outcome.
+
 ### Nullable Quest Updates
 
 For `fini quest update`, omit a field to preserve it, pass ordinary text (including an empty string) to store it, and pass literal `null` to clear nullable values such as `description`, `due`, `due_time`, and `repeat_rule`.


### PR DESCRIPTION
## Summary
- search completed as well as active quests before inferring a session-context quest
- report an existing completed quest instead of creating or completing a duplicate
- require user direction for duplicate matches

## Verification
- reinstalled the `fini` skill from the canonical source
- verified installed and active Hermes copies match the source
- ran `git diff --check`