### PR TITLE
Add the real Bluetooth transport: transport::ble over ble-gatt (Linux)

### DIFF
--- a/com.fini.app.yml
+++ b/com.fini.app.yml
@@ -13,6 +13,7 @@ finish-args:
   - --filesystem=home
   - --talk-name=org.freedesktop.Flatpak
   - --talk-name=org.freedesktop.Notifications
+  - --system-talk-name=org.bluez
 
 modules:
   - name: fini

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -395,6 +395,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ble-gatt"
+version = "0.1.0"
+source = "git+https://github.com/VRuzhentsov/ble-gatt?rev=d0d00a634156f98b7698eb8e0acf0df166c5d681#d0d00a634156f98b7698eb8e0acf0df166c5d681"
+dependencies = [
+ "async-trait",
+ "bluer",
+ "futures",
+ "jni",
+ "log",
+ "ndk-context",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "uuid",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +440,35 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "bluer"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af68112f5c60196495c8b0eea68349817855f565df5b04b2477916d09fb1a901"
+dependencies = [
+ "custom_debug",
+ "dbus",
+ "dbus-crossroads",
+ "dbus-tokio",
+ "displaydoc",
+ "futures",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "macaddr",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "strum",
+ "tokio",
+ "tokio-stream",
+ "uuid",
 ]
 
 [[package]]
@@ -962,13 +1008,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "custom_debug"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da7d1ad9567b3e11e877f1d7a0fa0360f04162f94965fc4448fbed41a65298e"
+dependencies = [
+ "custom_debug_derive",
+]
+
+[[package]]
+name = "custom_debug_derive"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a707ceda8652f6c7624f2be725652e9524c815bf3b9d55a0b2320be2303f9c11"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
 name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -987,11 +1079,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.117",
 ]
