### PR TITLE
Add MAC address input mask and broaden Bluetooth workflow test coverage

### DIFF
--- a/specs/e2e/actors/tests/unpair-and-rejoin-over-sim.spec.ts
+++ b/specs/e2e/actors/tests/unpair-and-rejoin-over-sim.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '../fixtures.ts';
+import { ensureSimPairedActors, waitForSimSession } from '../helpers/sim-sync.ts';
+import { ensurePersonalSpaceSync, waitForPersonalLastSyncedLabel } from '../helpers/personal-sync.ts';
+
+interface PairedDeviceRow {
+  peer_device_id: string;
+}
+
+/**
+ * The "delete Bluetooth connection, then pair again" lifecycle: unpairing
+ * fully deletes the paired_devices row (cascading to pair_space_mappings,
+ * see migration 00000000000010's ON DELETE CASCADE), so a subsequent
+ * pairing goes through the exact same fresh-insert path a first-ever pair
+ * does -- not a resumed/patched-up one. This proves that full cycle
+ * recovers completely: session re-establishes, and Space sync has to be
+ * re-requested and re-approved from scratch (the mapping is genuinely
+ * gone, not just hidden), not silently inherited from before the unpair.
+ */
+test('unpairing and re-pairing over Sim transport fully recovers session and Space sync', async ({
+  actorA,
+  actorB,
+}) => {
+  const [firstSyncedA, firstSyncedB] = await ensureSimPairedActors([actorA, actorB]);
+  await waitForSimSession(actorA);
+  await waitForSimSession(actorB);
+  await ensurePersonalSpaceSync(
+    actorA,
+    firstSyncedB.identity.device_id,
+    actorB,
+    firstSyncedA.identity.device_id,
+  );
+  const labelBeforeUnpair = await waitForPersonalLastSyncedLabel(actorA, firstSyncedB.identity.device_id);
+  expect(labelBeforeUnpair).toContain('last synced:');
+
+  await actorA.invoke('device_connection_unpair', { peerDeviceId: firstSyncedB.identity.device_id });
+  await actorB.invoke('device_connection_unpair', { peerDeviceId: firstSyncedA.identity.device_id });
+
+  const pairedOnAAfterUnpair = await actorA.invoke<PairedDeviceRow[]>('device_connection_get_paired_devices');
+  const pairedOnBAfterUnpair = await actorB.invoke<PairedDeviceRow[]>('device_connection_get_paired_devices');
+  expect(pairedOnAAfterUnpair.some((row) => row.peer_device_id === firstSyncedB.identity.device_id)).toBe(false);
+  expect(pairedOnBAfterUnpair.some((row) => row.peer_device_id === firstSyncedA.identity.device_id)).toBe(false);
+
+  const [syncedA, syncedB] = await ensureSimPairedActors([actorA, actorB]);
+  await waitForSimSession(actorA);
+  await waitForSimSession(actorB);
+
+  const mappedOnAAfterRepair = await actorA.invoke<string[]>('space_sync_list_mappings', {
+    peerDeviceId: syncedB.identity.device_id,
+  });
+  expect(
+    mappedOnAAfterRepair,
+    'unpair must cascade-delete the old Space mapping, not carry it over into the fresh pair',
+  ).not.toContain('1');
+
+  await ensurePersonalSpaceSync(actorA, syncedB.identity.device_id, actorB, syncedA.identity.device_id);
+  const labelAfterRepair = await waitForPersonalLastSyncedLabel(actorA, syncedB.identity.device_id);
+  expect(labelAfterRepair).toContain('last synced:');
+});

--- a/specs/e2e/playwright.config.ts
+++ b/specs/e2e/playwright.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
       // actor process pool (the worker-scoped fixture spawns actors once,
       // shared by every test in this project) — see the 'actors-sim'
       // project below and `specs/e2e/transports.md`.
-      testIgnore: ['actors/tests/peer-sync-over-sim.spec.ts'],
+      testIgnore: ['actors/tests/peer-sync-over-sim.spec.ts', 'actors/tests/unpair-and-rejoin-over-sim.spec.ts'],
     },
     {
       // Opt-in: only runs when explicitly selected (`--project actors-sim`)
@@ -31,7 +31,7 @@ export default defineConfig({
       // an unfiltered `playwright test` run alongside the other projects,
       // since it needs network discovery genuinely disabled for its actors.
       name: 'actors-sim',
-      testMatch: ['actors/tests/peer-sync-over-sim.spec.ts'],
+      testMatch: ['actors/tests/peer-sync-over-sim.spec.ts', 'actors/tests/unpair-and-rejoin-over-sim.spec.ts'],
     },
   ],
 });

