### PR TITLE
ADR-0003 Phase 2: unified status model + push-based UI updates

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -193,6 +193,59 @@ fn sync_native_theme(app: AppHandle, theme: String) {
     settings::apply_native_theme(&app, &theme);
 }
 
+/// Payload for `SESSION_CHANGED_EVENT` — ADR-0003 Phase 2. `established`
+/// distinguishes the two `LifecycleEvent` variants; `kind` is the
+/// finer-grained `services::transport::TransportKind` the event itself
+/// carries (TcpWs/Sim/Bluetooth), not `device_connection::transport`'s
+/// coarser Network/Bluetooth row kind — the frontend doesn't need to
+/// interpret it, it's just enough for the listener to log/filter on if it
+/// ever wants to.
+#[cfg(feature = "ui-plane")]
+#[derive(Clone, serde::Serialize)]
+struct SessionChangedEvent {
+    peer_device_id: String,
+    kind: services::transport::TransportKind,
+    established: bool,
+}
+
+#[cfg(feature = "ui-plane")]
+const SESSION_CHANGED_EVENT: &str = "device-connection://session-changed";
+
+/// Forwards `DeviceConnectionState::subscribe_lifecycle()` to the frontend
+/// as they happen, so a session's connect/disconnect reaches the UI faster
+/// than the next `TRANSPORT_STATUS_POLL_INTERVAL_MS` poll (`device.ts`
+/// still polls too — this is a latency improvement, not the sole source of
+/// truth, so a missed/dropped event here self-heals within that poll
+/// window instead of staying wrong indefinitely). See ADR-0003 Phase 2.
+#[cfg(feature = "ui-plane")]
+async fn forward_session_lifecycle_events(
+    mut events: tokio::sync::broadcast::Receiver<services::transport::selection::LifecycleEvent>,
+    app: AppHandle,
+) {
+    use services::transport::selection::LifecycleEvent;
+
+    loop {
+        let event = match events.recv().await {
+            Ok(event) => event,
+            // Lagged: some events were dropped, but the receiver is still
+            // live -- keep forwarding what arrives next rather than giving
+            // up on the whole subscription. `device.ts`'s poll fallback
+            // covers whatever this specific gap missed.
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
+        };
+        let payload = match event {
+            LifecycleEvent::SessionEstablished { peer_device_id, kind } => {
+                SessionChangedEvent { peer_device_id, kind, established: true }
+            }
+            LifecycleEvent::SessionEnded { peer_device_id, kind } => {
+                SessionChangedEvent { peer_device_id, kind, established: false }
+            }
+        };
+        let _ = app.emit(SESSION_CHANGED_EVENT, payload);
+    }
+}
+
 #[cfg(feature = "cli-plane")]
 pub fn run_cli() -> i32 {
     services::cli::run(std::env::args().collect())
@@ -296,6 +349,10 @@ pub fn run() {
             sim::maybe_spawn_server(dc_state.clone(), dc_state.db_path.clone());
             #[cfg(target_os = "linux")]
             tauri::async_runtime::spawn(ble::run_server(dc_state.clone(), dc_state.db_path.clone()));
+            tauri::async_runtime::spawn(forward_session_lifecycle_events(
+                dc_state.subscribe_lifecycle(),
+                app_handle.clone(),
+            ));
             app.manage(dc_state);
             Ok(())
         })

--- a/src-tauri/src/services/device_connection/commands.rs
+++ b/src-tauri/src/services/device_connection/commands.rs
@@ -23,7 +23,7 @@ use crate::services::device_connection::types::{
     PairCodeUpdate, PairCompletePayload, PairCompletionUpdate, PairRequestPayload,
 };
 use crate::services::device_connection::DeviceConnectionState;
-use crate::services::device_connection::{build_transport_statuses, TransportStatus};
+use crate::services::device_connection::{build_transport_statuses, TransportStatus, TransportStatusInputs};
 use crate::services::space_sync::types::PeerFrame;
 use crate::services::transport::TransportKind;
 
@@ -1483,14 +1483,16 @@ pub fn device_connection_transport_statuses_impl(
             | Some(crate::services::transport::TransportKind::Sim)
     );
 
-    Ok(build_transport_statuses(
-        state.network_peer_available(&peer_device_id),
-        paired.bluetooth_enabled,
+    Ok(build_transport_statuses(TransportStatusInputs {
+        network_present: state.network_peer_available(&peer_device_id),
+        network_reliable: state.network_effectively_available(&peer_device_id),
+        bluetooth_enabled: paired.bluetooth_enabled,
         bluetooth_has_metadata,
         bluetooth_os_paired,
+        bluetooth_reliable: state.bluetooth_effectively_reliable(&peer_device_id),
         network_connected,
         bluetooth_connected,
-    ))
+    }))
 }
 
 #[cfg(any(feature = "ui-plane", test))]

--- a/src-tauri/src/services/device_connection/mod.rs
+++ b/src-tauri/src/services/device_connection/mod.rs
@@ -54,7 +54,7 @@ pub use commands::{
     device_connection_unpair_impl, device_connection_update_last_seen_impl,
 };
 use runtime::{spawn_discovery_worker, try_load_or_create_identity};
-pub use transport::{build_transport_statuses, TransportStatus};
+pub use transport::{build_transport_statuses, TransportStatus, TransportStatusInputs};
 use types::DiscoveryRuntime;
 pub use types::{
     CustomSpaceDescriptor, DeviceIdentity, IncomingSpaceMappingUpdate, IncomingSpaceSyncEnd,
@@ -318,11 +318,11 @@ impl DeviceConnectionState {
         }
     }
 
-    /// Reserved for UI consumption (live transport-changed/connect/disconnect
-    /// rows) — the draft's `device_connection_transport_statuses` polling
-    /// command remains the UI-facing surface in this PR; wiring a push-based
-    /// subscriber is follow-up work.
-    #[allow(dead_code)]
+    /// Live transport-changed/connect/disconnect rows: `lib.rs`'s
+    /// `forward_session_lifecycle_events` subscribes once at app setup and
+    /// forwards each event to the frontend (ADR-0003 Phase 2).
+    /// `device_connection_transport_statuses` stays the source of truth for
+    /// a one-shot/polled read; this is the push side of the same signal.
     pub fn subscribe_lifecycle(&self) -> tokio::sync::broadcast::Receiver<LifecycleEvent> {
         self.lifecycle_tx.subscribe()
     }
