### PR TITLE
Fix Sim transport dial loop giving up after a lost claim race

### DIFF
--- a/src-tauri/src/services/transport/sim.rs
+++ b/src-tauri/src/services/transport/sim.rs
@@ -242,8 +242,15 @@ pub(crate) async fn dial_with_backoff(
                         )
                         .await;
                         eprintln!("[transport][sim] session with {peer_id} ended");
+                        return;
                     }
-                    return;
+                    // Lost the claim race (e.g. the peer's inbound accept claimed a session on
+                    // this same peer+transport first) — this auth'd link is now redundant, not a
+                    // failure to retry from scratch. Fall through to backoff so the next loop
+                    // iteration's has_session_on check (which should now see the winning session)
+                    // short-circuits, instead of this task silently exiting and leaving nothing
+                    // to notice if that session never actually materializes.
+                    eprintln!("[transport][sim] lost claim race with {peer_id} via :{port}");
                 }
                 Err(_) => continue, // wrong-guess port, or peer not yet listening
             }


### PR DESCRIPTION
## Summary

`dial_with_backoff` in `src-tauri/src/services/transport/sim.rs` returned unconditionally after a successful auth handshake, even when `try_claim_session` failed (e.g. the peer's own inbound accept claimed a session for this peer+transport first). That silently ended the dial task instead of falling through to the loop's existing backoff-and-retry tail — contradicting the function's own "dial loop... with backoff" contract. Its `tcp_ws.rs` sibling, which this function is documented to mirror, never had this bug (no early return on a failed claim there).

## Root cause evidence

Two occurrences of the identical failure in `specs/e2e/actors/tests/peer-sync-over-sim.spec.ts`:

- `Error: Timed out waiting for actor-b Personal last synced label.` — thrown after the full 60s poll window, with **no exception on any individual poll attempt** (the thrown error has no "Last error:" suffix). That rules out DOM/navigation flakiness — the backend genuinely never converged.
- Occurrence 1: during PR #151's own CI iteration (a run that passed on retry).
- Occurrence 2: on the v0.3.2 release CI run, using the exact commit that had passed this same test cleanly (11s) on an unrelated PR's CI hours earlier — confirming it's intermittent, not a deterministic regression from that PR.
- Always specifically on the *approving* actor (never the requester).

## Fix

Move the `return` inside the successful-claim branch. On a lost claim, fall through to the loop's existing backoff/retry instead of exiting the task.

## Test plan

- [x] `cargo test --features ui-plane --lib` — 226/226 pass
- [x] `npm run build` + `npm run test:unit` — 149/149 pass
- [x] 8 repeated full local runs of `peer-sync-over-sim.spec.ts` + `unpair-and-rejoin-over-sim.spec.ts` — 16/16 passed (evidence the fix helps for an inherently intermittent race, not proof)

## Follow-up

Once this merges to `main`, the failed v0.3.2 release tag can be retried per `fini-release` policy (nothing was published from the failed run, so a re-push is safe): `make pre-release-check` locally, then delete + re-push the `v0.3.2` tag.