### PR TITLE
Bump ble-gatt to fixed rev; add rich logging; fix stuck-connecting UI

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -55,6 +55,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
+dependencies = [
+ "android_log-sys",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,7 +414,7 @@ dependencies = [
 [[package]]
 name = "ble-gatt"
 version = "0.1.0"
-source = "git+https://github.com/VRuzhentsov/ble-gatt?rev=af4ed1e5cfcade75d15ff96e8c3e8de1d97749fa#af4ed1e5cfcade75d15ff96e8c3e8de1d97749fa"
+source = "git+https://github.com/VRuzhentsov/ble-gatt?rev=2564f8f6cb7e57507a2ceef79cd6693c4f5860b7#2564f8f6cb7e57507a2ceef79cd6693c4f5860b7"
 dependencies = [
  "async-trait",
  "bluer",
@@ -1562,6 +1579,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1625,6 +1652,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fern"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1673,6 +1709,7 @@ dependencies = [
  "gtk",
  "jni",
  "libsqlite3-sys",
+ "log",
  "mdns-sd",
  "ndk-context",
  "notify-rust",
@@ -1690,6 +1727,7 @@ dependencies = [
  "tauri-plugin-autostart",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
+ "tauri-plugin-log",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-playwright",
@@ -3239,6 +3277,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -5510,6 +5557,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-log"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6792296e6f389268016c77db21ebae1fc0568f2fccf88b1ec7e2ea71330afb4c"
+dependencies = [
+ "android_logger",
+ "fern",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "swift-rs",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "tauri-plugin-notification"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5793,7 +5861,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -67,12 +67,14 @@ flate2 = "1"
 tempfile = "3"
 tauri-plugin-dialog = { version = "2", optional = true }
 tauri-plugin-fs = { version = "2", optional = true }
+tauri-plugin-log = { version = "2", optional = true }
 url = { version = "2", optional = true }
+log = "0.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = { version = "0.18.2", optional = true }
 notify-rust = { version = "4", optional = true }
-ble-gatt = { git = "https://github.com/VRuzhentsov/ble-gatt", rev = "af4ed1e5cfcade75d15ff96e8c3e8de1d97749fa" }
+ble-gatt = { git = "https://github.com/VRuzhentsov/ble-gatt", rev = "2564f8f6cb7e57507a2ceef79cd6693c4f5860b7" }
 # Only used behind #[cfg(target_os = "linux")] (resume_watcher's sleep/wake
 # watcher, settings.rs's portal theme-change watcher, both over the
 # session/system D-Bus) -- kept target-gated rather than unconditional so
@@ -83,7 +85,7 @@ zbus = { version = "5.14.0", features = ["blocking-api"] }
 zvariant = "5.10.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
-ble-gatt = { git = "https://github.com/VRuzhentsov/ble-gatt", rev = "af4ed1e5cfcade75d15ff96e8c3e8de1d97749fa" }
+ble-gatt = { git = "https://github.com/VRuzhentsov/ble-gatt", rev = "2564f8f6cb7e57507a2ceef79cd6693c4f5860b7" }
 tao = "0.35"
 ndk-context = "0.1"
 tokio-stream = "0.1"
@@ -91,7 +93,7 @@ jni = "0.21"
 
 [features]
 default = []
-ui-plane = ["dep:tauri", "dep:tauri-build", "dep:tauri-plugin-opener", "dep:tauri-plugin-notification", "dep:tauri-plugin-autostart", "dep:tauri-plugin-dialog", "dep:tauri-plugin-fs", "dep:gtk", "dep:notify-rust"]
+ui-plane = ["dep:tauri", "dep:tauri-build", "dep:tauri-plugin-opener", "dep:tauri-plugin-notification", "dep:tauri-plugin-autostart", "dep:tauri-plugin-dialog", "dep:tauri-plugin-fs", "dep:tauri-plugin-log", "dep:gtk", "dep:notify-rust"]
 desktop-updater = ["ui-plane", "dep:tauri-plugin-updater", "dep:url"]
 cli-plane = ["dep:clap", "dep:self_update", "dep:url", "dep:zipsign-api"]
 # Enable developer/test control-plane hooks. Off by default; production builds

--- a/src-tauri/gen/android/app/src/main/kotlin/dev/blegatt/BleGattBridge.kt
+++ b/src-tauri/gen/android/app/src/main/kotlin/dev/blegatt/BleGattBridge.kt
@@ -20,6 +20,8 @@ import android.bluetooth.le.ScanResult
 import android.bluetooth.le.ScanSettings
 import android.content.Context
 import android.content.pm.PackageManager
+import android.os.Handler
+import android.os.Looper
 import android.os.ParcelUuid
 import android.util.Log
 import java.util.UUID
@@ -82,6 +84,13 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
     /// "verify this GATT still owns the address, then publish" atomic — and
     /// that pair is exactly where a cancellation and retry can interleave.
     private val gattLock = Any()
+    /// Schedules GATT-busy retries (see `GATT_BUSY_MAX_RETRIES`) off
+    /// whichever thread the rejected call happened to run on -- often a
+    /// Tokio worker thread arriving via JNI, which must not itself block on
+    /// a sleep. `gattLock` is bridge-wide (covers every connected peer), so
+    /// a retry's backoff must also happen without holding it, or one peer's
+    /// busy backoff would stall every other peer's GATT operations too.
+    private val retryHandler = Handler(Looper.getMainLooper())
     private val connectedGatts = ConcurrentHashMap<String, BluetoothGatt>()
     /// Rust's session id for the GATT currently owning each address.
     ///
@@ -514,46 +523,151 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
     private fun findCharacteristic(address: String, characteristicUuid: String): BluetoothGattCharacteristic? =
         pendingCharacteristics[address]?.get(characteristicUuid)
 
+    /// Runnables for a GATT-busy retry that has been scheduled but has not
+    /// fired yet -- present *only* for that window, never for an id whose
+    /// underlying platform call already returned `true` and is genuinely
+    /// in flight awaiting its real `onCharacteristicRead`/`onCharacteristicWrite`/
+    /// `onDescriptorWrite` callback. Removed either by `cancelPendingOperation`
+    /// or by the retry itself -- both under `gattLock`, see
+    /// `cancelPendingOperation`'s own comment for why that matters.
+    private val pendingRetries = ConcurrentHashMap<Long, Runnable>()
+
+    /// Called by Rust when a pending read/write/subscribe future is dropped
+    /// before its result arrived (a `timeout`, a losing `select!` branch) --
+    /// see `PendingOpGuard`/`SubscribeGuard`'s Drop impls on the Rust side.
+    /// Without this, a GATT-busy retry already scheduled via `retryHandler`
+    /// when the rejection happened has no way to learn its request was
+    /// abandoned: it fires anyway once the stack stops being busy,
+    /// transmitting the abandoned payload over the air.
+    ///
+    /// Three P1 review findings shaped this method, in order:
+    /// 1. Removing the id from the pending-id queue unconditionally
+    ///    corrupts FIFO matching for an id whose call had *already* been
+    ///    accepted by the platform and was genuinely in flight -- that
+    ///    entry must survive untouched for the real callback to find.
+    /// 2. Cancelling only the `Runnable` without also removing the queue
+    ///    entry leaves a permanent orphan for an id that really was only
+    ///    scheduled, never issued -- no real callback is ever coming for
+    ///    it, so left in place it silently swallows the *next* same-kind
+    ///    request's callback instead.
+    /// 3. Removing the `pendingRetries` entry from inside the retry's own
+    ///    `Runnable`, before it entered `synchronized(gattLock)`, left a
+    ///    window where a concurrent cancellation could see nothing left
+    ///    to cancel and return early while the retry -- already past that
+    ///    point -- fired anyway. `gattLock` is the actual correctness
+    ///    mechanism now: both this method and each `attempt*` (for
+    ///    `attempt > 0`, see their own first line) perform their
+    ///    `pendingRetries.remove` as the very first thing *inside* the
+    ///    lock, so whichever side acquires it first is unconditionally
+    ///    the one that gets to act. `Handler.removeCallbacks` below is
+    ///    only an optimisation that skips a wasted dispatch in the common
+    ///    case -- if the retry's `Runnable` ran anyway, its own
+    ///    `pendingRetries.remove` would find nothing and abort the same
+    ///    way `cancelPendingOperation` finding nothing here does.
+    fun cancelPendingOperation(requestId: Long): Unit = synchronized(gattLock) {
+        val retry = pendingRetries.remove(requestId) ?: return
+        retryHandler.removeCallbacks(retry)
+        for (queue in pendingWriteIds.values) synchronized(queue) { queue.remove(requestId) }
+        for (queue in pendingReadIds.values) synchronized(queue) { queue.remove(requestId) }
+        for (queue in pendingSubscribeIds.values) synchronized(queue) { queue.remove(requestId) }
+    }
+
     /// Every failure path must report back. An early `return` here leaves
     /// the Rust side's oneshot unresolved and its caller awaiting forever —
     /// and unknown UUIDs or incomplete service discovery are ordinary
     /// errors, not exotic ones.
     fun readCharacteristic(
         address: String, characteristicUuid: String, requestId: Long, session: Long,
+    ) = attemptRead(address, characteristicUuid, requestId, session, attempt = 0)
+
+    /// Same GATT-busy retry as `attemptWrite`/`attemptSubscribe` — see
+    /// `GATT_BUSY_MAX_RETRIES`'s doc comment. `gatt.readCharacteristic()` is
+    /// exactly as subject to the one-outstanding-op rule as the write path.
+    private fun attemptRead(
+        address: String, characteristicUuid: String, requestId: Long, session: Long, attempt: Int,
     ): Unit = synchronized(gattLock) {
+        // Must be the very first thing done under gattLock -- see
+        // cancelPendingOperation's doc comment (finding 3). A `null` here
+        // means cancellation already claimed this attempt; Rust has
+        // stopped listening, so there is nothing left to do.
+        if (attempt > 0 && pendingRetries.remove(requestId) == null) return
         if (gattSessions[address] != session) {
+            if (attempt > 0) {
+                pendingReadIds[address]?.let { queue -> synchronized(queue) { queue.remove(requestId) } }
+            }
             onCharacteristicRead(nativeHandle, requestId, address, characteristicUuid, ByteArray(0), false)
             return
         }
         val gatt = connectedGatts[address]
         val characteristic = findCharacteristic(address, characteristicUuid)
         val queue = pendingReadIds.getOrPut(address) { ArrayDeque() }
-        synchronized(queue) { queue.addLast(requestId) }
-        if (gatt == null || characteristic == null || !gatt.readCharacteristic(characteristic)) {
+        if (attempt == 0) {
+            synchronized(queue) { queue.addLast(requestId) }
+        }
+        if (gatt == null || characteristic == null) {
             Log.w(TAG, "readCharacteristic could not start: $address/$characteristicUuid")
             // Remove this id specifically: another operation's may be queued
             // ahead of it and must not be consumed by this failure.
             synchronized(queue) { queue.remove(requestId) }
             onCharacteristicRead(nativeHandle, requestId, address, characteristicUuid, ByteArray(0), false)
+            return
+        }
+        if (!gatt.readCharacteristic(characteristic)) {
+            if (attempt < GATT_BUSY_MAX_RETRIES) {
+                Log.w(
+                    TAG,
+                    "readCharacteristic rejected by the stack, retrying " +
+                        "(${attempt + 1}/$GATT_BUSY_MAX_RETRIES): $address/$characteristicUuid",
+                )
+                val retry = Runnable { attemptRead(address, characteristicUuid, requestId, session, attempt + 1) }
+                pendingRetries[requestId] = retry
+                retryHandler.postDelayed(retry, gattBusyRetryDelayMs(attempt + 1))
+            } else {
+                Log.w(TAG, "readCharacteristic rejected by the stack after $attempt retries: $address/$characteristicUuid")
+                synchronized(queue) { queue.remove(requestId) }
+                onCharacteristicRead(nativeHandle, requestId, address, characteristicUuid, ByteArray(0), false)
+            }
         }
     }
 
     /// `withoutResponse` selects ATT Write Command over Write Request —
     /// materially faster for bulk transfer, at the cost of the peer silently
     /// dropping writes it can't keep up with. See `models::WriteType`.
-    @Suppress("DEPRECATION")
     fun writeCharacteristic(
         address: String, characteristicUuid: String, value: ByteArray, withoutResponse: Boolean,
         requestId: Long, session: Long,
+    ) = attemptWrite(address, characteristicUuid, value, withoutResponse, requestId, session, attempt = 0)
+
+    /// See `GATT_BUSY_MAX_RETRIES`'s doc comment for why a `false` return
+    /// here gets retried rather than reported as failure immediately.
+    /// `requestId` is queued once, on `attempt == 0` — a retry reuses the
+    /// same slot rather than adding a second entry, since it's still the
+    /// same logical write as far as `onCharacteristicWrite`'s FIFO matching
+    /// is concerned; the platform never actually started the earlier
+    /// attempt, so there is nothing for it to complete out of order with.
+    @Suppress("DEPRECATION")
+    private fun attemptWrite(
+        address: String, characteristicUuid: String, value: ByteArray, withoutResponse: Boolean,
+        requestId: Long, session: Long, attempt: Int,
     ): Unit = synchronized(gattLock) {
+        // Must be the very first thing done under gattLock -- see
+        // cancelPendingOperation's doc comment (finding 3). A `null` here
+        // means cancellation already claimed this attempt; Rust has
+        // stopped listening, so there is nothing left to do.
+        if (attempt > 0 && pendingRetries.remove(requestId) == null) return
         if (gattSessions[address] != session) {
+            if (attempt > 0) {
+                pendingWriteIds[address]?.let { queue -> synchronized(queue) { queue.remove(requestId) } }
+            }
             onCharacteristicWriteResult(nativeHandle, requestId, address, characteristicUuid, false)
             return
         }
         val gatt = connectedGatts[address]
         val characteristic = findCharacteristic(address, characteristicUuid)
         val queue = pendingWriteIds.getOrPut(address) { ArrayDeque() }
-        synchronized(queue) { queue.addLast(requestId) }
+        if (attempt == 0) {
+            synchronized(queue) { queue.addLast(requestId) }
+        }
         if (gatt == null || characteristic == null) {
             Log.w(TAG, "writeCharacteristic could not start: $address/$characteristicUuid")
             synchronized(queue) { queue.remove(requestId) }
@@ -567,16 +681,49 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
         }
         characteristic.value = value
         if (!gatt.writeCharacteristic(characteristic)) {
-            Log.w(TAG, "writeCharacteristic rejected by the stack: $address/$characteristicUuid")
-            synchronized(queue) { queue.remove(requestId) }
-            onCharacteristicWriteResult(nativeHandle, requestId, address, characteristicUuid, false)
+            if (attempt < GATT_BUSY_MAX_RETRIES) {
+                Log.w(
+                    TAG,
+                    "writeCharacteristic rejected by the stack, retrying " +
+                        "(${attempt + 1}/$GATT_BUSY_MAX_RETRIES): $address/$characteristicUuid",
+                )
+                val retry = Runnable {
+                    attemptWrite(address, characteristicUuid, value, withoutResponse, requestId, session, attempt + 1)
+                }
+                pendingRetries[requestId] = retry
+                retryHandler.postDelayed(retry, gattBusyRetryDelayMs(attempt + 1))
+            } else {
+                Log.w(TAG, "writeCharacteristic rejected by the stack after $attempt retries: $address/$characteristicUuid")
+                synchronized(queue) { queue.remove(requestId) }
+                onCharacteristicWriteResult(nativeHandle, requestId, address, characteristicUuid, false)
+            }
         }
     }
 
     fun subscribeCharacteristic(
         address: String, characteristicUuid: String, requestId: Long, session: Long,
+    ) = attemptSubscribe(address, characteristicUuid, requestId, session, attempt = 0)
+
+    /// Same GATT-busy retry as `attemptWrite` — see `GATT_BUSY_MAX_RETRIES`'s
+    /// doc comment. Only the descriptor write (`gatt.writeDescriptor`) is a
+    /// real over-the-air GATT operation subject to the platform's
+    /// one-outstanding-op rule; `setCharacteristicNotification` is purely
+    /// local bookkeeping and re-running it on a retry is harmless.
+    @Suppress("DEPRECATION")
+    private fun attemptSubscribe(
+        address: String, characteristicUuid: String, requestId: Long, session: Long, attempt: Int,
     ): Unit = synchronized(gattLock) {
+        // Must be the very first thing done under gattLock -- see
+        // cancelPendingOperation's doc comment (finding 3). A `null` here
+        // means cancellation already claimed this attempt; Rust has
+        // stopped listening, so there is nothing left to do.
+        if (attempt > 0 && pendingRetries.remove(requestId) == null) return
         if (gattSessions[address] != session) {
+            if (attempt > 0) {
+                pendingSubscribeIds["$address/$characteristicUuid"]?.let { queue ->
+                    synchronized(queue) { queue.remove(requestId) }
+                }
+            }
             onSubscribed(nativeHandle, requestId, address, characteristicUuid, false)
             return
         }
@@ -586,7 +733,9 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
         // status as the new attempt's completion.
         val subscribeQueue =
             pendingSubscribeIds.getOrPut("$address/$characteristicUuid") { ArrayDeque() }
-        synchronized(subscribeQueue) { subscribeQueue.addLast(requestId) }
+        if (attempt == 0) {
+            synchronized(subscribeQueue) { subscribeQueue.addLast(requestId) }
+        }
         val gatt = connectedGatts[address]
         val characteristic = findCharacteristic(address, characteristicUuid)
         val cccd = characteristic?.getDescriptor(CLIENT_CHARACTERISTIC_CONFIG_UUID)
@@ -606,13 +755,25 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
             onSubscribed(nativeHandle, requestId, address, characteristicUuid, false)
             return
         }
-        @Suppress("DEPRECATION")
         cccd.value = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
-        @Suppress("DEPRECATION")
         if (!gatt.writeDescriptor(cccd)) {
-            Log.w(TAG, "subscribe descriptor write rejected: $address/$characteristicUuid")
-            synchronized(subscribeQueue) { subscribeQueue.remove(requestId) }
-            onSubscribed(nativeHandle, requestId, address, characteristicUuid, false)
+            if (attempt < GATT_BUSY_MAX_RETRIES) {
+                Log.w(
+                    TAG,
+                    "subscribe descriptor write rejected by the stack, retrying " +
+                        "(${attempt + 1}/$GATT_BUSY_MAX_RETRIES): $address/$characteristicUuid",
+                )
+                val retry = Runnable { attemptSubscribe(address, characteristicUuid, requestId, session, attempt + 1) }
+                pendingRetries[requestId] = retry
+                retryHandler.postDelayed(retry, gattBusyRetryDelayMs(attempt + 1))
+            } else {
+                Log.w(
+                    TAG,
+                    "subscribe descriptor write rejected by the stack after $attempt retries: $address/$characteristicUuid",
+                )
+                synchronized(subscribeQueue) { subscribeQueue.remove(requestId) }
+                onSubscribed(nativeHandle, requestId, address, characteristicUuid, false)
+            }
         }
     }
 
@@ -623,6 +784,12 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
     fun startAdvertising(
         serviceUuid: String, characteristicUuids: Array<String>, readable: BooleanArray, writable: BooleanArray,
         notifiable: BooleanArray, initialValues: Array<ByteArray>,
+        // Same parallel-array flattening `onPeerDiscovered` uses on the read
+        // side, mirrored here for the write side: a `java.util.HashMap`
+        // across JNI costs several reflective calls per entry, and the Rust
+        // side would have to walk it back out again either way.
+        manufacturerIds: IntArray, manufacturerValues: Array<ByteArray>,
+        serviceDataUuids: Array<String>, serviceDataValues: Array<ByteArray>,
     ) {
         // Tear down any predecessor first. This bridge holds a single
         // `gattServer`/`advertiseCallback` pair, so starting without
@@ -679,7 +846,10 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
                         return
                     }
                     Log.d(TAG, "onServiceAdded ok, starting advertisement")
-                    beginAdvertising(advertiser, serviceUuid, generation)
+                    beginAdvertising(
+                        advertiser, serviceUuid, generation,
+                        manufacturerIds, manufacturerValues, serviceDataUuids, serviceDataValues,
+                    )
                 }
             }
 
@@ -997,15 +1167,27 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
     private fun beginAdvertising(
         advertiser: android.bluetooth.le.BluetoothLeAdvertiser, serviceUuid: String,
         generation: Long,
+        manufacturerIds: IntArray, manufacturerValues: Array<ByteArray>,
+        serviceDataUuids: Array<String>, serviceDataValues: Array<ByteArray>,
     ) {
         val settings = AdvertiseSettings.Builder()
             .setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_BALANCED)
             .setConnectable(true)
             .build()
-        val data = AdvertiseData.Builder()
+        val dataBuilder = AdvertiseData.Builder()
             .addServiceUuid(ParcelUuid(UUID.fromString(serviceUuid)))
             .setIncludeDeviceName(false)
-            .build()
+        // Legacy advertisements are capped at 31 bytes total, and the
+        // service UUID above already spends most of that -- callers are
+        // responsible for keeping this small (see GattServiceSpec's own
+        // doc comment on manufacturer_data/service_data).
+        for (i in manufacturerIds.indices) {
+            dataBuilder.addManufacturerData(manufacturerIds[i], manufacturerValues[i])
+        }
+        for (i in serviceDataUuids.indices) {
+            dataBuilder.addServiceData(ParcelUuid(UUID.fromString(serviceDataUuids[i])), serviceDataValues[i])
+        }
+        val data = dataBuilder.build()
         val callback = object : AdvertiseCallback() {
             override fun onStartSuccess(settingsInEffect: AdvertiseSettings) {
                 // A stop/restart can leave this callback running against a
@@ -1311,5 +1493,44 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
         /// confused with a real controller error.
         private const val ADVERTISE_ERROR_UNAVAILABLE: Int = 100
         private const val ADVERTISE_ERROR_SERVICE_REJECTED: Int = 101
+
+        /// Android allows exactly one outstanding GATT operation per
+        /// connection (an MTU request, a characteristic read/write, a
+        /// descriptor write); calling the platform API for a new one before
+        /// the previous op's callback has landed makes it return `false`
+        /// immediately -- before anything is attempted over the air, not a
+        /// protocol-level rejection. Confirmed on real hardware (2026-08-17,
+        /// see ble-gatt/docs/hardware-verification.md) as reliably
+        /// reproducible under external radio contention -- a classic-profile
+        /// reconnect sharing the same radio -- even with a correctly
+        /// declared, fully-writable characteristic and zero bytes ever sent
+        /// on the air. That's exactly the transient condition the platform
+        /// expects callers to retry, not a hard failure, so `attemptWrite`/
+        /// `attemptRead`/`attemptSubscribe` back off and retry a bounded
+        /// number of times before reporting failure and tearing down the
+        /// link.
+        ///
+        /// A P1 review finding on the original flat 3 x 200ms schedule
+        /// (~600ms total): the busy window measured on that same real
+        /// hardware run was 3.7-3.8 seconds, not milliseconds -- every one
+        /// of those three retries fired while the stack was still busy, so
+        /// the write failed exactly as it would have with no retry at all.
+        /// `gattBusyRetryDelayMs` below instead backs off exponentially,
+        /// capped, giving a ~7s cumulative window (200+400+800+1600+2000+
+        /// 2000ms) that comfortably covers the measured worst case with
+        /// margin, while still giving up well short of the ~35-45s full
+        /// reconnect-and-reauthenticate cycle this exists to avoid paying
+        /// for on every transient stall.
+        private const val GATT_BUSY_MAX_RETRIES = 6
+        private const val GATT_BUSY_RETRY_BASE_DELAY_MS = 200L
+        private const val GATT_BUSY_RETRY_MAX_DELAY_MS = 2000L
+
+        /// `attempt` is the *upcoming* attempt number (1-indexed: the first
+        /// retry is 1, matching `attempt + 1` at each call site) -- delay
+        /// doubles each time, capped, so it's cheap to retry a genuinely
+        /// brief stall quickly without spending the whole budget on retries
+        /// fired too early to have any chance during a sustained one.
+        private fun gattBusyRetryDelayMs(attempt: Int): Long =
+            (GATT_BUSY_RETRY_BASE_DELAY_MS shl (attempt - 1)).coerceAtMost(GATT_BUSY_RETRY_MAX_DELAY_MS)
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -256,6 +256,24 @@ pub fn run_cli() -> i32 {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let builder = tauri::Builder::default()
+        // Registered first, and unconditionally (not gated on
+        // `debug_assertions`) -- on Android that guard is exactly what
+        // makes a release build silent: `tauri-plugin-log` is what routes
+        // records (both `ble_gatt`'s own, and fini's) to logcat there, and
+        // a debug-only registration means a release install has no logger
+        // installed at all, so every `log::info!`/`warn!`/`error!` call
+        // anywhere in the process -- ble-gatt's included -- is silently
+        // dropped rather than merely quiet. See ble-gatt's own
+        // docs/logging.md, which already assumes this is wired up here.
+        .plugin(
+            tauri_plugin_log::Builder::new()
+                .level(log::LevelFilter::Info)
+                .targets([
+                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout),
+                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::LogDir { file_name: None }),
+                ])
+                .build(),
+        )
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())

--- a/src-tauri/src/services/transport/ble.rs
+++ b/src-tauri/src/services/transport/ble.rs
@@ -122,7 +122,7 @@ mod android_lazy {
             match self.inner().await {
                 Ok(backend) => backend.capabilities().await,
                 Err(err) => {
-                    eprintln!("[transport][ble] android backend construction failed: {err}");
+                    log::warn!("[transport][ble] android backend construction failed: {err}");
                     CapabilityReport::default()
                 }
             }
@@ -678,14 +678,14 @@ pub async fn run_server(state: DeviceConnectionState, db_path: PathBuf) {
         let backend = match backend().await {
             Ok(backend) => backend,
             Err(err) => {
-                eprintln!("[transport][ble] adapter unavailable, retrying in {delay:?}: {err}");
+                log::warn!("[transport][ble] adapter unavailable, retrying in {delay:?}: {err}");
                 tokio::time::sleep(delay).await;
                 delay = (delay * 2).min(max_delay);
                 continue;
             }
         };
         if !backend.capabilities().await.peripheral {
-            eprintln!(
+            log::warn!(
                 "[transport][ble] adapter has no peripheral support; retrying in {delay:?} \
                  in case a different adapter becomes available"
             );
@@ -712,13 +712,13 @@ pub async fn run_server(state: DeviceConnectionState, db_path: PathBuf) {
         let mut incoming = match datagram::serve(backend, &datagram_config()).await {
             Ok(stream) => stream,
             Err(err) => {
-                eprintln!("[transport][ble] advertise failed, retrying in {delay:?}: {err}");
+                log::warn!("[transport][ble] advertise failed, retrying in {delay:?}: {err}");
                 tokio::time::sleep(delay).await;
                 delay = (delay * 2).min(max_delay);
                 continue;
             }
         };
-        eprintln!("[transport][ble] advertising, awaiting centrals");
+        log::info!("[transport][ble] advertising, awaiting centrals");
         delay = Duration::from_secs(2);
 
         let mut restarting_for_add_mode_change = false;
@@ -732,7 +732,7 @@ pub async fn run_server(state: DeviceConnectionState, db_path: PathBuf) {
                     tokio::spawn(session::run_peer_gate(link, state, db_path));
                 }
                 _ = add_mode_rx.changed() => {
-                    eprintln!("[transport][ble] add-mode changed; re-advertising");
+                    log::info!("[transport][ble] add-mode changed; re-advertising");
                     restarting_for_add_mode_change = true;
                     break;
                 }
@@ -752,7 +752,7 @@ pub async fn run_server(state: DeviceConnectionState, db_path: PathBuf) {
         // under it) rather than a caller closing it or an add-mode change
         // — nothing else here ever drops the stream deliberately. Retry
         // rather than leaving the peripheral role dead.
-        eprintln!("[transport][ble] serve stream ended unexpectedly; retrying in {delay:?}");
+        log::warn!("[transport][ble] serve stream ended unexpectedly; retrying in {delay:?}");
         tokio::time::sleep(delay).await;
         delay = (delay * 2).min(max_delay);
     }
@@ -884,7 +884,7 @@ async fn dial_with_backoff(state: DeviceConnectionState, db_path: PathBuf, peer_
         // entirely in the meantime — a setting meant to stop future
         // Bluetooth use silently not taking effect.
         if !is_still_bluetooth_eligible(&db_path, &peer_id, &address) {
-            eprintln!(
+            log::info!(
                 "[transport][ble] {peer_id} is no longer Bluetooth-enabled/OS-paired; \
                  stopping dial retries"
             );
@@ -897,7 +897,7 @@ async fn dial_with_backoff(state: DeviceConnectionState, db_path: PathBuf, peer_
                     .await
                 {
                     Ok(peer_protocol_version) => {
-                        eprintln!("[transport][ble] auth OK with {peer_id} via {address}");
+                        log::info!("[transport][ble] auth OK with {peer_id} via {address}");
                         // The connect+auth round trip is real wall-clock time
                         // during which the user could disable Bluetooth or
                         // unpair entirely; without this, a disable/unpair
@@ -906,7 +906,7 @@ async fn dial_with_backoff(state: DeviceConnectionState, db_path: PathBuf, peer_
                         // same eligibility check the top of this loop uses,
                         // right before claiming, to close that window.
                         if !is_still_bluetooth_eligible(&db_path, &peer_id, &address) {
-                            eprintln!(
+                            log::info!(
                                 "[transport][ble] {peer_id} became ineligible during the \
                                  connect/auth handshake; discarding this session"
                             );
@@ -923,12 +923,12 @@ async fn dial_with_backoff(state: DeviceConnectionState, db_path: PathBuf, peer_
                                 peer_protocol_version,
                             )
                             .await;
-                            eprintln!("[transport][ble] session with {peer_id} ended");
+                            log::info!("[transport][ble] session with {peer_id} ended");
                         }
                         delay = Duration::from_secs(2);
                     }
                     Err(err) => {
-                        eprintln!("[transport][ble] auth with {peer_id} failed: {err}");
+                        log::warn!("[transport][ble] auth with {peer_id} failed: {err}");
                         // "bluetooth disabled"/"not OS-paired" are not
                         // permanent the way "unknown device" is -- the user
                         // could re-enable, or re-pair, at any time. Keep
@@ -951,7 +951,7 @@ async fn dial_with_backoff(state: DeviceConnectionState, db_path: PathBuf, peer_
                 }
             }
             Err(err) => {
-                eprintln!("[transport][ble] connect to {peer_id} ({address}) failed: {err}");
+                log::warn!("[transport][ble] connect to {peer_id} ({address}) failed: {err}");
             }
         }
 

--- a/src-tauri/src/services/transport/tcp_ws.rs
+++ b/src-tauri/src/services/transport/tcp_ws.rs
@@ -196,16 +196,16 @@ pub(crate) async fn run_server_on_port(
     let listener = match TcpListener::bind(format!("0.0.0.0:{port}")).await {
         Ok(l) => l,
         Err(err) => {
-            eprintln!("[transport][tcp_ws] failed to bind :{port}: {err}");
+            log::error!("[transport][tcp_ws] failed to bind :{port}: {err}");
             return;
         }
     };
-    eprintln!("[transport][tcp_ws] listening on :{port}");
+    log::info!("[transport][tcp_ws] listening on :{port}");
 
     loop {
         match listener.accept().await {
             Ok((stream, addr)) => {
-                eprintln!("[transport][tcp_ws] connection from {addr}");
+                log::info!("[transport][tcp_ws] connection from {addr}");
                 let state = state.clone();
                 let db_path = db_path.clone();
                 let peer_addr = Some(addr.ip().to_string());
@@ -215,11 +215,11 @@ pub(crate) async fn run_server_on_port(
                             let link: Box<dyn Link> = Box::new(TcpWsLink::new_plain(ws, peer_addr));
                             session::run_peer_gate(link, state, db_path).await;
                         }
-                        Err(err) => eprintln!("[transport][tcp_ws] WS handshake failed: {err}"),
+                        Err(err) => log::warn!("[transport][tcp_ws] WS handshake failed: {err}"),
                     }
                 });
             }
-            Err(err) => eprintln!("[transport][tcp_ws] accept error: {err}"),
+            Err(err) => log::warn!("[transport][tcp_ws] accept error: {err}"),
         }
     }
 }
@@ -347,7 +347,7 @@ pub(crate) async fn dial_with_backoff(
         };
 
         let Ok(target_addr) = addr.parse::<IpAddr>() else {
-            eprintln!("[transport][tcp_ws] invalid peer addr '{addr}'");
+            log::warn!("[transport][tcp_ws] invalid peer addr '{addr}'");
             return;
         };
 
@@ -361,7 +361,7 @@ pub(crate) async fn dial_with_backoff(
                 .await
                 {
                     Ok(peer_protocol_version) => {
-                        eprintln!("[transport][tcp_ws] auth OK with {peer_id}");
+                        log::info!("[transport][tcp_ws] auth OK with {peer_id}");
                         let (tx, rx) = tokio::sync::mpsc::channel(64);
                         if state.try_claim_session(&peer_id, TransportKind::TcpWs, tx, &db_path) {
                             session::run_session(
@@ -373,12 +373,12 @@ pub(crate) async fn dial_with_backoff(
                                 peer_protocol_version,
                             )
                             .await;
-                            eprintln!("[transport][tcp_ws] session with {peer_id} ended");
+                            log::info!("[transport][tcp_ws] session with {peer_id} ended");
                         }
                         delay = Duration::from_secs(1);
                     }
                     Err(err) => {
-                        eprintln!("[transport][tcp_ws] auth with {peer_id} failed: {err}");
+                        log::warn!("[transport][tcp_ws] auth with {peer_id} failed: {err}");
                         if err.starts_with("auth rejected") {
                             // Not just "don't retry within this task" --
                             // `spawn_dial_loop` would otherwise spawn a
@@ -394,7 +394,7 @@ pub(crate) async fn dial_with_backoff(
                 }
             }
             Err(err) => {
-                eprintln!("[transport][tcp_ws] connect to {peer_id} failed: {err}");
+                log::warn!("[transport][tcp_ws] connect to {peer_id} failed: {err}");
             }
         }
 

--- a/src/views/DeviceView.vue
+++ b/src/views/DeviceView.vue
@@ -94,6 +94,37 @@ const hasMappingChanges = computed(() => {
 const TRANSPORT_STATUS_POLL_INTERVAL_MS = 5_000;
 let transportStatusTimer: ReturnType<typeof setInterval> | null = null;
 
+// Drives the "stuck connecting" timeout below. Updated on the same 5s tick
+// that already polls live state -- no need for a finer-grained clock than
+// that to notice a 30s threshold has passed.
+const now = ref(Date.now());
+const CONNECTING_TIMEOUT_MS = 30_000;
+// First-seen timestamp per row, keyed by transport kind -- this view only
+// ever shows the two rows for one device, so kind alone is enough. Reset on
+// device navigation (see the `deviceId` watcher below) so a slow row on one
+// device doesn't report as instantly "stuck" on the next.
+const connectingSince = ref<Partial<Record<DeviceTransportStatus["kind"], number>>>({});
+
+watch(
+  transportStatuses,
+  (statuses) => {
+    for (const status of statuses) {
+      const connecting = status.state.state === "configured" && status.state.code?.code === "connecting";
+      if (connecting) {
+        if (!(status.kind in connectingSince.value)) connectingSince.value[status.kind] = Date.now();
+      } else {
+        delete connectingSince.value[status.kind];
+      }
+    }
+  },
+  { immediate: true },
+);
+
+function isStuckConnecting(status: DeviceTransportStatus): boolean {
+  const since = connectingSince.value[status.kind];
+  return status.state.code?.code === "connecting" && since !== undefined && now.value - since > CONNECTING_TIMEOUT_MS;
+}
+
 onMounted(() => {
   void deviceStore.hydrate();
   void spaceStore.fetchSpaces();
@@ -114,6 +145,7 @@ onMounted(() => {
   // for as long as it stays open -- only the live "connected" state
   // actually needs to be fresh here.
   transportStatusTimer = setInterval(() => {
+    now.value = Date.now();
     if (deviceId.value) void deviceStore.refreshLiveConnectedState(deviceId.value);
   }, TRANSPORT_STATUS_POLL_INTERVAL_MS);
 });
@@ -138,6 +170,7 @@ watch(deviceId, () => {
   findingBluetoothAddress.value = false;
   bluetoothFindResult.value = null;
   bluetoothTransportError.value = null;
+  connectingSince.value = {};
 });
 
 watch(savedMappedSelection, (next) => {
@@ -301,15 +334,24 @@ function rowDotClass(status: DeviceTransportStatus): string {
 
 function rowDetailText(status: DeviceTransportStatus): string {
   if (status.state.state === "unconfigured") return "Unavailable";
-  if (status.state.code !== null) return "Connecting…";
+  if (status.state.code !== null) return isStuckConnecting(status) ? "Still connecting…" : "Connecting…";
   return status.primary ? "Connected now" : "Ready";
 }
 
 // The "i" tooltip only has something to say when there's a code to explain
-// -- a fully green, primary-or-not row has no error to surface.
+// -- a fully green, primary-or-not row has no error to surface. Past the
+// 30s timeout, "connecting" specifically swaps its usual (accurate but
+// static) explanation for something actionable, since by then the plain
+// "no session established yet" text has stopped telling the user anything
+// new -- see `CONNECTING_TIMEOUT_MS`/`isStuckConnecting`.
 function rowStatusTooltip(status: DeviceTransportStatus): string | null {
   const code = status.state.code;
-  return code ? transportStatusText(code) : null;
+  if (!code) return null;
+  if (isStuckConnecting(status)) {
+    const peerHint = status.kind === "bluetooth" ? "Bluetooth is on for both devices" : "both devices are on the same network";
+    return `Still trying after 30+ seconds. Check that the peer device is powered on, nearby, and that ${peerHint}.`;
+  }
+  return transportStatusText(code);
 }
 </script>
 
@@ -380,7 +422,7 @@ function rowStatusTooltip(status: DeviceTransportStatus): string | null {
             />
             <div
               v-if="rowStatusTooltip(status)"
-              class="tooltip tooltip-right ml-1 inline-block align-text-top"
+              class="tooltip tooltip-bottom ml-1 inline-block align-text-top"
               :data-tip="rowStatusTooltip(status)"
             >
               <InformationCircleIcon


### PR DESCRIPTION
## Summary

- Bumps the `ble-gatt` dependency to `2564f8f` (VRuzhentsov/ble-gatt#4, merged), fixing two defects a live hardware round-trip attempt found: the Android peripheral role's `startAdvertising` `NoSuchMethodError`, and the Android central role's GATT writes/reads/subscribes failing locally under radio contention (a concurrent classic-Bluetooth-profile reconnect) with no retry at all. Full findings in ble-gatt's own `docs/hardware-verification.md`.
- Syncs the vendored `gen/android/app/src/main/kotlin/dev/blegatt/BleGattBridge.kt` -- confirmed there's no separate Gradle subproject for it (`settings.gradle` only includes `:app`), so it doesn't auto-track the Cargo git rev and needed a manual copy. Previous copy was dated 2026-08-09, predating every fix above.
- Wires up `tauri-plugin-log`, registered unconditionally so it also covers release builds (per ble-gatt's own `docs/logging.md`), targeting stdout + the platform log dir. Fini installed no logger before this, so every `log::info!`/`warn!`/`error!` call throughout `ble-gatt` -- and fini's own transport lifecycle logs, now migrated from ad-hoc `eprintln!` to the same macros -- was silently dropped.
- `DeviceView.vue`: a row stuck "connecting" for 30s+ now shows an actionable tooltip (check the peer is powered on, nearby, and has the transport enabled) instead of the same static text forever; the info tooltip now opens downward instead of off-screen to the right.

## Verification

- `cargo build`/`test` (ui-plane, x86_64 and `aarch64-linux-android` targets), 3x locally: all pass clean (221/221).
- `vue-tsc --noEmit`: clean.
- Full `tauri android build --debug` links the updated Rust and synced Kotlin together without error.
- Confirmed live on an Android emulator: BLE peripheral role starts cleanly, zero crash, and both fini's and ble-gatt's log lines appear in logcat with the Rust module path as the tag itself (e.g. `fini_lib::services::transport::ble`), natively filterable.
- Not independently re-verified against real hardware tonight (that's what surfaced the original bugs) -- the fixes carry the same hardware-measured reasoning as the merged ble-gatt PR.