### PR TITLE
ci: run Snyk only in optional release scan

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -22,10 +22,6 @@ env:
   NODE_VERSION: "24"
 
 jobs:
-  security-scan:
-    uses: ./.github/workflows/security.yml
-    secrets: inherit
-
   signing-readiness:
     name: Signing Readiness
     runs-on: ubuntu-latest
@@ -80,7 +76,7 @@ jobs:
   quality-gates:
     name: Quality Gates
     runs-on: ubuntu-latest
-    needs: [signing-readiness, security-scan]
+    needs: signing-readiness
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -156,7 +156,7 @@ jobs:
   quality-gates:
     name: Quality Gates
     runs-on: ubuntu-latest
-    needs: [signing-readiness, security-scan]
+    needs: signing-readiness
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,14 +2,12 @@ name: Security Check
 
 on:
   workflow_call:
-  push:
-    branches:
-      - main
 
 jobs:
   snyk:
     name: Snyk Vulnerability Scan
     runs-on: ubuntu-latest
+    continue-on-error: true
     env:
       SNYK_CLI_VERSION: 1.1305.2
     steps:


### PR DESCRIPTION
## Summary
- remove standalone push-triggered Snyk runs and the release-prep Snyk caller
- retain Snyk only as the reusable scan invoked by the tagged release workflow
- make that scan non-blocking and remove it from release quality-gate dependencies

## Release failure
The latest tagged release, [Release From Tag run 30242499109](https://github.com/VRuzhentsov/fini/actions/runs/30242499109), stopped because Snyk hit the organisation's 200 private-test monthly limit. This change keeps the scan visible on release CI without preventing the release from completing.

## Verification
- YAML workflow contract check passed
-  passed
- actionlint reported only the same pre-existing ShellCheck findings on the base branch