### PR TITLE
Gate send_pair_ble to Linux/Android, fixing the Windows build

### DIFF
--- a/src-tauri/src/services/device_connection/commands.rs
+++ b/src-tauri/src/services/device_connection/commands.rs
@@ -479,6 +479,7 @@ fn send_pair_ws(addr: IpAddr, port: u16, msg: PeerFrame) -> Result<(), String> {
 /// attempt.
 const SEND_PAIR_BLE_TIMEOUT: Duration = Duration::from_secs(10);
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn send_pair_ble(address: &str, msg: PeerFrame) -> Result<(), String> {
     tauri::async_runtime::block_on(async move {
         tokio::time::timeout(SEND_PAIR_BLE_TIMEOUT, async {


### PR DESCRIPTION
## Summary
- After #143 fixed the zbus/uds_windows failure, the v0.2.9 release run's Windows builds (x64 + arm64) still failed, now on a different, previously-masked error:
  ```
  error[E0433]: cannot find `ble` in `transport`
  error[E0425]: cannot find value `SEND_PAIR_BLE_TIMEOUT` in this scope
  ```
- Root cause: `SEND_PAIR_BLE_TIMEOUT` is correctly `#[cfg(any(target_os = "linux", target_os = "android"))]`, but `fn send_pair_ble` right below it (which uses that constant and calls into the Linux/Android-only `transport::ble` module) had no cfg attribute at all -- so it compiled unconditionally, including on Windows, where neither symbol exists. This has been broken since ADR 0002 merged; #143's fix only let Windows compilation get far enough to reach this function for the first time.
- All three call sites of `send_pair_ble` were already correctly gated. Audited every other `transport::ble`/`ble_gatt` reference across the crate (`commands.rs`, `space_sync/commands.rs`, `lib.rs`) and confirmed this was the only gap.
- No local way to cross-compile/check the actual Windows target on this machine (no MSVC toolchain; mingw-w64 install is blocked -- sudo/dnf are off-limits here), so this fix is verified by careful static audit of cfg-gating rather than a local compile. Real verification is this PR's own CI Windows builds.

## Test plan
- [x] `cargo check`/`cargo test --lib` on Linux: unaffected, 253 passed (stable across 3 runs)
- [x] Manual audit: every other `transport::ble`/`ble_gatt::` reference in the crate confirmed properly cfg-gated
- [ ] CI Windows artifact builds (x64 + arm64) pass on this PR -- the actual verification for this fix