--- a/src-tauri/src/services/device_connection/commands.rs
+++ b/src-tauri/src/services/device_connection/commands.rs
@@ -2122,4 +2122,71 @@ mod tests {
         assert_eq!(disabled.bluetooth_last_verified_at, None);
         std::env::remove_var("FINI_BLUETOOTH_PAIRED_ADDRESSES");
     }
+
+    #[test]
+    fn unpair_removes_the_paired_device_row_entirely() {
+        let mut conn = test_conn();
+
+        device_connection_unpair_impl(&mut conn, "peer-a".to_string()).expect("unpair");
+
+        let remaining = paired_devices::table
+            .find("peer-a")
+            .select(PairedDevice::as_select())
+            .first(&mut conn)
+            .optional()
+            .expect("query after unpair");
+        assert!(
+            remaining.is_none(),
+            "unpair must remove the row, not just clear its Bluetooth fields"
+        );
+    }
+
+    /// The "delete Bluetooth connection, then pair again" lifecycle a user
+    /// takes when e.g. resetting a stuck pair: unpair fully deletes the
+    /// row (unlike disabling, which only clears Bluetooth fields on an
+    /// otherwise-still-paired row), so a subsequent pairing always goes
+    /// through save_paired_device's *insert* branch, not its update
+    /// branch. Regression coverage for that specific path staying clean --
+    /// no leftover state from the deleted row (there is none to leak, but
+    /// this proves the full cycle end-to-end rather than each half in
+    /// isolation) and the re-pair enabling normally when the fresh address
+    /// is OS-bonded.
+    #[test]
+    fn unpair_then_re_pair_via_bluetooth_starts_with_clean_state() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("FINI_BLUETOOTH_PAIRED_ADDRESSES", "AA:BB:CC:DD:EE:FF");
+
+        let mut conn = test_conn();
+        device_connection_set_bluetooth_transport_impl(
+            &mut conn,
+            paired_device_input(true, Some("AA:BB:CC:DD:EE:FF")),
+        )
+        .expect("enable bluetooth on the original pairing");
+
+        device_connection_unpair_impl(&mut conn, "peer-a".to_string()).expect("unpair");
+
+        // A real re-pair hands over whatever address the fresh handshake
+        // observed -- plausibly a different one than before (the peer may
+        // have re-paired from a different adapter/OS install).
+        std::env::set_var("FINI_BLUETOOTH_PAIRED_ADDRESSES", "11:22:33:44:55:66");
+        let repaired = device_connection_save_paired_device_impl(
+            &mut conn,
+            "peer-a".to_string(),
+            "Peer A".to_string(),
+            Some("11:22:33:44:55:66".to_string()),
+            true, // via_bluetooth
+            std::path::PathBuf::from("/nonexistent"),
+        )
+        .expect("re-pair after unpair");
+
+        assert!(
+            repaired.bluetooth_enabled,
+            "a fresh re-pair with an OS-bonded address must enable normally, \
+             not inherit anything from the deleted row"
+        );
+        assert_eq!(repaired.bluetooth_address.as_deref(), Some("11:22:33:44:55:66"));
+        assert!(!repaired.bluetooth_disabled_by_user);
+
+        std::env::remove_var("FINI_BLUETOOTH_PAIRED_ADDRESSES");
+    }
 }

