### PR TITLE
Log peer-gate auth outcomes on the accept path

### DIFF
--- a/src-tauri/src/services/space_sync/session.rs
+++ b/src-tauri/src/services/space_sync/session.rs
@@ -247,6 +247,7 @@ pub async fn run_peer_gate(mut link: Box<dyn Link>, state: DeviceConnectionState
             protocol_version,
         } => (device_id, peer_device_id, protocol_version),
         _ => {
+            log::warn!("[space_sync][gate] {kind:?} link from {from_addr}: expected auth first, got a different frame");
             let _ = send_frame(
                 link.as_mut(),
                 &PeerFrame::AuthFail {
@@ -258,7 +259,14 @@ pub async fn run_peer_gate(mut link: Box<dyn Link>, state: DeviceConnectionState
         }
     };
 
+    log::info!("[space_sync][gate] {kind:?} auth attempt from {device_id} via {from_addr}");
+
     if peer_device_id != state.identity.device_id {
+        log::warn!(
+            "[space_sync][gate] {kind:?} auth from {device_id} rejected: wrong target device \
+             ({peer_device_id}, expected {})",
+            state.identity.device_id
+        );
         let _ = send_frame(
             link.as_mut(),
             &PeerFrame::AuthFail {
@@ -270,6 +278,7 @@ pub async fn run_peer_gate(mut link: Box<dyn Link>, state: DeviceConnectionState
     }
 
     if !check_paired(&db_path, &device_id) {
+        log::warn!("[space_sync][gate] {kind:?} auth from {device_id} rejected: unknown device (not paired)");
         let _ = send_frame(
             link.as_mut(),
             &PeerFrame::AuthFail {
@@ -282,6 +291,9 @@ pub async fn run_peer_gate(mut link: Box<dyn Link>, state: DeviceConnectionState
 
     if kind == TransportKind::Bluetooth {
         if !check_bluetooth_enabled(&db_path, &device_id) {
+            log::warn!(
+                "[space_sync][gate] bluetooth auth from {device_id} rejected: bluetooth disabled for this pair"
+            );
             let _ = send_frame(
                 link.as_mut(),
                 &PeerFrame::AuthFail {
@@ -292,6 +304,9 @@ pub async fn run_peer_gate(mut link: Box<dyn Link>, state: DeviceConnectionState
             return;
         }
         if !check_bluetooth_bond(&db_path, &device_id, link.peer_addr().as_deref()) {
+            log::warn!(
+                "[space_sync][gate] bluetooth auth from {device_id} rejected: not currently OS-paired"
+            );
             let _ = send_frame(
                 link.as_mut(),
                 &PeerFrame::AuthFail {
@@ -305,6 +320,16 @@ pub async fn run_peer_gate(mut link: Box<dyn Link>, state: DeviceConnectionState
 
     let (tx, rx) = mpsc::channel::<SessionCommand>(64);
     if !state.try_claim_session(&device_id, kind, tx, &db_path) {
+        // If this fires repeatedly for a peer that has no other live session
+        // on this transport (check `device_connection_debug_status` / the
+        // sibling session logs), the claim is stale -- a slot never released
+        // by a prior session that ended without going through
+        // `release_session` (e.g. a panic in `run_session`'s inbound-frame
+        // handling). That's a "stuck connecting forever" shape from the
+        // gate's own side, not just the dial loop's.
+        log::warn!(
+            "[space_sync][gate] {kind:?} auth from {device_id} rejected: session already active on this transport"
+        );
         let _ = send_frame(
             link.as_mut(),
             &PeerFrame::AuthFail {
@@ -324,10 +349,12 @@ pub async fn run_peer_gate(mut link: Box<dyn Link>, state: DeviceConnectionState
     .await
     .is_err()
     {
+        log::warn!("[space_sync][gate] {kind:?} auth OK for {device_id} but AuthOk send failed; releasing claim");
         state.release_session(&device_id, kind, &db_path);
         return;
     }
 
+    log::info!("[space_sync][gate] {kind:?} auth OK for {device_id}; starting session");
     run_session(link, rx, state, db_path, device_id, peer_protocol_version).await;
 }
 

--- a/src-tauri/src/services/transport/ble.rs
+++ b/src-tauri/src/services/transport/ble.rs
@@ -727,6 +727,17 @@ pub async fn run_server(state: DeviceConnectionState, db_path: PathBuf) {
                 channel = incoming.next() => {
                     let Some(channel) = channel else { break; };
                     let link: Box<dyn Link> = Box::new(BleLink::new(channel));
+                    // Mirrors tcp_ws's/sim's "connection from {addr}" accept
+                    // log -- without this, `run_peer_gate`'s own auth-outcome
+                    // logging (added alongside this) has no matching "an
+                    // attempt arrived at all" line to pair with, so a link
+                    // that dies before ever sending an Auth frame (e.g. lost
+                    // at the GATT layer before the first read) would leave no
+                    // trace here that anything was accepted.
+                    log::info!(
+                        "[transport][ble] central connected: {}",
+                        link.peer_addr().unwrap_or_default()
+                    );
                     let state = state.clone();
                     let db_path = db_path.clone();
                     tokio::spawn(session::run_peer_gate(link, state, db_path));


### PR DESCRIPTION
## Summary

Investigating a live "Still connecting…" BLE report on real hardware (Pixel 6 Pro ↔ desktop) surfaced that `run_peer_gate` — the transport-neutral server-side accept/auth path shared by `tcp_ws`/`ble`/`sim` — has **zero logging on every branch**: auth accepted, and every rejection reason (wrong target device, unknown device, bluetooth disabled, not OS-paired, stale session claim already held) all fail or succeed completely silently.

The rich per-transport logging added in #155 covers the GATT/advertise layer (connect, MTU, subscribe, etc.), but the app-level `Auth`/`AuthOk`/`AuthFail` handshake that actually decides whether a session gets established was invisible — a rejection there (e.g. a stale claimed-but-never-released session slot) looks identical in the logs to no connection attempt ever arriving at all. This made the actual root cause of the "still connecting" report undiagnosable from logs alone; it took a live `adb logcat` capture and `dumpsys bluetooth_manager` on the phone itself to find it (root cause tracked separately — see [ble-gatt#5](https://github.com/VRuzhentsov/ble-gatt/pull/5)).

## Changes

- `session.rs`: `run_peer_gate` now logs at every decision point — the incoming auth attempt, each rejection reason with enough context to diagnose it (target device mismatch, not paired, bluetooth disabled/not-bonded, stale session claim), AuthOk send failure, and successful auth before handing off to `run_session`.
- `ble.rs`: the BLE peripheral accept loop now logs "central connected: {addr}" when a link is accepted, matching the existing pattern already used in `tcp_ws`'s and `sim`'s own accept loops — so there's always a paired "an attempt arrived" line to go with the gate's new auth-outcome line.

Logging only — no behavior change.

## Test plan

- [x] `cargo check` passes clean.
- [x] Confirmed no new warnings introduced in either edited file.