@@ -1014,9 +1117,31 @@ version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
 dependencies = [
+ "futures-channel",
+ "futures-util",
  "libc",
  "libdbus-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-crossroads"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64bff0bd181fba667660276c6b7ebdc50cff37ce593e7adf9e734f89c8f444e8"
+dependencies = [
+ "dbus",
+]
+
+[[package]]
+name = "dbus-tokio"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007688d459bc677131c063a3a77fb899526e17b7980f390b69644bdbc41fad13"
+dependencies = [
+ "dbus",
+ "libc",
+ "tokio",
 ]
 
 [[package]]
@@ -1293,7 +1418,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd122633e4bef06db27737f21d3738fb89c8f6d5360d6d9d7635dda142a7757e"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "either",
  "heck 0.5.0",
  "proc-macro2",
@@ -1536,6 +1661,7 @@ name = "fini"
 version = "0.2.4"
 dependencies = [
  "async-trait",
+ "ble-gatt",
  "chrono",
  "clap",
  "cpal",
@@ -1670,6 +1796,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1744,6 +1885,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -2631,6 +2773,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2771,6 +2919,12 @@ dependencies = [
  "objc2-foundation",
  "time",
 ]
+
+[[package]]
+name = "macaddr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baee0bbc17ce759db233beb01648088061bf678383130602a298e6998eedb2d8"
 
 [[package]]
 name = "mach2"
@@ -2992,6 +3146,18 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nodrop"
@@ -3599,6 +3765,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher 1.0.2",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4660,7 +4846,7 @@ version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4970,6 +5156,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "subtle"
@@ -5665,6 +5873,18 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -74,6 +74,7 @@ url = { version = "2", optional = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = { version = "0.18.2", optional = true }
 notify-rust = { version = "4", optional = true }
+ble-gatt = { git = "https://github.com/VRuzhentsov/ble-gatt", rev = "d0d00a634156f98b7698eb8e0acf0df166c5d681" }
 
 [features]
 default = []

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -62,6 +62,8 @@ use services::space_sync::{
     space_sync_resolve_custom_space_mapping, space_sync_status, space_sync_tick,
     space_sync_update_mappings,
 };
+#[cfg(all(feature = "ui-plane", target_os = "linux"))]
+use services::transport::ble;
 #[cfg(feature = "ui-plane")]
 use services::transport::{sim, tcp_ws};
 #[cfg(feature = "ui-plane")]
@@ -291,6 +293,8 @@ pub fn run() {
             let dc_state = DeviceConnectionState::from_app_data_dir(&data_dir);
             tauri::async_runtime::spawn(tcp_ws::run_server(dc_state.clone(), dc_state.db_path.clone()));
             sim::maybe_spawn_server(dc_state.clone(), dc_state.db_path.clone());
+            #[cfg(target_os = "linux")]
+            tauri::async_runtime::spawn(ble::run_server(dc_state.clone(), dc_state.db_path.clone()));
             app.manage(dc_state);
             Ok(())
         })

--- a/src-tauri/src/services/device_connection/commands.rs
+++ b/src-tauri/src/services/device_connection/commands.rs
@@ -52,7 +52,23 @@ fn bluetooth_address_is_os_paired(address: &str) -> bool {
 
     #[cfg(target_os = "linux")]
     {
-        return std::process::Command::new("bluetoothctl")
+        // Inside the Flatpak sandbox, `bluetoothctl` and the system D-Bus
+        // it needs aren't reachable directly (the GNOME runtime doesn't
+        // bundle the binary, and its own D-Bus proxy is per-app/session,
+        // not the host's `bluetoothd`). Route through `flatpak-spawn
+        // --host` instead, the same pattern already used elsewhere in this
+        // codebase (see `lib.rs`'s `FLATPAK_ID` check) — it runs the
+        // command on the host, where the real `bluetoothctl` and its
+        // system-bus connection exist, using the `--talk-name=org.freedesktop.Flatpak`
+        // permission the manifest already grants.
+        let mut command = if std::env::var_os("FLATPAK_ID").is_some() {
+            let mut command = std::process::Command::new("flatpak-spawn");
+            command.arg("--host").arg("bluetoothctl");
+            command
+        } else {
+            std::process::Command::new("bluetoothctl")
+        };
+        return command
             .arg("info")
             .arg(address)
             .output()

--- a/src-tauri/src/services/device_connection/commands.rs
+++ b/src-tauri/src/services/device_connection/commands.rs
@@ -773,6 +773,29 @@ pub fn device_connection_transport_statuses(
     device_connection_transport_statuses_impl(&mut conn, &state, peer_device_id)
 }
 
+/// Every paired peer eligible for a Bluetooth dial attempt right now:
+/// Bluetooth-enabled, with a stored address, and currently OS-paired. Used
+/// by `transport::ble::spawn_dial_loop` — unlike `tcp_ws`/`sim` there is no
+/// presence worker or static port list to draw candidates from, so this
+/// queries `paired_devices` directly, the same source
+/// `device_connection_transport_statuses` already checks per-peer.
+#[cfg(target_os = "linux")]
+pub fn bluetooth_dial_candidates(conn: &mut SqliteConnection) -> Vec<(String, String)> {
+    let paired: Vec<PairedDevice> = paired_devices::table
+        .filter(paired_devices::bluetooth_enabled.eq(true))
+        .select(PairedDevice::as_select())
+        .load(&mut *conn)
+        .unwrap_or_default();
+
+    paired
+        .into_iter()
+        .filter_map(|device| {
+            let address = device.bluetooth_address.as_deref().and_then(normalize_bluetooth_address)?;
+            bluetooth_address_is_os_paired(&address).then_some((device.peer_device_id, address))
+        })
+        .collect()
+}
+
 pub fn device_connection_session_transport_impl(
     state: &DeviceConnectionState,
     peer_device_id: String,

--- a/src-tauri/src/services/device_connection/mod.rs
+++ b/src-tauri/src/services/device_connection/mod.rs
@@ -25,6 +25,8 @@ pub use commands::{
     device_connection_transport_statuses, device_connection_unpair,
     device_connection_update_last_seen,
 };
+#[cfg(target_os = "linux")]
+pub use commands::bluetooth_dial_candidates;
 #[cfg(any(feature = "cli-plane", test))]
 pub use commands::{
     device_connection_consume_space_mapping_updates_impl, device_connection_debug_status_impl,

--- a/src-tauri/src/services/device_connection/transport.rs
+++ b/src-tauri/src/services/device_connection/transport.rs
@@ -54,14 +54,14 @@ pub fn select_transport_endpoint(
     })
 }
 
-/// No real Bluetooth `Transport`/`Link` adapter is registered yet — this PR
-/// only wires up `tcp_ws` and `sim` in `lib.rs` (see
-/// `docs/adr/0001-transport-neutral-peer-protocol.md`); the real adapter is
-/// a stacked follow-up PR. Until it lands, no Bluetooth session can ever be
-/// established, so status must never report `available`/`preferred`
-/// regardless of stored metadata — otherwise the Device view would promise
-/// a fallback that silently cannot sync. Flip to `true` when the adapter
-/// lands.
+/// `transport::ble` (BlueZ via `ble-gatt`) is wired up in `lib.rs` on Linux;
+/// Android has no adapter yet (needs the `tao` -> `ndk-context` bridge —
+/// see that module's doc comment). Until Android lands, status there must
+/// never report `available`/`preferred` regardless of stored metadata, or
+/// the Device view would promise a fallback that silently cannot sync.
+#[cfg(target_os = "linux")]
+const BLUETOOTH_ADAPTER_IMPLEMENTED: bool = true;
+#[cfg(not(target_os = "linux"))]
 const BLUETOOTH_ADAPTER_IMPLEMENTED: bool = false;
 
 pub fn build_transport_statuses(
@@ -199,16 +199,17 @@ mod tests {
             .any(|status| status.kind == TransportKind::Network && status.preferred));
     }
 
-    /// No Bluetooth `Transport`/`Link` adapter is registered in this PR
-    /// (`tcp_ws`/`sim` only — see `BLUETOOTH_ADAPTER_IMPLEMENTED`'s doc
-    /// comment), so a Bluetooth session can never actually establish.
-    /// Status must report `available`/`preferred: false` regardless of how
-    /// complete the stored enablement metadata is, or the Device view would
-    /// promise a fallback that silently cannot sync.
+    /// No Bluetooth `Transport`/`Link` adapter is registered on this platform
+    /// (Android — see `BLUETOOTH_ADAPTER_IMPLEMENTED`'s doc comment), so a
+    /// Bluetooth session can never actually establish there. Status must
+    /// report `available`/`preferred: false` regardless of how complete the
+    /// stored enablement metadata is, or the Device view would promise a
+    /// fallback that silently cannot sync. On Linux, where the real adapter
+    /// (`transport::ble`) is wired up, full metadata *should* report ready —
+    /// see `bluetooth_is_available_on_linux_with_full_metadata` below.
+    #[cfg(not(target_os = "linux"))]
     #[test]
     fn bluetooth_is_never_reported_available_without_a_registered_adapter() {
-        // Every combination that used to make the old (buggy) heuristic
-        // report Bluetooth as available/preferred:
         for (network_available, enabled, has_metadata, os_paired) in [
             (true, true, true, true),
             (false, true, true, true),
@@ -221,6 +222,46 @@ mod tests {
                 .expect("bluetooth status row");
             assert!(!bluetooth.available, "bluetooth must not report available");
             assert!(!bluetooth.preferred, "bluetooth must not report preferred");
+        }
+    }
+
+    /// Mirror of the above for Linux, where `transport::ble` is a real,
+    /// registered adapter: full enablement metadata should now report
+    /// Bluetooth ready, and preferred exactly when network is not.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn bluetooth_is_available_on_linux_with_full_metadata() {
+        let fallback = build_transport_statuses(false, true, true, true);
+        let bluetooth = fallback
+            .iter()
+            .find(|status| status.kind == TransportKind::Bluetooth)
+            .expect("bluetooth status row");
+        assert!(bluetooth.available, "bluetooth should report available");
+        assert!(bluetooth.preferred, "bluetooth should be preferred when network is absent");
+
+        let both = build_transport_statuses(true, true, true, true);
+        let bluetooth = both
+            .iter()
+            .find(|status| status.kind == TransportKind::Bluetooth)
+            .expect("bluetooth status row");
+        assert!(bluetooth.available, "bluetooth should still report available");
+        assert!(!bluetooth.preferred, "network should be preferred when both are available");
+    }
+
+    /// Incomplete metadata must still gate availability even with a real
+    /// adapter registered.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn bluetooth_still_requires_full_metadata_on_linux() {
+        for (enabled, has_metadata, os_paired) in
+            [(false, true, true), (true, false, true), (true, true, false)]
+        {
+            let statuses = build_transport_statuses(false, enabled, has_metadata, os_paired);
+            let bluetooth = statuses
+                .iter()
+                .find(|status| status.kind == TransportKind::Bluetooth)
+                .expect("bluetooth status row");
+            assert!(!bluetooth.available, "incomplete metadata must not report available");
         }
     }
 }

--- a/src-tauri/src/services/space_sync/commands.rs
+++ b/src-tauri/src/services/space_sync/commands.rs
@@ -1266,6 +1266,16 @@ pub fn space_sync_tick_impl(
         device_connection.db_path.clone(),
         &paired_peer_ids,
     );
+    #[cfg(target_os = "linux")]
+    {
+        let mut conn = crate::services::db::open_db_at_path(&device_connection.db_path);
+        let candidates = crate::services::device_connection::bluetooth_dial_candidates(&mut conn);
+        crate::services::transport::ble::spawn_dial_loop(
+            device_connection,
+            device_connection.db_path.clone(),
+            &candidates,
+        );
+    }
 
     let ticked_at = utc_now();
     let mut transferred_by_peer: std::collections::HashMap<String, (usize, usize, usize)> =

--- a/src-tauri/src/services/transport/ble.rs
+++ b/src-tauri/src/services/transport/ble.rs
@@ -20,8 +20,9 @@
 //! `device_connection::commands::bluetooth_address_is_os_paired` already
 //! checks for the enable command.
 
+use std::collections::HashSet;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -235,14 +236,33 @@ pub fn spawn_dial_loop(
         if state.network_effectively_available(peer_id) {
             continue;
         }
+        // One retry loop per peer, not one per tick: `space_sync_tick`
+        // (and therefore this function) runs every few seconds from the
+        // frontend, and `dial_with_backoff` itself already loops with
+        // backoff until a session claims or the peer stops being
+        // eligible. Without this guard, every tick while a peer stays
+        // unreachable would spawn *another* concurrent retry loop for the
+        // same peer on top of the ones already running — unbounded tasks
+        // and increasingly concurrent connection attempts to one address.
+        if !in_flight_dials().lock().unwrap().insert(peer_id.clone()) {
+            continue;
+        }
         let state = state.clone();
         let db_path = db_path.clone();
         let peer_id = peer_id.clone();
         let address = address.clone();
         tauri::async_runtime::spawn(async move {
-            dial_with_backoff(state, db_path, peer_id, address).await;
+            dial_with_backoff(state, db_path, peer_id.clone(), address).await;
+            in_flight_dials().lock().unwrap().remove(&peer_id);
         });
     }
+}
+
+/// Peers with a `dial_with_backoff` task currently running. See the doc
+/// comment on the guard in `spawn_dial_loop` for why this exists.
+fn in_flight_dials() -> &'static StdMutex<HashSet<String>> {
+    static IN_FLIGHT: OnceLock<StdMutex<HashSet<String>>> = OnceLock::new();
+    IN_FLIGHT.get_or_init(|| StdMutex::new(HashSet::new()))
 }
 
 /// Deterministic dialer rule, mirroring `tcp_ws::should_dial_peer`/