--- a/src/spec/utils/macAddress.spec.ts
+++ b/src/spec/utils/macAddress.spec.ts
@@ -1,0 +1,49 @@
+import { formatMacAddress, macAddressHexDigits } from "../../utils/macAddress";
+
+describe("macAddressHexDigits", () => {
+  it("uppercases and keeps only hex characters", () => {
+    expect(macAddressHexDigits("aabbccddeeff")).toBe("AABBCCDDEEFF");
+  });
+
+  it("strips separators from an already-formatted paste", () => {
+    expect(macAddressHexDigits("AA:BB:CC:DD:EE:FF")).toBe("AABBCCDDEEFF");
+    expect(macAddressHexDigits("aa-bb-cc-dd-ee-ff")).toBe("AABBCCDDEEFF");
+  });
+
+  it("truncates at 12 hex digits (6 octets)", () => {
+    expect(macAddressHexDigits("AABBCCDDEEFFGGHH")).toBe("AABBCCDDEEFF");
+    expect(macAddressHexDigits("aabbccddeeff1122")).toBe("AABBCCDDEEFF");
+  });
+
+  it("drops non-hex letters and punctuation entirely, not just separators", () => {
+    expect(macAddressHexDigits("zzAAbbZZccQQ")).toBe("AABBCC");
+  });
+
+  it("handles empty and partial input", () => {
+    expect(macAddressHexDigits("")).toBe("");
+    expect(macAddressHexDigits("a")).toBe("A");
+  });
+});
+
+describe("formatMacAddress", () => {
+  it("groups a full address into colon-separated octets", () => {
+    expect(formatMacAddress("AABBCCDDEEFF")).toBe("AA:BB:CC:DD:EE:FF");
+  });
+
+  it("formats a partial, in-progress value without a trailing colon", () => {
+    expect(formatMacAddress("A")).toBe("A");
+    expect(formatMacAddress("AA")).toBe("AA");
+    expect(formatMacAddress("AAB")).toBe("AA:B");
+    expect(formatMacAddress("AABB")).toBe("AA:BB");
+  });
+
+  it("formats an empty value as an empty string", () => {
+    expect(formatMacAddress("")).toBe("");
+  });
+
+  it("round-trips through macAddressHexDigits for any pasted format", () => {
+    for (const pasted of ["AA:BB:CC:DD:EE:FF", "aabbccddeeff", "aa-bb-cc-dd-ee-ff"]) {
+      expect(formatMacAddress(macAddressHexDigits(pasted))).toBe("AA:BB:CC:DD:EE:FF");
+    }
+  });
+});

--- a/src/spec/views/DeviceView.spec.ts
+++ b/src/spec/views/DeviceView.spec.ts
@@ -4,9 +4,10 @@ import DeviceView from "../../views/DeviceView.vue";
 import { useDeviceStore } from "../../stores/device";
 import { useSpaceStore } from "../../stores/space";
 