@@ -511,6 +511,46 @@ impl DeviceConnectionState {
     pub fn network_effectively_available(&self, peer_device_id: &str) -> bool {
         self.network_peer_available(peer_device_id)
             && self.tcp_dial_failure_count(peer_device_id)
-                < crate::services::transport::selection::NETWORK_UNRESPONSIVE_THRESHOLD
+                < crate::services::transport::selection::TRANSPORT_UNRESPONSIVE_THRESHOLD
+    }
+
+    /// Bluetooth's counterpart to `record_tcp_dial_success` — same shape,
+    /// different map. See ADR-0003 Phase 2.
+    pub fn record_bluetooth_dial_success(&self, peer_device_id: &str) {
+        if let Ok(mut guard) = self.runtime.lock() {
+            guard.bluetooth_dial_failures.remove(peer_device_id);
+        }
+    }
+
+    pub fn record_bluetooth_dial_failure(&self, peer_device_id: &str) {
+        if let Ok(mut guard) = self.runtime.lock() {
+            *guard
+                .bluetooth_dial_failures
+                .entry(peer_device_id.to_string())
+                .or_insert(0) += 1;
+        }
+    }
+
+    pub fn bluetooth_dial_failure_count(&self, peer_device_id: &str) -> u32 {
+        let Ok(guard) = self.runtime.lock() else {
+            return 0;
+        };
+        guard
+            .bluetooth_dial_failures
+            .get(peer_device_id)
+            .copied()
+            .unwrap_or(0)
+    }
+
+    /// Whether recent Bluetooth connection attempts give reason to distrust
+    /// this transport for this peer right now — the same
+    /// "no reason to distrust it" bar `network_effectively_available` uses
+    /// (a peer with zero attempts yet counts as reliable by default). Feeds
+    /// the `Configured { reliable }` state in the unified status model
+    /// (ADR-0003 Phase 2), not `network_effectively_available` itself,
+    /// which is Network-specific and used for transport *selection*.
+    pub fn bluetooth_effectively_reliable(&self, peer_device_id: &str) -> bool {
+        self.bluetooth_dial_failure_count(peer_device_id)
+            < crate::services::transport::selection::TRANSPORT_UNRESPONSIVE_THRESHOLD
     }
 }

--- a/src-tauri/src/services/device_connection/transport.rs
+++ b/src-tauri/src/services/device_connection/transport.rs
@@ -24,23 +24,40 @@ pub struct BluetoothTransportMetadata {
     pub os_paired: bool,
 }
 
