### PR TITLE
ci: run Snyk only after main pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,30 +45,6 @@ jobs:
               - 'src-tauri/**'
               - 'xtask/**'
 
-  snyk:
-    name: Snyk Vulnerability Scan
-    runs-on: ubuntu-latest
-    env:
-      SNYK_CLI_VERSION: 1.1305.2
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: '24'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Install Snyk CLI
-        run: npm install --global snyk@"$SNYK_CLI_VERSION"
-
-      - name: Run Snyk checks
-        run: snyk test --file=package.json --severity-threshold=high
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
   fe-unit-tests:
     name: FE Unit Tests

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,10 +1,9 @@
 name: Security Check
 
 on:
-  workflow_call:
-    secrets:
-      SNYK_TOKEN:
-        required: true
+  push:
+    branches:
+      - main
 
 jobs:
   snyk:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,6 +1,7 @@
 name: Security Check
 
 on:
+  workflow_call:
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary
- remove the Snyk job from pull-request CI
- trigger the dedicated Security Check workflow only for pushes to `main`

## Verification
- PyYAML workflow-contract check
- `actionlint` on both changed workflows
- `git diff --check`

External Snyk GitHub App checks are intentionally out of scope.