### PR TITLE
Gate zbus/zvariant to Linux, fixing the Windows release build

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,8 +61,6 @@ time = { version = "0.3.47", features = ["parsing", "formatting"] }
 tauri-plugin-playwright = { version = "0.2", optional = true }
 socket2 = "0.6"
 mdns-sd = "0.13"
-zbus = { version = "5.14.0", features = ["blocking-api"] }
-zvariant = "5.10.0"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 tar = "0.4"
 flate2 = "1"
@@ -75,6 +73,14 @@ url = { version = "2", optional = true }
 gtk = { version = "0.18.2", optional = true }
 notify-rust = { version = "4", optional = true }
 ble-gatt = { git = "https://github.com/VRuzhentsov/ble-gatt", rev = "af4ed1e5cfcade75d15ff96e8c3e8de1d97749fa" }
+# Only used behind #[cfg(target_os = "linux")] (resume_watcher's sleep/wake
+# watcher, settings.rs's portal theme-change watcher, both over the
+# session/system D-Bus) -- kept target-gated rather than unconditional so
+# Windows/macOS builds don't pull in zbus's Windows uds_windows backend at
+# all, which has no reason to be exercised there and can independently break
+# on its own dependency drift (windows-sys versions dropping `core::BOOL`).
+zbus = { version = "5.14.0", features = ["blocking-api"] }
+zvariant = "5.10.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 ble-gatt = { git = "https://github.com/VRuzhentsov/ble-gatt", rev = "af4ed1e5cfcade75d15ff96e8c3e8de1d97749fa" }


### PR DESCRIPTION
## Summary
- The v0.2.8 release CI failed on both Windows artifact builds: `uds_windows 1.2.0` (a transitive dep of `zbus`, pulled in unconditionally) fails to compile against the resolved `windows-sys 0.59.0` (`unresolved import windows_sys::core::BOOL`).
- Every real `zbus`/`zvariant` usage in this crate is already `#[cfg(target_os = "linux")]` (resume_watcher's sleep/wake D-Bus watcher, settings.rs's portal theme-change watcher) -- the dependency declarations just weren't gated to match, so Windows builds compiled `zbus`'s unused Windows backend for nothing.
- Moved both into the existing `target.'cfg(target_os = "linux")'.dependencies` section. Confirmed `uds_windows` drops out of the Windows dependency graph entirely (`cargo tree --target x86_64-pc-windows-msvc -i uds_windows` → nothing to print), and the Linux build/253 backend tests are unaffected.
- (The Docker image push failure in the same run was a transient GHCR secondary rate limit, unrelated to this -- just needs a re-run once this merges.)

## Test plan
- [x] `cargo check`/`cargo test --lib` on Linux: unaffected, 253 passed
- [x] `cargo tree --target x86_64-pc-windows-msvc -i uds_windows`: empty (was previously resolvable)
- [ ] CI Windows artifact builds pass on this PR