+const mockRouterPush = jest.fn();
 jest.mock("vue-router", () => ({
   useRoute: () => ({ params: { id: "peer-device-123" } }),
-  useRouter: () => ({ push: jest.fn() }),
+  useRouter: () => ({ push: mockRouterPush }),
 }));
 
 jest.mock("../../stores/device", () => ({
@@ -163,5 +164,177 @@ describe("DeviceView mapped spaces sync labels", () => {
     expect(rows[0].text()).toContain("preferred");
     expect(rows[1].text()).toContain("Bluetooth");
     expect(rows[1].text()).toContain("Available for fallback");
+  });
+});
+
+describe("DeviceView Bluetooth manual entry, search, and unpair", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let deviceStoreMock: any;
+
+  beforeEach(() => {
+    // jsdom doesn't implement <dialog>'s showModal/close -- stub them so
+    // openUnpairDialog/confirmUnpair don't throw when this component calls
+    // through the template ref.
+    HTMLDialogElement.prototype.showModal ??= jest.fn();
+    HTMLDialogElement.prototype.close ??= jest.fn();
+    mockRouterPush.mockClear();
+
+    deviceStoreMock = {
+      findPairedDevice: jest.fn().mockReturnValue({
+        peer_device_id: "peer-device-123",
+        display_name: "peer-host",
+        paired_at: "2026-04-07T11:00:00.000Z",
+        last_seen_at: "2026-04-07T11:05:00.000Z",
+        pair_state: "paired",
+        bluetooth_enabled: false,
+        bluetooth_address: null,
+        bluetooth_last_verified_at: null,
+      }),
+      isDeviceOnline: jest.fn().mockReturnValue(true),
+      getSpaceSyncStatus: jest.fn().mockReturnValue({
+        peer_device_id: "peer-device-123",
+        pending_event_count: 0,
+        outbox_event_count: 0,
+        acked_event_count: 0,
+        mapped_space_ids: [],
+        seen_event_count: 0,
+        tombstone_count: 0,
+      }),
+      getLastSyncedAt: jest.fn().mockReturnValue(null),
+      getLastSyncedAtBySpace: jest.fn().mockReturnValue({}),
+      getMappedSpaceIds: jest.fn().mockReturnValue([]),
+      getUnresolvedCustomSpaces: jest.fn().mockReturnValue([]),
+      getTransportStatuses: jest.fn().mockReturnValue([
+        {
+          kind: "network",
+          enabled: true,
+          available: true,
+          preferred: true,
+          connected: true,
+          detail: "Available",
+        },
+        {
+          kind: "bluetooth",
+          enabled: false,
+          available: false,
+          preferred: false,
+          connected: false,
+          detail: "Disabled for this Fini pair",
+        },
+      ]),
+      shortDeviceId: jest.fn().mockReturnValue("ce-123"),
+      hydrate: jest.fn().mockResolvedValue(undefined),
+      runSpaceSyncTick: jest.fn().mockResolvedValue(undefined),
+      loadMappedSpaces: jest.fn().mockResolvedValue([]),
+      refreshSpaceSyncStatus: jest.fn().mockResolvedValue(undefined),
+      refreshTransportStatuses: jest.fn().mockResolvedValue(undefined),
+      refreshLiveConnectedState: jest.fn().mockResolvedValue(undefined),
+      setBluetoothTransport: jest.fn().mockResolvedValue(undefined),
+      findBluetoothAddress: jest.fn(),
+      saveMappedSpaces: jest.fn().mockResolvedValue([]),
+      resolveCustomSpaceMapping: jest.fn().mockResolvedValue(undefined),
+      unpairDevice: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const spaceStoreMock = {
+      spaces: [],
+      fetchSpaces: jest.fn().mockResolvedValue(undefined),
+    };
+
+    (useDeviceStore as unknown as jest.Mock).mockReturnValue(deviceStoreMock);
+    (useSpaceStore as unknown as jest.Mock).mockReturnValue(spaceStoreMock);
+  });
+
+  function mountView() {
+    return mount(DeviceView, {
+      global: {
+        stubs: {
+          "router-link": { template: "<a><slot /></a>" },
+        },
+      },
+    });
+  }
+
+  it("masks manually typed input with colons and sends the normalized address on Enable", async () => {
+    const wrapper = mountView();
+    await flushUi();
+
+    const input = wrapper.find('[data-testid="bluetooth-address-input"]');
+    await input.setValue("aabbccddeeff");
+    await flushUi();
+
+    expect((input.element as HTMLInputElement).value).toBe("AA:BB:CC:DD:EE:FF");
+
+    await wrapper.find('[data-testid="enable-bluetooth-transport"]').trigger("click");
+    await flushUi();
+
+    expect(deviceStoreMock.setBluetoothTransport).toHaveBeenCalledWith(
+      "peer-device-123",
+      true,
+      "AA:BB:CC:DD:EE:FF",
+    );
+  });
+
+  it("masks a paste with existing separators the same way as raw digits", async () => {
+    const wrapper = mountView();
+    await flushUi();
+
+    const input = wrapper.find('[data-testid="bluetooth-address-input"]');
+    await input.setValue("aa-bb-cc-dd-ee-ff");
+    await flushUi();
+
+    expect((input.element as HTMLInputElement).value).toBe("AA:BB:CC:DD:EE:FF");
+  });
+
+  it("finds an address via Bluetooth scan and displays it masked", async () => {
+    deviceStoreMock.findBluetoothAddress.mockResolvedValue("AA:BB:CC:DD:EE:FF");
+    const wrapper = mountView();
+    await flushUi();
+
+    await wrapper.find('[data-testid="find-bluetooth-address"]').trigger("click");
+    await flushUi();
+
+    expect(deviceStoreMock.findBluetoothAddress).toHaveBeenCalledWith("peer-device-123");
+    const input = wrapper.find('[data-testid="bluetooth-address-input"]');
+    expect((input.element as HTMLInputElement).value).toBe("AA:BB:CC:DD:EE:FF");
+    expect(wrapper.text()).toContain("Found and confirmed nearby.");
+  });
+
+  it("shows a not-found message when the Bluetooth scan finds nothing", async () => {
+    deviceStoreMock.findBluetoothAddress.mockResolvedValue(null);
+    const wrapper = mountView();
+    await flushUi();
+
+    await wrapper.find('[data-testid="find-bluetooth-address"]').trigger("click");
+    await flushUi();
+
+    expect(wrapper.text()).toContain("Not found within 60s");
+  });
+
+  it("surfaces a scan error instead of a silent not-found", async () => {
+    deviceStoreMock.findBluetoothAddress.mockRejectedValue(new Error("adapter unavailable"));
+    const wrapper = mountView();
+    await flushUi();
+
+    await wrapper.find('[data-testid="find-bluetooth-address"]').trigger("click");
+    await flushUi();
+
+    expect(wrapper.text()).toContain("adapter unavailable");
+    expect(wrapper.text()).not.toContain("Not found within 60s");
+  });
+
+  it("unpairs the device and navigates back to settings on confirm", async () => {
+    const wrapper = mountView();
+    await flushUi();
+
+    const dialog = wrapper.find("dialog");
+    const confirmButton = dialog.findAll("button").find((btn) => btn.text() === "Unpair");
+    expect(confirmButton).toBeTruthy();
+
+    await confirmButton!.trigger("click");
+    await flushUi();
+
+    expect(deviceStoreMock.unpairDevice).toHaveBeenCalledWith("peer-device-123");
+    expect(mockRouterPush).toHaveBeenCalledWith("/settings");
   });
 });

--- a/src/utils/macAddress.ts
+++ b/src/utils/macAddress.ts
@@ -1,0 +1,9 @@
+/** Uppercase hex digits only, capped at 12 (6 octets) -- the raw form a MAC address input mask stores between keystrokes. */
+export function macAddressHexDigits(value: string): string {
+  return value.toUpperCase().replace(/[^0-9A-F]/g, "").slice(0, 12);
+}
+
+/** Groups raw hex digits into "AA:BB:CC:DD:EE:FF" form, colon-separated as they arrive rather than only once 12 digits are typed. */
+export function formatMacAddress(hexDigits: string): string {
+  return hexDigits.match(/.{1,2}/g)?.join(":") ?? "";
+}

--- a/src/views/DeviceView.vue
+++ b/src/views/DeviceView.vue
@@ -6,6 +6,7 @@ import SettingsListItem from "../components/SettingsView/SettingsListItem.vue";
 import { useDeviceStore } from "../stores/device";
 import { useSpaceStore, isBuiltinSpace } from "../stores/space";
 import { shortUuid } from "../utils/shortUuid";
+import { formatMacAddress, macAddressHexDigits } from "../utils/macAddress";
 
 const route = useRoute();
 const router = useRouter();
@@ -13,7 +14,16 @@ const deviceStore = useDeviceStore();
 const spaceStore = useSpaceStore();
 const unpairDialog = ref<HTMLDialogElement | null>(null);
 const mappedSelection = ref<string[]>([]);
-const bluetoothAddressInput = ref("");
+// Stores just the raw hex digits (no colons); the input mask formats them
+// with colons on display and strips any pasted/typed separators back out
+// on write, so the user never has to type ":" themselves.
+const bluetoothAddressHexDigits = ref("");
+const bluetoothAddressInput = computed({
+  get: () => formatMacAddress(bluetoothAddressHexDigits.value),
+  set: (value: string) => {
+    bluetoothAddressHexDigits.value = macAddressHexDigits(value);
+  },
+});
 const mappingsLoaded = ref(false);
 const savingMappings = ref(false);
 const savingBluetoothTransport = ref(false);
@@ -333,6 +343,7 @@ function mappedSpaceEndLabel(spaceId: string): string | null {
           class="input input-sm input-bordered"
           data-testid="bluetooth-address-input"
           placeholder="AA:BB:CC:DD:EE:FF"
+          maxlength="17"
           :disabled="savingBluetoothTransport"
         />
         <p class="text-xs opacity-60">


### PR DESCRIPTION
## Summary
Two related asks: a small UX feature, and closing a real test-coverage gap in the Bluetooth pairing workflow (delete + rejoin, search, manual input).

- **Mask**: `src/utils/macAddress.ts` auto-formats the Bluetooth address field with colons as you type or paste (accepts raw hex, colon-, or dash-separated input, caps at 6 octets) -- no more typing `:::::` by hand. Wired into `DeviceView.vue`'s address input as a writable computed; programmatic assigns (loading a device, a successful Find scan) are unaffected.
- **Test coverage**, none of which existed before:
  - Backend: `unpair_removes_the_paired_device_row_entirely`, `unpair_then_re_pair_via_bluetooth_starts_with_clean_state` -- the "delete Bluetooth connection, pair again" lifecycle had zero coverage.
  - Frontend: `macAddress.spec.ts` for the mask utility; `DeviceView.spec.ts` gains manual-entry masking (raw + separator-pasted), Find-via-Bluetooth found/not-found/error cases, and the unpair-and-navigate flow.
  - E2E: `unpair-and-rejoin-over-sim.spec.ts` -- two real app processes over Sim transport: pair, sync a Space, unpair both sides, confirm the row *and* its cascade-deleted Space mapping are actually gone, re-pair, confirm session + Space sync fully recover from scratch (not silently inherited). Wired into `playwright.config.ts`'s `actors-sim` project.

## Test plan
- [x] `cargo test --lib`: 255 passed
- [x] `vue-tsc --noEmit` + `jest`: clean, 143 passed
- [x] `make e2e-headed`'s `actors-sim` project run **locally against freshly built binaries** (not just inferred from CI): both `peer-sync-over-sim.spec.ts` and the new `unpair-and-rejoin-over-sim.spec.ts` pass (10.8s)