+/// Unified per-row status shape (ADR-0003 Phase 2), shared between the
+/// Network and Bluetooth rows: each transport supplies its own condition
+/// logic for which state applies (see `build_transport_statuses`), but the
+/// UI only ever has to render these three cases, for either row.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum RowState {
+    /// Local preconditions for this transport aren't met at all -- nothing
+    /// to distrust or trust yet, it simply can't carry a session right now.
+    /// `reason` is the transport-specific "why" shown to the user.
+    Unconfigured { reason: String },
+    /// Preconditions are met; not the transport actually carrying the live
+    /// session right now. `reliable` distinguishes "no reason to distrust
+    /// it" (true -- including a peer with zero attempts yet, the same bar
+    /// `network_effectively_available` already used before this ADR) from
+    /// "recent consecutive attempts have failed" (false).
+    Configured { reliable: bool },
+    /// A session is live on this specific transport right now, confirmed by
+    /// `session_kind` -- trustworthy as of ADR-0003 Phase 1, which is what
+    /// makes sure a silently-dead session doesn't linger here.
+    Live,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TransportStatus {
     pub kind: TransportKind,
-    pub enabled: bool,
-    pub available: bool,
+    /// What the automatic dial order would pick first on the *next*
+    /// establishment attempt -- independent of `state`, which reports what
+    /// *is* true right now. The two can legitimately disagree: sticky
+    /// handoff (`transport::selection`) means a session already live on one
+    /// transport is kept even if the other becomes preferred while it's
+    /// still up.
     pub preferred: bool,
-    /// Whether an authenticated session is live on *this specific*
-    /// transport right now — distinct from `available`, which only reports
-    /// whether the precondition for one is met. Network is preferred
-    /// whenever both are available (ADR-0001's selection order), so a
-    /// peer can be fully reachable while this is `false` on the Bluetooth
-    /// row because the live session happens to be running over network
-    /// instead — that is expected, not a bug. See
-    /// `docs/adr/0002-bluetooth-address-exchange-live-status-and-ble-pairing.md`
-    /// Phase 2.
-    pub connected: bool,
-    pub detail: String,
+    pub state: RowState,
 }
 
 pub fn select_transport_endpoint(
@@ -68,69 +85,112 @@ pub fn select_transport_endpoint(
 /// `transport::ble` (BlueZ on Linux, GATT via `ble_gatt::backend::android`
 /// on Android, both through `ble-gatt`) is wired up in `lib.rs`/
 /// `space_sync::commands` on both platforms. Everywhere else, status must
-/// never report `available`/`preferred` regardless of stored metadata, or
-/// the Device view would promise a fallback that silently cannot sync.
+/// never report a `Configured`/`Live` Bluetooth row regardless of stored
+/// metadata, or the Device view would promise a fallback that silently
+/// cannot sync.
 #[cfg(any(target_os = "linux", target_os = "android"))]
 const BLUETOOTH_ADAPTER_IMPLEMENTED: bool = true;
 #[cfg(not(any(target_os = "linux", target_os = "android")))]
 const BLUETOOTH_ADAPTER_IMPLEMENTED: bool = false;
 
-pub fn build_transport_statuses(
-    network_available: bool,
-    bluetooth_enabled: bool,
-    bluetooth_has_metadata: bool,
-    bluetooth_os_paired: bool,
-    network_connected: bool,
-    bluetooth_connected: bool,
-) -> Vec<TransportStatus> {
-    let bluetooth_ready = BLUETOOTH_ADAPTER_IMPLEMENTED
-        && bluetooth_enabled
-        && bluetooth_has_metadata
-        && bluetooth_os_paired;
+/// Everything `build_transport_statuses` needs, one field per condition it
+/// checks. A named-field struct instead of positional bools deliberately:
+/// this function used to take six, Phase 2 adds two more, and transposing
+/// two same-typed bools at a call site is exactly the class of bug a
+/// struct's field names catch that positional args don't.
+#[derive(Debug, Clone, Copy)]
+pub struct TransportStatusInputs {
+    /// Raw discovery presence (`network_peer_available`) -- "is this
+    /// peer's beacon reaching us right now."
+    pub network_present: bool,
+    /// `network_effectively_available`'s failure-history half: not stuck
+    /// failing to actually connect. Kept separate from `network_present`
+    /// because `Unconfigured` (no presence at all) and `Configured {
+    /// reliable: false }` (presenced, but recently unreachable) are
+    /// different states with different `reason`/no-`reason` shapes.
+    pub network_reliable: bool,
+    pub bluetooth_enabled: bool,
+    pub bluetooth_has_metadata: bool,
+    pub bluetooth_os_paired: bool,
+    /// `bluetooth_effectively_reliable` -- Bluetooth's counterpart to
+    /// `network_reliable`.
+    pub bluetooth_reliable: bool,
+    pub network_connected: bool,
+    pub bluetooth_connected: bool,
+}
+
+pub fn build_transport_statuses(inputs: TransportStatusInputs) -> Vec<TransportStatus> {
+    let TransportStatusInputs {
+        network_present,
+        network_reliable,
+        bluetooth_enabled,
+        bluetooth_has_metadata,
+        bluetooth_os_paired,
+        bluetooth_reliable,
+        network_connected,
+        bluetooth_connected,
+    } = inputs;
+
+    let network_unconfigured_reason = if network_present {
+        None
+    } else {
+        Some("Unavailable".to_string())
+    };
+    let bluetooth_unconfigured_reason =
+        bluetooth_unconfigured_reason(bluetooth_enabled, bluetooth_has_metadata, bluetooth_os_paired);
+
+    // Mirrors what `select_dial_order`'s real callers actually check
+    // (`network_effectively_available`/`bluetooth_effectively_reliable`),
+    // not just raw presence/configuration -- so `preferred` reports what
+    // the next establishment attempt would *actually* pick, not merely
+    // what's nominally configured.
+    let network_selectable = network_present && network_reliable;
+    let bluetooth_selectable = bluetooth_unconfigured_reason.is_none() && bluetooth_reliable;
 
     vec![
         TransportStatus {
             kind: TransportKind::Network,
-            enabled: true,
-            available: network_available,
-            preferred: network_available,
-            connected: network_connected,
-            detail: if network_available {
-                "Available"
-            } else {
-                "Unavailable"
-            }
-            .to_string(),
+            preferred: network_selectable,
+            state: row_state(network_unconfigured_reason, network_connected, network_reliable),
         },
         TransportStatus {
             kind: TransportKind::Bluetooth,
-            enabled: bluetooth_enabled,
-            available: bluetooth_ready,
-            preferred: !network_available && bluetooth_ready,
-            connected: bluetooth_connected,
-            detail: bluetooth_status_detail(
-                bluetooth_enabled,
-                bluetooth_has_metadata,
-                bluetooth_os_paired,
-            ),
+            preferred: !network_selectable && bluetooth_selectable,
+            state: row_state(bluetooth_unconfigured_reason, bluetooth_connected, bluetooth_reliable),
         },
     ]
 }
 
-fn bluetooth_status_detail(enabled: bool, has_metadata: bool, os_paired: bool) -> String {
+/// Shared shape for both rows: given whether (and why) a transport isn't
+/// configured at all, whether it's carrying the live session, and whether
+/// recent attempts on it have been reliable, decide which of the three
+/// `RowState` cases applies. Transport-specific work stays in each
+/// transport's own "why unconfigured" logic (`bluetooth_unconfigured_reason`,
+/// inline for Network above) -- this function only knows the shared shape.
+fn row_state(unconfigured_reason: Option<String>, connected: bool, reliable: bool) -> RowState {
+    if let Some(reason) = unconfigured_reason {
+        return RowState::Unconfigured { reason };
+    }
+    if connected {
+        return RowState::Live;
+    }
+    RowState::Configured { reliable }
+}
+
+fn bluetooth_unconfigured_reason(enabled: bool, has_metadata: bool, os_paired: bool) -> Option<String> {
     if !BLUETOOTH_ADAPTER_IMPLEMENTED {
-        return "Bluetooth transport not implemented yet".to_string();
+        return Some("Bluetooth transport not implemented yet".to_string());
     }
     if !enabled {
-        return "Disabled for this Fini pair".to_string();
+        return Some("Disabled for this Fini pair".to_string());
     }
     if !has_metadata {
-        return "Enable after OS Bluetooth pairing to store reconnect metadata".to_string();
+        return Some("Enable after OS Bluetooth pairing to store reconnect metadata".to_string());
     }
     if !os_paired {
-        return "OS Bluetooth pairing required".to_string();
+        return Some("OS Bluetooth pairing required".to_string());
     }
-    "Available for fallback".to_string()
+    None
 }
 
 #[cfg(test)]
@@ -153,6 +213,29 @@ mod tests {
             enabled: true,
             os_paired: true,
         }
+    }
+
+    /// All inputs "healthy and ready" by default -- individual tests
+    /// override just the field(s) they're exercising.
+    fn ready_inputs() -> TransportStatusInputs {
+        TransportStatusInputs {
+            network_present: true,
+            network_reliable: true,
+            bluetooth_enabled: true,
+            bluetooth_has_metadata: true,
+            bluetooth_os_paired: true,
+            bluetooth_reliable: true,
+            network_connected: false,
+            bluetooth_connected: false,
+        }
+    }
+
+    fn find(statuses: &[TransportStatus], kind: TransportKind) -> TransportStatus {
+        statuses
+            .iter()
+            .find(|status| status.kind == kind)
+            .cloned()
+            .unwrap_or_else(|| panic!("no {kind:?} status row"))
     }
 
     #[test]
@@ -202,114 +285,162 @@ mod tests {
     }
 
     #[test]
-    fn status_marks_network_preferred_when_available() {
-        let both = build_transport_statuses(true, true, true, true, false, false);
-        assert!(both
-            .iter()
-            .any(|status| status.kind == TransportKind::Network && status.preferred));
+    fn network_is_preferred_when_present_and_reliable() {
+        let statuses = build_transport_statuses(ready_inputs());
+        assert!(find(&statuses, TransportKind::Network).preferred);
 
-        let fallback = build_transport_statuses(false, true, true, true, false, false);
-        assert!(!fallback
-            .iter()
-            .any(|status| status.kind == TransportKind::Network && status.preferred));
+        let not_present = build_transport_statuses(TransportStatusInputs {
+            network_present: false,
+            ..ready_inputs()
+        });
+        assert!(!find(&not_present, TransportKind::Network).preferred);
+
+        let unreliable = build_transport_statuses(TransportStatusInputs {
+            network_reliable: false,
+            ..ready_inputs()
+        });
+        assert!(
+            !find(&unreliable, TransportKind::Network).preferred,
+            "recently-unreliable network must not be preferred even while presenced"
+        );
     }
 
-    /// Phase 2 of ADR 0002: `connected` reports live session state per row,
-    /// independent of `available`/`preferred` — a row can be available but
-    /// not currently connected (network reachable, no session established
-    /// yet), or connected on one transport while the other reports
-    /// available too (Bluetooth configured and bonded, but the live
-    /// session happens to be running over network since network is always
-    /// preferred when both are available).
+    /// ADR-0003 Phase 2: `Live` reports the actual session per row,
+    /// independent of `Configured`/reliability -- a row can be `Configured`
+    /// but not `Live` (network reachable, no session established yet), or
+    /// `Live` on one transport while the other reports `Configured` too
+    /// (Bluetooth ready and bonded, but the live session happens to be
+    /// running over network since network is always preferred when both
+    /// are available).
     #[test]
-    fn connected_reflects_live_session_state_independent_of_availability() {
-        let statuses = build_transport_statuses(true, true, true, true, true, false);
-        let network = statuses
-            .iter()
-            .find(|status| status.kind == TransportKind::Network)
-            .expect("network status row");
-        let bluetooth = statuses
-            .iter()
-            .find(|status| status.kind == TransportKind::Bluetooth)
-            .expect("bluetooth status row");
-        assert!(network.connected, "network row should report the live session");
-        assert!(bluetooth.available, "bluetooth stays available even while not the live transport");
-        assert!(!bluetooth.connected, "bluetooth row must not claim a session it isn't carrying");
+    fn live_reflects_the_actual_session_independent_of_configuration() {
+        let network_live = build_transport_statuses(TransportStatusInputs {
+            network_connected: true,
+            ..ready_inputs()
+        });
+        let network = find(&network_live, TransportKind::Network);
+        let bluetooth = find(&network_live, TransportKind::Bluetooth);
+        assert_eq!(network.state, RowState::Live);
+        assert_eq!(
+            bluetooth.state,
+            RowState::Configured { reliable: true },
+            "bluetooth stays Configured, not Live, while network carries the session"
+        );
 
-        let bluetooth_live = build_transport_statuses(true, true, true, true, false, true);
-        let bluetooth = bluetooth_live
-            .iter()
-            .find(|status| status.kind == TransportKind::Bluetooth)
-            .expect("bluetooth status row");
-        assert!(bluetooth.connected, "bluetooth row should report a live Bluetooth session");
+        let bluetooth_live = build_transport_statuses(TransportStatusInputs {
+            bluetooth_connected: true,
+            ..ready_inputs()
+        });
+        assert_eq!(
+            find(&bluetooth_live, TransportKind::Bluetooth).state,
+            RowState::Live
+        );
     }
 
-    /// No Bluetooth `Transport`/`Link` adapter is registered on this platform
-    /// (see `BLUETOOTH_ADAPTER_IMPLEMENTED`'s doc comment), so a Bluetooth
-    /// session can never actually establish there. Status must report
-    /// `available`/`preferred: false` regardless of how complete the stored
+    /// No Bluetooth `Transport`/`Link` adapter is registered on this
+    /// platform (see `BLUETOOTH_ADAPTER_IMPLEMENTED`'s doc comment), so a
+    /// Bluetooth session can never actually establish there. Status must
+    /// report `Unconfigured` regardless of how complete the stored
     /// enablement metadata is, or the Device view would promise a fallback
     /// that silently cannot sync. On Linux/Android, where the real adapter
-    /// (`transport::ble`) is wired up, full metadata *should* report ready —
-    /// see `bluetooth_is_available_with_full_metadata_where_implemented`
+    /// (`transport::ble`) is wired up, full metadata *should* report
+    /// `Configured` -- see `bluetooth_is_configured_with_full_metadata_where_implemented`
     /// below.
     #[cfg(not(any(target_os = "linux", target_os = "android")))]
     #[test]
-    fn bluetooth_is_never_reported_available_without_a_registered_adapter() {
-        for (network_available, enabled, has_metadata, os_paired) in [
-            (true, true, true, true),
-            (false, true, true, true),
-        ] {
-            let statuses =
-                build_transport_statuses(network_available, enabled, has_metadata, os_paired, false, false);
-            let bluetooth = statuses
-                .iter()
-                .find(|status| status.kind == TransportKind::Bluetooth)
-                .expect("bluetooth status row");
-            assert!(!bluetooth.available, "bluetooth must not report available");
+    fn bluetooth_is_never_configured_without_a_registered_adapter() {
+        for network_present in [true, false] {
+            let statuses = build_transport_statuses(TransportStatusInputs {
+                network_present,
+                ..ready_inputs()
+            });
+            let bluetooth = find(&statuses, TransportKind::Bluetooth);
+            assert!(
+                matches!(bluetooth.state, RowState::Unconfigured { .. }),
+                "bluetooth must report Unconfigured, got {:?}",
+                bluetooth.state
+            );
             assert!(!bluetooth.preferred, "bluetooth must not report preferred");
         }
     }
 
     /// Mirror of the above for platforms where `transport::ble` is a real,
     /// registered adapter (Linux, Android): full enablement metadata should
-    /// now report Bluetooth ready, and preferred exactly when network is
-    /// not.
+    /// now report Bluetooth `Configured`, and preferred exactly when
+    /// network isn't selectable.
     #[cfg(any(target_os = "linux", target_os = "android"))]
     #[test]
-    fn bluetooth_is_available_with_full_metadata_where_implemented() {
-        let fallback = build_transport_statuses(false, true, true, true, false, false);
-        let bluetooth = fallback
-            .iter()
-            .find(|status| status.kind == TransportKind::Bluetooth)
-            .expect("bluetooth status row");
-        assert!(bluetooth.available, "bluetooth should report available");
+    fn bluetooth_is_configured_with_full_metadata_where_implemented() {
+        let fallback = build_transport_statuses(TransportStatusInputs {
+            network_present: false,
+            ..ready_inputs()
+        });
+        let bluetooth = find(&fallback, TransportKind::Bluetooth);
+        assert_eq!(bluetooth.state, RowState::Configured { reliable: true });
         assert!(bluetooth.preferred, "bluetooth should be preferred when network is absent");
 
-        let both = build_transport_statuses(true, true, true, true, false, false);
-        let bluetooth = both
-            .iter()
-            .find(|status| status.kind == TransportKind::Bluetooth)
-            .expect("bluetooth status row");
-        assert!(bluetooth.available, "bluetooth should still report available");
+        let both = build_transport_statuses(ready_inputs());
+        let bluetooth = find(&both, TransportKind::Bluetooth);
+        assert_eq!(bluetooth.state, RowState::Configured { reliable: true });
         assert!(!bluetooth.preferred, "network should be preferred when both are available");
     }
 
-    /// Incomplete metadata must still gate availability even with a real
+    /// Incomplete metadata must still gate configuration even with a real
     /// adapter registered.
     #[cfg(any(target_os = "linux", target_os = "android"))]
     #[test]
     fn bluetooth_still_requires_full_metadata_where_implemented() {
-        for (enabled, has_metadata, os_paired) in
-            [(false, true, true), (true, false, true), (true, true, false)]
-        {
-            let statuses =
-                build_transport_statuses(false, enabled, has_metadata, os_paired, false, false);
-            let bluetooth = statuses
-                .iter()
-                .find(|status| status.kind == TransportKind::Bluetooth)
-                .expect("bluetooth status row");
-            assert!(!bluetooth.available, "incomplete metadata must not report available");
+        for inputs in [
+            TransportStatusInputs {
+                bluetooth_enabled: false,
+                ..ready_inputs()
+            },
+            TransportStatusInputs {
+                bluetooth_has_metadata: false,
+                ..ready_inputs()
+            },
+            TransportStatusInputs {
+                bluetooth_os_paired: false,
+                ..ready_inputs()
+            },
+        ] {
+            let statuses = build_transport_statuses(TransportStatusInputs {
+                network_present: false,
+                ..inputs
+            });
+            let bluetooth = find(&statuses, TransportKind::Bluetooth);
+            assert!(
+                matches!(bluetooth.state, RowState::Unconfigured { .. }),
+                "incomplete metadata must report Unconfigured, got {:?}",
+                bluetooth.state
+            );
         }
+    }
+
+    /// ADR-0003 Phase 2's actual new behavior: a `Configured` transport
+    /// with recent consecutive failures reports `reliable: false`
+    /// (renders amber), distinct from both `Unconfigured` (gray) and a
+    /// trustworthy `Configured`/`Live` (green).
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[test]
+    fn unreliable_configured_bluetooth_is_distinguishable_from_reliable() {
+        let unreliable = build_transport_statuses(TransportStatusInputs {
+            network_present: false,
+            bluetooth_reliable: false,
+            ..ready_inputs()
+        });
+        assert_eq!(
+            find(&unreliable, TransportKind::Bluetooth).state,
+            RowState::Configured { reliable: false }
+        );
+
+        let reliable = build_transport_statuses(TransportStatusInputs {
+            network_present: false,
+            ..ready_inputs()
+        });
+        assert_eq!(
+            find(&reliable, TransportKind::Bluetooth).state,
+            RowState::Configured { reliable: true }
+        );
     }
 }

--- a/src-tauri/src/services/device_connection/types.rs
+++ b/src-tauri/src/services/device_connection/types.rs
@@ -262,4 +262,9 @@ pub(super) struct DiscoveryRuntime {
     /// the network transport is present-but-unusable, not just absent. See
     /// `DeviceConnectionState::network_effectively_available`.
     pub tcp_dial_failures: HashMap<String, u32>,
+    /// Consecutive Bluetooth connect/auth failures per peer, reset on
+    /// success — the same signal `tcp_dial_failures` is, for the other
+    /// transport. See `DeviceConnectionState::bluetooth_effectively_reliable`
+    /// and ADR-0003 Phase 2.
+    pub bluetooth_dial_failures: HashMap<String, u32>,
 }

--- a/src-tauri/src/services/transport/ble.rs
+++ b/src-tauri/src/services/transport/ble.rs
@@ -865,6 +865,7 @@ async fn dial_with_backoff(state: DeviceConnectionState, db_path: PathBuf, peer_
                 {
                     Ok(peer_protocol_version) => {
                         eprintln!("[transport][ble] auth OK with {peer_id} via {address}");
+                        state.record_bluetooth_dial_success(&peer_id);
                         // The connect+auth round trip is real wall-clock time
                         // during which the user could disable Bluetooth or
                         // unpair entirely; without this, a disable/unpair
@@ -899,10 +900,17 @@ async fn dial_with_backoff(state: DeviceConnectionState, db_path: PathBuf, peer_
                         if err.starts_with("auth rejected") {
                             return; // not paired; don't retry
                         }
+                        // Connection-level failure (link dropped mid-auth,
+                        // etc.), not a rejection -- counts toward "recently
+                        // unreliable," mirroring tcp_ws::dial_with_backoff.
+                        state.record_bluetooth_dial_failure(&peer_id);
                     }
                 }
             }
-            Err(err) => eprintln!("[transport][ble] connect to {peer_id} ({address}) failed: {err}"),
+            Err(err) => {
+                eprintln!("[transport][ble] connect to {peer_id} ({address}) failed: {err}");
+                state.record_bluetooth_dial_failure(&peer_id);
+            }
         }
 
         tokio::time::sleep(delay).await;

--- a/src-tauri/src/services/transport/selection.rs
+++ b/src-tauri/src/services/transport/selection.rs
@@ -31,11 +31,14 @@ pub type LifecycleBus = tokio::sync::broadcast::Sender<LifecycleEvent>;
 
 const LIFECYCLE_BUS_CAPACITY: usize = 64;
 
-/// Consecutive TCP-WS dial/auth failures at or above which a presenced peer
-/// is treated as not effectively network-available for transport selection
-/// (see `DeviceConnectionState::network_effectively_available`) — presence
-/// alone doesn't mean the WebSocket port is reachable.
-pub const NETWORK_UNRESPONSIVE_THRESHOLD: u32 = 3;
+/// Consecutive dial/auth failures at or above which a peer is treated as
+/// unreliable on a transport — for Network, that means not effectively
+/// available for transport selection (see
+/// `DeviceConnectionState::network_effectively_available`; presence alone
+/// doesn't mean the WebSocket port is reachable). Shared with Bluetooth's
+/// `bluetooth_effectively_reliable` (ADR-0003 Phase 2), which uses the same
+/// bar for the unified status model but never affects transport selection.
+pub const TRANSPORT_UNRESPONSIVE_THRESHOLD: u32 = 3;
 
 pub fn new_lifecycle_bus() -> LifecycleBus {
     let (tx, _rx) = tokio::sync::broadcast::channel(LIFECYCLE_BUS_CAPACITY);

--- a/src-tauri/src/services/transport/tests.rs
+++ b/src-tauri/src/services/transport/tests.rs
@@ -627,7 +627,7 @@ async fn pair_request_accept_round_trip_delivers_a_code_back_to_the_requester() 
 /// firewall) but who is still discoverable.
 #[test]
 fn network_effectively_available_demotes_after_repeated_tcp_failures() {
-    use crate::services::transport::selection::NETWORK_UNRESPONSIVE_THRESHOLD;
+    use crate::services::transport::selection::TRANSPORT_UNRESPONSIVE_THRESHOLD;
 
     let (state, _db) = server_state("transport-network-effectively-available");
 
@@ -638,25 +638,64 @@ fn network_effectively_available_demotes_after_repeated_tcp_failures() {
     // by the existing discovery/pairing tests).
     assert!(!state.network_effectively_available("peer-x"));
 
-    for _ in 0..(NETWORK_UNRESPONSIVE_THRESHOLD - 1) {
+    for _ in 0..(TRANSPORT_UNRESPONSIVE_THRESHOLD - 1) {
         state.record_tcp_dial_failure("peer-x");
     }
     assert_eq!(
         state.tcp_dial_failure_count("peer-x"),
-        NETWORK_UNRESPONSIVE_THRESHOLD - 1,
+        TRANSPORT_UNRESPONSIVE_THRESHOLD - 1,
         "below threshold yet"
     );
 
     state.record_tcp_dial_failure("peer-x");
     assert_eq!(
         state.tcp_dial_failure_count("peer-x"),
-        NETWORK_UNRESPONSIVE_THRESHOLD,
+        TRANSPORT_UNRESPONSIVE_THRESHOLD,
         "at threshold"
     );
 
     // A later success resets the counter (transient blip, not permanent).
     state.record_tcp_dial_success("peer-x");
     assert_eq!(state.tcp_dial_failure_count("peer-x"), 0);
+}
+
+/// Bluetooth's counterpart to the test above (ADR-0003 Phase 2): a fresh
+/// peer with zero attempts is reliable by default -- "no reason to distrust
+/// it" is the bar, not "has been proven to work" -- then demotes once
+/// consecutive failures reach the shared threshold, and a later success
+/// resets it.
+#[test]
+fn bluetooth_effectively_reliable_demotes_after_repeated_failures_and_resets_on_success() {
+    use crate::services::transport::selection::TRANSPORT_UNRESPONSIVE_THRESHOLD;
+
+    let (state, _db) = server_state("transport-bluetooth-effectively-reliable");
+
+    assert!(
+        state.bluetooth_effectively_reliable("peer-x"),
+        "a never-attempted peer must default to reliable"
+    );
+
+    for _ in 0..(TRANSPORT_UNRESPONSIVE_THRESHOLD - 1) {
+        state.record_bluetooth_dial_failure("peer-x");
+    }
+    assert!(
+        state.bluetooth_effectively_reliable("peer-x"),
+        "below threshold yet"
+    );
+
+    state.record_bluetooth_dial_failure("peer-x");
+    assert_eq!(
+        state.bluetooth_dial_failure_count("peer-x"),
+        TRANSPORT_UNRESPONSIVE_THRESHOLD
+    );
+    assert!(
+        !state.bluetooth_effectively_reliable("peer-x"),
+        "at threshold, no longer reliable"
+    );
+
+    state.record_bluetooth_dial_success("peer-x");
+    assert_eq!(state.bluetooth_dial_failure_count("peer-x"), 0);
+    assert!(state.bluetooth_effectively_reliable("peer-x"));
 }
 
 /// Regression test: `tcp_dial_failures` must not outlive the Sim session it

--- a/src/spec/views/DeviceView.spec.ts
+++ b/src/spec/views/DeviceView.spec.ts
@@ -59,19 +59,13 @@ describe("DeviceView mapped spaces sync labels", () => {
       getTransportStatuses: jest.fn().mockReturnValue([
         {
           kind: "network",
-          enabled: true,
-          available: true,
           preferred: true,
-          connected: true,
-          detail: "Available",
+          state: { state: "live" },
         },
         {
           kind: "bluetooth",
-          enabled: true,
-          available: true,
           preferred: false,
-          connected: false,
-          detail: "Available for fallback",
+          state: { state: "configured", reliable: true },
         },
       ]),
       shortDeviceId: jest.fn().mockReturnValue("ce-123"),
@@ -162,6 +156,6 @@ describe("DeviceView mapped spaces sync labels", () => {
     expect(rows[0].text()).toContain("Network");
     expect(rows[0].text()).toContain("preferred");
     expect(rows[1].text()).toContain("Bluetooth");
-    expect(rows[1].text()).toContain("Available for fallback");
+    expect(rows[1].text()).toContain("Ready");
   });
 });

--- a/src/stores/device.ts
+++ b/src/stores/device.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { defineStore } from "pinia";
 import { computed, ref } from "vue";
 import { shortUuid } from "../utils/shortUuid";
@@ -14,15 +15,26 @@ export interface PairedDevice {
   bluetooth_last_verified_at: string | null;
 }
 
+// Mirrors the backend's RowState (device_connection::transport, ADR 0003
+// Phase 2): shared shape between the Network and Bluetooth rows.
+// - unconfigured: local preconditions aren't met at all; `reason` is why.
+// - configured: preconditions met, not the live transport right now;
+//   `reliable` is false only after recent consecutive connect failures --
+//   a never-attempted peer defaults to reliable.
+// - live: a session is actually live on this transport right now.
+export type DeviceTransportRowState =
+  | { state: "unconfigured"; reason: string }
+  | { state: "configured"; reliable: boolean }
+  | { state: "live" };
+
 export interface DeviceTransportStatus {
   kind: "network" | "bluetooth";
-  enabled: boolean;
-  available: boolean;
+  // What the automatic dial order would pick next -- independent of
+  // `state`, which reports what's true right now (sticky handoff means
+  // these can legitimately disagree while a session stays live on the
+  // non-preferred transport).
   preferred: boolean;
-  // Live session state for this specific transport right now, distinct
-  // from `available` (precondition met) -- see ADR 0002 Phase 2.
-  connected: boolean;
-  detail: string;
+  state: DeviceTransportRowState;
 }
 
 export interface DiscoveredDevice {
@@ -227,6 +239,12 @@ export const useDeviceStore = defineStore("device", () => {
 
   let discoveryTimer: ReturnType<typeof setInterval> | null = null;
   let presenceTimer: ReturnType<typeof setInterval> | null = null;
+  // Guards against `hydrate()` (called from more than one view's onMounted
+  // over the store's lifetime) registering the same Tauri event listener
+  // twice. Set synchronously, before the `await listen(...)` below, so two
+  // `hydrate()` calls racing each other can't both pass the check before
+  // either's `listen()` call resolves.
+  let sessionChangedListenerStarted = false;
   let mappingUpdateTimer: ReturnType<typeof setInterval> | null = null;
   let bluetoothScanTimer: ReturnType<typeof setTimeout> | null = null;
   let bluetoothScanActive = false;
@@ -500,15 +518,35 @@ export const useDeviceStore = defineStore("device", () => {
     }
   }
 
+  // Applies a fresh liveness check to a previously-loaded row state without
+  // re-deriving `unconfigured`'s `reason` or `configured`'s `reliable` --
+  // this lightweight check doesn't have that information (see
+  // `refreshLiveConnectedState` below). An `unconfigured` row can't become
+  // live and stays as-is; a `configured` row becomes `live` if the check
+  // says so, otherwise keeps its prior reliability; a `live` row that's no
+  // longer live falls back to `configured`/`reliable: true` -- a session
+  // ending isn't itself evidence of unreliability, and the real
+  // reliability signal (recent failure count) isn't something this check
+  // determines, so defaulting to reliable avoids painting amber on
+  // information this function doesn't actually have.
+  function withLiveness(
+    state: DeviceTransportRowState,
+    isLive: boolean,
+  ): DeviceTransportRowState {
+    if (state.state === "unconfigured") return state;
+    if (isLive) return { state: "live" };
+    if (state.state === "configured") return state;
+    return { state: "configured", reliable: true };
+  }
+
   // On Linux, `device_connection_transport_statuses` re-checks OS bond
   // status via a `bluetoothctl` subprocess call on every invocation --
   // fine for a one-shot load, but not something a live-status poll should
   // rerun every few seconds while a device's page stays open (a stalled
   // BlueZ/D-Bus would hold up every other DB-backed command for as long as
   // the view stays mounted). `device_connection_session_transport` reads
-  // only in-memory session state, so this patches just the `connected`
-  // field of whatever was last loaded rather than re-deriving the whole
-  // row set.
+  // only in-memory session state, so this patches just the `state` field
+  // of whatever was last loaded rather than re-deriving the whole row set.
   async function refreshLiveConnectedState(peerDeviceId: string) {
     if (!transportStatusesByPeer.value[peerDeviceId]?.length) return;
 
@@ -520,18 +558,17 @@ export const useDeviceStore = defineStore("device", () => {
       // Re-read *after* the await, not the array captured before it: an
       // enable/disable operation's full refresh (`setBluetoothTransport`)
       // can land while this invoke is pending, and patching on top of the
-      // pre-await snapshot would silently revert `enabled`/`available`/
-      // `detail` back to their stale values -- with nothing else to correct
-      // it afterward for a Bluetooth-only peer, since it never appears in
-      // the network presence snapshot that would otherwise trigger a fresh
-      // full load.
+      // pre-await snapshot would silently revert `state` back to a stale
+      // value -- with nothing else to correct it afterward for a
+      // Bluetooth-only peer, since it never appears in the network
+      // presence snapshot that would otherwise trigger a fresh full load.
       const current = transportStatusesByPeer.value[peerDeviceId];
       if (!current || current.length === 0) return;
       const networkConnected = liveKind === "tcp_ws";
       const bluetoothConnected = liveKind === "bluetooth" || liveKind === "sim";
       transportStatusesByPeer.value[peerDeviceId] = current.map((status) => ({
         ...status,
-        connected: status.kind === "network" ? networkConnected : bluetoothConnected,
+        state: withLiveness(status.state, status.kind === "network" ? networkConnected : bluetoothConnected),
       }));
     } catch (error) {
       console.warn("[device-connection] failed to refresh live connected state", error);
@@ -933,12 +970,30 @@ export const useDeviceStore = defineStore("device", () => {
     }, MAPPING_UPDATE_POLL_INTERVAL_MS);
   }
 
+  // ADR 0003 Phase 2: pushes `refreshLiveConnectedState` the moment a
+  // session actually connects/disconnects backend-side, instead of relying
+  // solely on `TRANSPORT_STATUS_POLL_INTERVAL_MS`'s next tick. Deliberately
+  // not the sole source of truth -- that poll stays running too, so a
+  // missed/dropped event here self-heals within its interval rather than
+  // leaving the row stuck stale indefinitely.
+  async function startSessionChangedListener() {
+    if (sessionChangedListenerStarted) return;
+    sessionChangedListenerStarted = true;
+    await listen<{ peer_device_id: string; kind: string; established: boolean }>(
+      "device-connection://session-changed",
+      (event) => {
+        void refreshLiveConnectedState(event.payload.peer_device_id);
+      },
+    );
+  }
+
   async function hydrate() {
     await loadPairedDevices();
     await refreshIdentity();
     setDiscovered([]);
     startPresenceLoop();
     startMappingUpdateLoop();
+    void startSessionChangedListener();
     void refreshPresence();
     void refreshDebugStatus();
   }

--- a/src/views/DeviceView.vue
+++ b/src/views/DeviceView.vue
@@ -3,7 +3,7 @@ import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import SettingsListGroup from "../components/SettingsView/SettingsListGroup.vue";
 import SettingsListItem from "../components/SettingsView/SettingsListItem.vue";
-import { useDeviceStore } from "../stores/device";
+import { useDeviceStore, type DeviceTransportRowState } from "../stores/device";
 import { useSpaceStore, isBuiltinSpace } from "../stores/space";
 import { shortUuid } from "../utils/shortUuid";
 
@@ -239,6 +239,35 @@ function mappedSpaceEndLabel(spaceId: string): string | null {
   const lastSynced = lastSyncedLabelBySpace.value[spaceId];
   return lastSynced ? `last synced: ${lastSynced}` : "Mapped";
 }
+
+// ADR 0003 Phase 2: shared four-state model for both transport rows.
+// `live` is the only state that gets a border (ring) -- the sole "this is
+// the transport actually carrying the session right now" signal, replacing
+// the old separate "connected now" text badge. Amber now only means
+// "recently unreliable" (Configured, reliable: false), not "network is
+// just doing the job instead" -- that case is Configured/reliable: true,
+// green with no border.
+function rowDotClass(state: DeviceTransportRowState): string {
+  switch (state.state) {
+    case "live":
+      return "bg-green-500 ring-2 ring-green-600 ring-offset-2 ring-offset-base-200";
+    case "configured":
+      return state.reliable ? "bg-green-500" : "bg-amber-400";
+    case "unconfigured":
+      return "bg-gray-400";
+  }
+}
+
+function rowDetailText(state: DeviceTransportRowState): string {
+  switch (state.state) {
+    case "unconfigured":
+      return state.reason;
+    case "configured":
+      return state.reliable ? "Ready" : "Recently unreliable";
+    case "live":
+      return "Connected now";
+  }
+}
 </script>
 
 <template>
@@ -291,24 +320,14 @@ function mappedSpaceEndLabel(spaceId: string): string | null {
           :data-transport-kind="status.kind"
         >
           <template #leading>
-            <span
-              class="h-2.5 w-2.5 rounded-full"
-              :class="
-                status.connected
-                  ? 'bg-green-500'
-                  : status.available
-                    ? 'bg-amber-400'
-                    : 'bg-gray-400'
-              "
-            />
+            <span class="h-2.5 w-2.5 rounded-full" :class="rowDotClass(status.state)" />
           </template>
           <template #start>
             <span class="font-medium">{{ status.kind === "network" ? "Network" : "Bluetooth" }}</span>
             <span v-if="status.preferred" class="ml-2 text-[11px] opacity-60">preferred</span>
-            <span v-if="status.connected" class="ml-2 text-[11px] text-success">connected now</span>
           </template>
           <template #end>
-            <span class="text-xs opacity-60">{{ status.detail }}</span>
+            <span class="text-xs opacity-60">{{ rowDetailText(status.state) }}</span>
           </template>
         </SettingsListItem>
       </SettingsListGroup>


### PR DESCRIPTION
## Summary
Second of three phases from `docs/adr/0003-transport-liveness-unified-status-and-manual-switching.md`. Independent of Phase 1 (#147) -- no file overlap, verified to build/test cleanly on its own.

- Replaces each row's `available`/`connected`/`detail` fields with a shared `RowState`: `Unconfigured{reason}` / `Configured{reliable}` / `Live`. Both Network and Bluetooth rows go through the same `row_state()` logic.
- Amber is redefined: it now only means "configured but recently unreliable" (repeated connect failures), not "ready, just not the active transport right now" -- that case is `Configured{reliable: true}`, green. `Live` gets a border, replacing the redundant "connected now" text badge.
- Bluetooth gets its own dial-failure counter for the first time, mirroring Network's existing `tcp_dial_failures` mechanism exactly.
- `build_transport_statuses` takes a named-field `TransportStatusInputs` struct instead of eight positional bools (readability/correctness -- easy to transpose two same-typed bools otherwise).
- Push: wires up `subscribe_lifecycle()`, which has existed unused since ADR-0001 ("wiring a push-based subscriber is follow-up work"). The 5s poll stays as a correctness safety net, not replaced.

## Test plan
- [x] `cargo test --lib`: 255 passed, stable across 3 runs (this branch alone, no Phase 1)
- [x] `vue-tsc --noEmit` + `jest`: clean, 128 passed
- [x] `cargo check --target x86_64-pc-windows-msvc`: no new Rust-level errors