--- a/src-tauri/src/services/transport/ble.rs
+++ b/src-tauri/src/services/transport/ble.rs
@@ -1,0 +1,267 @@
+//! The Bluetooth transport: BLE GATT `Link`s over `ble-gatt`'s datagram tier
+//! (github.com/VRuzhentsov/ble-gatt).
+//!
+//! Linux only for now (BlueZ via `ble_gatt::backend::linux`). Android needs
+//! the same `tao` -> `ndk-context` bridge `tauri-plugin-ble-gatt`'s own
+//! `android_lazy` module already solved for the JS-facing plugin — this
+//! Rust-native path (Fini's own backend calling `ble-gatt` directly, no
+//! Tauri IPC involved) hasn't been wired up for it yet. Gating the whole
+//! module behind `target_os = "linux"` keeps that follow-up isolated rather
+//! than half-implemented behind runtime checks.
+//!
+//! Plays the same "Bluetooth fallback" role `transport::sim` plays for
+//! tests/E2E, but for real: network is preferred (see
+//! `transport::selection`), Bluetooth engages only when a paired peer is not
+//! effectively reachable over the network. Unlike `tcp_ws` (backed by the
+//! mDNS/UDP presence worker) and `sim` (statically configured ports), there
+//! is no discovery step here — candidates come from stored per-peer
+//! Bluetooth metadata (`paired_devices.bluetooth_address`, gated on
+//! `bluetooth_enabled` and a live OS-pairing check), exactly what
+//! `device_connection::commands::bluetooth_address_is_os_paired` already
+//! checks for the enable command.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use ble_gatt::backend::linux::LinuxBackend;
+use ble_gatt::datagram::{self, DatagramChannel, DatagramConfig};
+use ble_gatt::{Backend, CharacteristicUuid, PeerAddress, ServiceUuid};
+use tokio::sync::OnceCell;
+use uuid::Uuid;
+
+use crate::services::device_connection::DeviceConnectionState;
+use crate::services::space_sync::session;
+use crate::services::transport::{BoxDialFuture, Link, Transport, TransportKind};
+
+/// Fini's own GATT service/characteristic for the datagram tier. Fixed, not
+/// user-configurable: both sync peers must advertise/expect the same UUIDs
+/// to find each other's service. Distinct from any third-party device's own
+/// UUIDs — this is Fini-to-Fini only, the app-to-app case `ble-gatt`'s
+/// ADR-0003 describes.
+const FINI_BLE_SERVICE_UUID: &str = "b1e6a000-f101-4000-8000-00805f9b34fb";
+const FINI_BLE_CHARACTERISTIC_UUID: &str = "b1e6a001-f101-4000-8000-00805f9b34fb";
+
+fn datagram_config() -> DatagramConfig {
+    DatagramConfig::new(
+        ServiceUuid(Uuid::parse_str(FINI_BLE_SERVICE_UUID).expect("valid UUID literal")),
+        CharacteristicUuid(Uuid::parse_str(FINI_BLE_CHARACTERISTIC_UUID).expect("valid UUID literal")),
+    )
+}
+
+/// One `LinuxBackend` for the process's lifetime. `ble_gatt::backend::linux::LinuxBackend::new()`
+/// opens a BlueZ D-Bus session and requires a powered adapter; constructing
+/// it lazily (on first dial/serve attempt) rather than at startup means a
+/// machine with no/unpowered Bluetooth adapter never fails app startup over
+/// a transport most sessions won't use.
+async fn backend() -> Result<Arc<dyn Backend>, String> {
+    static BACKEND: OnceCell<Result<Arc<dyn Backend>, String>> = OnceCell::const_new();
+    BACKEND
+        .get_or_init(|| async {
+            LinuxBackend::new()
+                .await
+                .map(|backend| Arc::new(backend) as Arc<dyn Backend>)
+                .map_err(|err| err.to_string())
+        })
+        .await
+        .clone()
+}
+
+pub struct BleLink {
+    channel: DatagramChannel,
+    peer_addr: String,
+}
+
+impl BleLink {
+    fn new(channel: DatagramChannel) -> Self {
+        let peer_addr = channel.peer().0.clone();
+        Self { channel, peer_addr }
+    }
+}
+
+#[async_trait]
+impl Link for BleLink {
+    fn kind(&self) -> TransportKind {
+        TransportKind::Bluetooth
+    }
+
+    fn peer_addr(&self) -> Option<String> {
+        Some(self.peer_addr.clone())
+    }
+
+    async fn send(&mut self, payload: Vec<u8>) -> Result<(), String> {
+        self.channel.send(payload).await.map_err(|err| err.to_string())
+    }
+
+    async fn recv(&mut self) -> Option<Result<Vec<u8>, String>> {
+        match self.channel.recv().await? {
+            Ok(bytes) => Some(Ok(bytes)),
+            Err(err) => Some(Err(err.to_string())),
+        }
+    }
+}
+
+/// Central role: dial a peer's Bluetooth address.
+pub async fn dial(address: &str) -> Result<Box<dyn Link>, String> {
+    let backend = backend().await?;
+    let peer = PeerAddress(address.to_string());
+    let channel = datagram::connect(backend, &peer, &datagram_config())
+        .await
+        .map_err(|err| format!("ble connect to {address} failed: {err}"))?;
+    Ok(Box::new(BleLink::new(channel)))
+}
+
+/// `Transport` implementation for the Bluetooth adapter — see the note on
+/// `transport::tcp_ws::TcpWsTransport` for why production dial loops call
+/// `dial()` directly rather than through this trait object.
+#[allow(dead_code)]
+pub struct BleTransport;
+
+#[async_trait]
+impl Transport for BleTransport {
+    fn kind(&self) -> TransportKind {
+        TransportKind::Bluetooth
+    }
+
+    fn dial(&self, _peer_device_id: &str, addr: &str, _port: u16) -> BoxDialFuture {
+        let addr = addr.to_string();
+        Box::pin(async move { dial(&addr).await })
+    }
+}
+
+/// Peripheral role: advertise Fini's BLE service and gate every accepted
+/// central through the same transport-neutral session gate every other
+/// adapter uses. No-op (logs and returns) when the local adapter can't do
+/// peripheral mode, or isn't available at all — Bluetooth is always a
+/// fallback, never a hard requirement to start the app. `ui-plane`/`test`
+/// only, matching `tcp_ws::run_server`/`sim::run_server` — `cli-plane` dials
+/// out but does not run an inbound acceptor.
+#[cfg(any(feature = "ui-plane", test))]
+pub async fn run_server(state: DeviceConnectionState, db_path: PathBuf) {
+    use futures_util::StreamExt;
+
+    let backend = match backend().await {
+        Ok(backend) => backend,
+        Err(err) => {
+            eprintln!("[transport][ble] adapter unavailable, Bluetooth transport disabled: {err}");
+            return;
+        }
+    };
+    if !backend.capabilities().await.peripheral {
+        eprintln!("[transport][ble] adapter has no peripheral support; central-only for this device");
+        return;
+    }
+    let mut incoming = match datagram::serve(backend, &datagram_config()).await {
+        Ok(stream) => stream,
+        Err(err) => {
+            eprintln!("[transport][ble] advertise failed: {err}");
+            return;
+        }
+    };
+    eprintln!("[transport][ble] advertising, awaiting centrals");
+
+    while let Some(channel) = incoming.next().await {
+        let link: Box<dyn Link> = Box::new(BleLink::new(channel));
+        let state = state.clone();
+        let db_path = db_path.clone();
+        tokio::spawn(session::run_peer_gate(link, state, db_path));
+    }
+}
+
+/// Fallback dial loop: for every paired, Bluetooth-enabled, OS-paired peer
+/// with no active session and no effectively-available network, attempt a
+/// central-role connect. `candidates` is (peer_device_id, bluetooth_address)
+/// for peers meeting those stored-metadata conditions — gathered by the
+/// caller from `paired_devices` (see
+/// `device_connection::commands::bluetooth_dial_candidates`), since unlike
+/// `tcp_ws`/`sim` there is no presence worker or static port list to draw
+/// from here.
+pub fn spawn_dial_loop(
+    state: &DeviceConnectionState,
+    db_path: PathBuf,
+    candidates: &[(String, String)],
+) {
+    let my_id = state.identity.device_id.clone();
+
+    for (peer_id, address) in candidates {
+        if !should_dial_peer(&my_id, peer_id, state.has_session(peer_id)) {
+            continue;
+        }
+        // Network-first: only engage when the peer isn't effectively
+        // reachable over the network — mirrors `sim::spawn_fallback_dial_loop`'s
+        // `sim_is_preferred` check, but for the real fallback role instead
+        // of the test stand-in.
+        if state.network_effectively_available(peer_id) {
+            continue;
+        }
+        let state = state.clone();
+        let db_path = db_path.clone();
+        let peer_id = peer_id.clone();
+        let address = address.clone();
+        tauri::async_runtime::spawn(async move {
+            dial_with_backoff(state, db_path, peer_id, address).await;
+        });
+    }
+}
+
+/// Deterministic dialer rule, mirroring `tcp_ws::should_dial_peer`/
+/// `sim::should_dial_fallback_peer`: exactly one side of a pair ever
+/// attempts to dial, so both peers dialling each other in the same tick
+/// can't race to claim the same session on both ends.
+fn should_dial_peer(my_id: &str, peer_id: &str, has_session: bool) -> bool {
+    my_id < peer_id && !has_session
+}
+
+async fn dial_with_backoff(state: DeviceConnectionState, db_path: PathBuf, peer_id: String, address: String) {
+    let mut delay = Duration::from_secs(2);
+    let max_delay = Duration::from_secs(30);
+
+    loop {
+        if state.has_session(&peer_id) || state.network_effectively_available(&peer_id) {
+            return;
+        }
+
+        match dial(&address).await {
+            Ok(mut link) => {
+                match session::perform_client_auth(link.as_mut(), &state.identity.device_id, &peer_id)
+                    .await
+                {
+                    Ok(()) => {
+                        eprintln!("[transport][ble] auth OK with {peer_id} via {address}");
+                        let (tx, rx) = tokio::sync::mpsc::channel(64);
+                        if state.try_claim_session(&peer_id, TransportKind::Bluetooth, tx) {
+                            session::run_session(link, rx, state.clone(), db_path.clone(), peer_id.clone())
+                                .await;
+                            eprintln!("[transport][ble] session with {peer_id} ended");
+                        }
+                        delay = Duration::from_secs(2);
+                    }
+                    Err(err) => {
+                        eprintln!("[transport][ble] auth with {peer_id} failed: {err}");
+                        if err.starts_with("auth rejected") {
+                            return; // not paired; don't retry
+                        }
+                    }
+                }
+            }
+            Err(err) => eprintln!("[transport][ble] connect to {peer_id} ({address}) failed: {err}"),
+        }
+
+        tokio::time::sleep(delay).await;
+        delay = (delay * 2).min(max_delay);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_dial_only_from_the_lower_device_id_and_only_without_a_session() {
+        assert!(should_dial_peer("local-a", "peer-b", false));
+        assert!(!should_dial_peer("peer-b", "local-a", false));
+        assert!(!should_dial_peer("local-a", "peer-b", true));
+        assert!(!should_dial_peer("same-id", "same-id", false));
+    }
+}

--- a/src-tauri/src/services/transport/ble.rs
+++ b/src-tauri/src/services/transport/ble.rs
@@ -56,16 +56,24 @@ fn datagram_config() -> DatagramConfig {
 /// machine with no/unpowered Bluetooth adapter never fails app startup over
 /// a transport most sessions won't use.
 async fn backend() -> Result<Arc<dyn Backend>, String> {
-    static BACKEND: OnceCell<Result<Arc<dyn Backend>, String>> = OnceCell::const_new();
+    // `get_or_try_init`, not `get_or_init` over a cached `Result`: the
+    // latter permanently bakes in whatever the *first* call returned,
+    // success or failure. If Fini starts while Bluetooth is off, BlueZ is
+    // restarting, or the adapter is briefly unavailable, that first
+    // failure would be replayed to every later dial/serve attempt for the
+    // rest of the process's life, even after the adapter comes back —
+    // `get_or_try_init` instead leaves the cell empty on error, so the
+    // next call genuinely retries construction.
+    static BACKEND: OnceCell<Arc<dyn Backend>> = OnceCell::const_new();
     BACKEND
-        .get_or_init(|| async {
+        .get_or_try_init(|| async {
             LinuxBackend::new()
                 .await
                 .map(|backend| Arc::new(backend) as Arc<dyn Backend>)
                 .map_err(|err| err.to_string())
         })
         .await
-        .clone()
+        .map(Arc::clone)
 }
 
 pub struct BleLink {

--- a/src-tauri/src/services/transport/ble.rs
+++ b/src-tauri/src/services/transport/ble.rs
@@ -66,13 +66,27 @@ async fn backend() -> Result<Arc<dyn Backend>, String> {
     // rest of the process's life, even after the adapter comes back —
     // `get_or_try_init` instead leaves the cell empty on error, so the
     // next call genuinely retries construction.
+    // Bounded: `LinuxBackend::new()` opens a D-Bus system-bus session and
+    // talks to BlueZ over it. On a machine with no `bluetoothd` running at
+    // all (headless CI containers, minimal installs) there's nothing wrong
+    // locally, but D-Bus's own service-activation/name-owner-wait semantics
+    // can leave that call pending far longer than this transport is worth
+    // blocking anything on — this runs at app startup via
+    // `tauri::async_runtime::spawn`, so an unbounded wait here would tie up
+    // an async worker thread for however long that takes. A timeout turns
+    // "no adapter reachable" into a fast, retryable failure instead.
+    const BACKEND_INIT_TIMEOUT: Duration = Duration::from_secs(5);
+
     static BACKEND: OnceCell<Arc<dyn Backend>> = OnceCell::const_new();
     BACKEND
         .get_or_try_init(|| async {
-            LinuxBackend::new()
-                .await
-                .map(|backend| Arc::new(backend) as Arc<dyn Backend>)
-                .map_err(|err| err.to_string())
+            match tokio::time::timeout(BACKEND_INIT_TIMEOUT, LinuxBackend::new()).await {
+                Ok(Ok(backend)) => Ok(Arc::new(backend) as Arc<dyn Backend>),
+                Ok(Err(err)) => Err(err.to_string()),
+                Err(_) => Err(format!(
+                    "timed out after {BACKEND_INIT_TIMEOUT:?} waiting for the Bluetooth adapter"
+                )),
+            }
         })
         .await
         .map(Arc::clone)

--- a/src-tauri/src/services/transport/ble.rs
+++ b/src-tauri/src/services/transport/ble.rs
@@ -31,7 +31,8 @@ use ble_gatt::{Backend, CharacteristicUuid, PeerAddress, ServiceUuid};
 use tokio::sync::OnceCell;
 use uuid::Uuid;
 
-use crate::services::device_connection::DeviceConnectionState;
+use crate::services::db::open_db_at_path;
+use crate::services::device_connection::{bluetooth_dial_candidates, DeviceConnectionState};
 use crate::services::space_sync::session;
 use crate::services::transport::{BoxDialFuture, Link, Transport, TransportKind};
 
@@ -149,31 +150,62 @@ impl Transport for BleTransport {
 pub async fn run_server(state: DeviceConnectionState, db_path: PathBuf) {
     use futures_util::StreamExt;
 
-    let backend = match backend().await {
-        Ok(backend) => backend,
-        Err(err) => {
-            eprintln!("[transport][ble] adapter unavailable, Bluetooth transport disabled: {err}");
-            return;
-        }
-    };
-    if !backend.capabilities().await.peripheral {
-        eprintln!("[transport][ble] adapter has no peripheral support; central-only for this device");
-        return;
-    }
-    let mut incoming = match datagram::serve(backend, &datagram_config()).await {
-        Ok(stream) => stream,
-        Err(err) => {
-            eprintln!("[transport][ble] advertise failed: {err}");
-            return;
-        }
-    };
-    eprintln!("[transport][ble] advertising, awaiting centrals");
+    // Retried with backoff, not returned-from-once: `lib.rs` spawns this
+    // exactly once at startup, so an early failure here (adapter off,
+    // BlueZ restarting, briefly unavailable) used to end the peripheral
+    // role for the rest of the process's life even after `backend()`
+    // itself became able to retry. If this device also has the higher
+    // device id, the deterministic dial rule means it never dials out
+    // either — Bluetooth would be unusable until restart. Looping means
+    // enabling Bluetooth later (or the adapter coming back) can still
+    // stand up the acceptor.
+    let mut delay = Duration::from_secs(2);
+    let max_delay = Duration::from_secs(60);
 
-    while let Some(channel) = incoming.next().await {
-        let link: Box<dyn Link> = Box::new(BleLink::new(channel));
-        let state = state.clone();
-        let db_path = db_path.clone();
-        tokio::spawn(session::run_peer_gate(link, state, db_path));
+    loop {
+        let backend = match backend().await {
+            Ok(backend) => backend,
+            Err(err) => {
+                eprintln!("[transport][ble] adapter unavailable, retrying in {delay:?}: {err}");
+                tokio::time::sleep(delay).await;
+                delay = (delay * 2).min(max_delay);
+                continue;
+            }
+        };
+        if !backend.capabilities().await.peripheral {
+            eprintln!(
+                "[transport][ble] adapter has no peripheral support; retrying in {delay:?} \
+                 in case a different adapter becomes available"
+            );
+            tokio::time::sleep(delay).await;
+            delay = (delay * 2).min(max_delay);
+            continue;
+        }
+        let mut incoming = match datagram::serve(backend, &datagram_config()).await {
+            Ok(stream) => stream,
+            Err(err) => {
+                eprintln!("[transport][ble] advertise failed, retrying in {delay:?}: {err}");
+                tokio::time::sleep(delay).await;
+                delay = (delay * 2).min(max_delay);
+                continue;
+            }
+        };
+        eprintln!("[transport][ble] advertising, awaiting centrals");
+        delay = Duration::from_secs(2);
+
+        while let Some(channel) = incoming.next().await {
+            let link: Box<dyn Link> = Box::new(BleLink::new(channel));
+            let state = state.clone();
+            let db_path = db_path.clone();
+            tokio::spawn(session::run_peer_gate(link, state, db_path));
+        }
+        // The serve stream itself ended (e.g. the adapter dropped out from
+        // under it) rather than a caller closing it — nothing here ever
+        // drops the stream deliberately. Retry rather than leaving the
+        // peripheral role dead.
+        eprintln!("[transport][ble] serve stream ended unexpectedly; retrying in {delay:?}");
+        tokio::time::sleep(delay).await;
+        delay = (delay * 2).min(max_delay);
     }
 }
 
@@ -221,12 +253,42 @@ fn should_dial_peer(my_id: &str, peer_id: &str, has_session: bool) -> bool {
     my_id < peer_id && !has_session
 }
 
+/// Re-reads `paired_devices` for the current, live answer to "is this peer
+/// still a valid Bluetooth dial target" — enabled, still holding this exact
+/// address, and currently OS-paired. `block_in_place` around the blocking
+/// DB open, matching `space_sync::session::check_paired`'s existing pattern
+/// for the same kind of call from inside an async loop.
+fn is_still_bluetooth_eligible(db_path: &std::path::Path, peer_id: &str, address: &str) -> bool {
+    tokio::task::block_in_place(|| {
+        let mut conn = open_db_at_path(db_path);
+        bluetooth_dial_candidates(&mut conn)
+            .into_iter()
+            .any(|(candidate_id, candidate_address)| {
+                candidate_id == peer_id && candidate_address == address
+            })
+    })
+}
+
 async fn dial_with_backoff(state: DeviceConnectionState, db_path: PathBuf, peer_id: String, address: String) {
     let mut delay = Duration::from_secs(2);
     let max_delay = Duration::from_secs(30);
 
     loop {
         if state.has_session(&peer_id) || state.network_effectively_available(&peer_id) {
+            return;
+        }
+        // Re-checked every retry, not just at the moment this task was
+        // spawned: the candidate list `spawn_dial_loop` built is a single
+        // snapshot, so a peer reachable only later in this backoff loop
+        // would otherwise still complete auth and claim a session even
+        // after the user disabled Bluetooth for them or unpaired them
+        // entirely in the meantime — a setting meant to stop future
+        // Bluetooth use silently not taking effect.
+        if !is_still_bluetooth_eligible(&db_path, &peer_id, &address) {
+            eprintln!(
+                "[transport][ble] {peer_id} is no longer Bluetooth-enabled/OS-paired; \
+                 stopping dial retries"
+            );
             return;
         }
 

--- a/src-tauri/src/services/transport/mod.rs
+++ b/src-tauri/src/services/transport/mod.rs
@@ -8,14 +8,18 @@
 //! - `tcp_ws` — the network transport (mDNS/UDP discovery + WebSocket link).
 //! - `sim` — a deterministic, CI-safe adapter used by tests and E2E to
 //!   exercise transport selection/fallback/handoff without real radios.
-//! - Bluetooth (Linux BlueZ + Android) and LoRaWAN are reserved `TransportKind`
-//!   variants with no adapter yet; see `docs/adr/0001-transport-neutral-peer-protocol.md`.
+//! - `ble` — the real Bluetooth adapter (Linux BlueZ via `ble-gatt`; Android
+//!   not yet wired up, see that module's doc comment). LoRaWAN remains a
+//!   reserved `TransportKind` variant with no adapter; see
+//!   `docs/adr/0001-transport-neutral-peer-protocol.md`.
 //!
 //! A `Link` moves opaque byte datagrams (whole payloads, boundaries
 //! preserved); each adapter owns its own chunking/framing. Above `Link` sits
 //! `codec` (envelope + `PeerFrame` (de)serialization) and `secure_channel`
 //! (currently pass-through; the seam for future end-to-end encryption).
 
+#[cfg(target_os = "linux")]
+pub mod ble;
 pub mod codec;
 pub mod envelope;
 pub mod secure_channel;
@@ -40,8 +44,8 @@ pub enum TransportKind {
     /// Deterministic loopback-TCP adapter used by tests/E2E to prove
     /// selection, fallback, and handoff without a real radio.
     Sim,
-    /// Reserved for the real Bluetooth adapter (Linux BlueZ + Android),
-    /// landing in a follow-up PR. No adapter implements this kind yet.
+    /// The real Bluetooth adapter — see `transport::ble` (Linux BlueZ via
+    /// `ble-gatt`; Android not yet wired up).
     Bluetooth,
     /// Reserved for a future LoRaWAN adapter. No adapter implements this
     /// kind yet.


### PR DESCRIPTION
## Summary

Closes the gap #135 tracks. Fini can now actually sync over Bluetooth on Linux — this was the missing piece: PR #121 built the transport-neutral protocol plus the `Sim` adapter that plays "Bluetooth" for tests, but no real Bluetooth `Link` ever existed in the app. It does now.

**What this is:** a new `transport::ble` adapter, consuming the [ble-gatt](https://github.com/VRuzhentsov/ble-gatt) library (a separate BLE GATT crate built for this, central+peripheral, Linux via BlueZ + Android via raw JNI), plugged into Fini's existing transport-selection machinery the same way `tcp_ws`/`sim` are.

**What it does, concretely:** two paired devices with Bluetooth enabled for each other can now establish a real BLE-carried sync session when the network transport isn't reachable — dial, auth, and the full sync session loop, over an actual GATT connection instead of TCP.

## What changed

- **`transport/ble.rs` (new)** — `BleLink` (wraps `ble-gatt`'s `DatagramChannel`), `dial()`/`BleTransport` (central role), `run_server()` (peripheral role: advertise + accept + hand off to the shared `session::run_peer_gate`), `spawn_dial_loop()`/`dial_with_backoff()` (the production fallback dial loop — network-first, only engages when a paired peer isn't effectively reachable over the network).
- **`device_connection::commands`** — `bluetooth_dial_candidates()`: since Bluetooth has no presence worker (unlike `tcp_ws`'s mDNS/UDP or `sim`'s static ports), candidates come from stored per-peer metadata (`bluetooth_enabled`, has an address, currently OS-paired).
- **`lib.rs`** — `ble::run_server` spawned alongside the existing `tcp_ws`/`sim` server startup.
- **`space_sync::commands::space_sync_tick_impl`** — `ble::spawn_dial_loop` called alongside the existing dial loops.
- **`device_connection::transport::BLUETOOTH_ADAPTER_IMPLEMENTED`** flips to `true` on Linux. This flag existed specifically so the Device view couldn't claim Bluetooth was available before an adapter existed to back that claim — now one does, there. Updated the existing test that asserted the old always-false behavior, added coverage for the new true path.
- **`Cargo.toml`** — `ble-gatt` added as a Linux-only git dependency (pinned to its current `main`), matching how `gtk`/`notify-rust` are already scoped to that target.

## Explicitly not in this PR

- **Android's Bluetooth adapter.** It needs the same `tao` → `ndk-context` bridge `tauri-plugin-ble-gatt`'s Tauri plugin wrapper already solved for the JS-facing path — this is Fini's Rust backend calling `ble-gatt` directly (no Tauri IPC involved), which doesn't have that bridge yet. `BLUETOOTH_ADAPTER_IMPLEMENTED` stays `false` there, so status/availability is honest about it. Documented in the module's doc comment, not silently left as a gap.
- **Encryption over the datagram tier.** `secure_channel` stays the existing `PlaintextChannel` pass-through — tracked separately per `docs/adr/0001-transport-neutral-peer-protocol.md` and ADR-0003 on the `ble-gatt` side, not specific to this transport.
- **Real two-device hardware verification of this exact integration.** `ble-gatt` itself has an emulator-based verification harness (see its `docs/hardware-verification.md`); this PR hasn't yet been run against two real paired Linux machines end-to-end.

## Verification

- `cargo check` clean on `cli-plane`, `ui-plane`, `ui-plane`+`devtools`, and `desktop-updater`.
- `cargo test --lib --features ui-plane`: 169 passed, 0 failed.
- No new clippy warnings in any file this touches (checked with `cargo clippy --lib --features ui-plane` and diffed against the pre-existing warning set on `main`).

## Test plan

- [ ] Two Linux machines (or one machine + a USB Bluetooth dongle for a second adapter), both already OS-Bluetooth-paired.
- [ ] Complete Fini app pairing between them over the network transport (unchanged).
- [ ] Enable Bluetooth transport for that pair on both sides (`device_connection_set_bluetooth_transport`).
- [ ] Disable/block the network transport between them and confirm a session establishes over Bluetooth instead, and sync events still flow.
- [ ] Re-enable network and confirm the next session establishment goes back to network-first.

Refs: #135, #25, #121.