### PR TITLE
Bump ble-gatt to pick up the CONNECTION_PRIORITY_HIGH fix

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -116,7 +116,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -127,7 +127,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "ble-gatt"
 version = "0.1.0"
-source = "git+https://github.com/VRuzhentsov/ble-gatt?rev=2564f8f6cb7e57507a2ceef79cd6693c4f5860b7#2564f8f6cb7e57507a2ceef79cd6693c4f5860b7"
+source = "git+https://github.com/VRuzhentsov/ble-gatt?rev=d8de96abc582b47f388d1e4713578217636a7355#d8de96abc582b47f388d1e4713578217636a7355"
 dependencies = [
  "async-trait",
  "bluer",
@@ -1612,7 +1612,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3127,7 +3127,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4115,7 +4115,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4491,7 +4491,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4550,7 +4550,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5054,7 +5054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5789,7 +5789,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6201,7 +6201,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6786,7 +6786,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -74,7 +74,7 @@ log = "0.4"
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = { version = "0.18.2", optional = true }
 notify-rust = { version = "4", optional = true }
-ble-gatt = { git = "https://github.com/VRuzhentsov/ble-gatt", rev = "2564f8f6cb7e57507a2ceef79cd6693c4f5860b7" }
+ble-gatt = { git = "https://github.com/VRuzhentsov/ble-gatt", rev = "d8de96abc582b47f388d1e4713578217636a7355" }
 # Only used behind #[cfg(target_os = "linux")] (resume_watcher's sleep/wake
 # watcher, settings.rs's portal theme-change watcher, both over the
 # session/system D-Bus) -- kept target-gated rather than unconditional so
@@ -85,7 +85,7 @@ zbus = { version = "5.14.0", features = ["blocking-api"] }
 zvariant = "5.10.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
-ble-gatt = { git = "https://github.com/VRuzhentsov/ble-gatt", rev = "2564f8f6cb7e57507a2ceef79cd6693c4f5860b7" }
+ble-gatt = { git = "https://github.com/VRuzhentsov/ble-gatt", rev = "d8de96abc582b47f388d1e4713578217636a7355" }
 tao = "0.35"
 ndk-context = "0.1"
 tokio-stream = "0.1"

--- a/src-tauri/gen/android/app/src/main/kotlin/dev/blegatt/BleGattBridge.kt
+++ b/src-tauri/gen/android/app/src/main/kotlin/dev/blegatt/BleGattBridge.kt
@@ -307,6 +307,23 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
             override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
                 when (newState) {
                     BluetoothProfile.STATE_CONNECTED -> {
+                        // Default connection priority (BALANCED) lets Android's
+                        // scheduler give background BLE activity on the shared
+                        // radio -- Nearby/Fast Pair scanning, other apps' GATT
+                        // servers -- an equal or greater claim on connection-event
+                        // time than this link. Live production capture
+                        // (2026-08-23, Pixel 6 Pro) showed the very first
+                        // characteristic write after connect+subscribe rejected
+                        // locally by the stack for the *entire* 7s retry budget on
+                        // every attempt, with `dumpsys bluetooth_manager` showing a
+                        // concurrent system GATT server (com.google.uid.shared,
+                        // tag=nearby_presence) registered on the same adapter --
+                        // exactly the shared-radio contention this priority bump
+                        // exists to outrank. Requesting HIGH asks the platform for
+                        // the shortest connection interval it can offer, so our own
+                        // operations get serviced on the next event instead of
+                        // losing the race to unrelated background BLE traffic.
+                        gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_HIGH)
                         // Ask for the largest MTU the spec allows before
                         // discovering services. The peer decides the real
                         // value and reports it via onMtuChanged; until then

--- a/src-tauri/gen/android/app/src/main/kotlin/dev/blegatt/BleGattBridge.kt
+++ b/src-tauri/gen/android/app/src/main/kotlin/dev/blegatt/BleGattBridge.kt
@@ -336,31 +336,24 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
                         // the shortest connection interval it can offer, so our own
                         // operations get serviced on the next event instead of
                         // losing the race to unrelated background BLE traffic.
-                        // Temporary, not permanent: `onCharacteristicWrite` drops
-                        // this back to BALANCED after the first successful write,
-                        // once the bootstrap this exists to protect is done -- see
-                        // `priorityLowered`'s doc comment.
+                        // Temporary, not permanent: dropped back to BALANCED once
+                        // the bootstrap this exists to protect is done -- see
+                        // `priorityLowered`'s doc comment on *where* that happens
+                        // and why it is deliberately not scheduled from here. A
+                        // P1 review finding on an earlier version of this fix:
+                        // scheduling the revert-to-BALANCED fallback from this
+                        // exact point (connect time) let MTU negotiation, service
+                        // discovery, and CCCD subscription -- each individually
+                        // unbounded, and subscription can itself retry for up to
+                        // GATT_BUSY_MAX_RETRIES's ~7s -- eat into the fallback's
+                        // own countdown before the write it's meant to protect
+                        // even started, so the fallback could fire *during* that
+                        // write's retry window and recreate the exact "Still
+                        // connecting..." failure this whole fix exists to solve.
+                        // HIGH still gets requested immediately here regardless
+                        // -- it also speeds up this MTU/discovery/subscribe
+                        // sequence itself, not just the write after it.
                         gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_HIGH)
-                        // Bounded fallback for the P1 above `onCharacteristicWrite`
-                        // is meant to close: a receive-only or otherwise
-                        // write-less connection never reaches that callback, so
-                        // without this HIGH would hold for the connection's
-                        // entire lifetime. Guarantees BALANCED resumes within
-                        // PRIORITY_BOOTSTRAP_TIMEOUT_MS regardless of whether a
-                        // write ever happens. `priorityLowered.add` is the same
-                        // once-only gate `onCharacteristicWrite` uses, so
-                        // whichever path -- a write, or this timeout -- gets
-                        // there first makes the other a no-op; the `gattLock`
-                        // ownership check matters because 10s is easily long
-                        // enough for this connection to have been superseded or
-                        // torn down by the time this fires.
-                        retryHandler.postDelayed({
-                            synchronized(gattLock) {
-                                if (connectedGatts[address] === gatt && priorityLowered.add(address)) {
-                                    gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_BALANCED)
-                                }
-                            }
-                        }, PRIORITY_BOOTSTRAP_TIMEOUT_MS)
                         // Ask for the largest MTU the spec allows before
                         // discovering services. The peer decides the real
                         // value and reports it via onMtuChanged; until then
@@ -566,6 +559,28 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
                     characteristicUuid,
                     status == BluetoothGatt.GATT_SUCCESS,
                 )
+                if (status == BluetoothGatt.GATT_SUCCESS) {
+                    // Anchored here, not at `STATE_CONNECTED` -- see that
+                    // callback's doc comment for the P1 this fixes. Subscribe
+                    // just succeeded, which is exactly the moment before Rust
+                    // attempts the first characteristic write this priority
+                    // bump exists to protect, so the full
+                    // PRIORITY_BOOTSTRAP_TIMEOUT_MS window starts now,
+                    // comfortably covering that write's own up-to-~7s
+                    // GATT_BUSY_MAX_RETRIES budget with margin rather than
+                    // racing it. Bounded fallback for connections that never
+                    // reach `onCharacteristicWrite` at all (idle/receive-only);
+                    // `priorityLowered.add` is the same once-only gate that
+                    // callback uses, so whichever happens first -- a write, or
+                    // this timeout -- makes the other a no-op.
+                    retryHandler.postDelayed({
+                        synchronized(gattLock) {
+                            if (connectedGatts[address] === gatt && priorityLowered.add(address)) {
+                                gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_BALANCED)
+                            }
+                        }
+                    }, PRIORITY_BOOTSTRAP_TIMEOUT_MS)
+                }
                 }
             }
         }

--- a/src-tauri/gen/android/app/src/main/kotlin/dev/blegatt/BleGattBridge.kt
+++ b/src-tauri/gen/android/app/src/main/kotlin/dev/blegatt/BleGattBridge.kt
@@ -102,10 +102,10 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
     /// the GATT, which makes validation and initiation one transition.
     private val gattSessions = ConcurrentHashMap<String, Long>()
     /// Addresses whose connection priority has already been dropped back to
-    /// BALANCED after their first successful post-connect write. See the doc
-    /// comment on `requestConnectionPriority(CONNECTION_PRIORITY_HIGH)` in
-    /// `connect()` -- HIGH is requested only to get the connect/auth
-    /// bootstrap (subscribe, then the first characteristic write) through a
+    /// BALANCED by the bounded bootstrap-timeout fallback scheduled in
+    /// `onDescriptorWrite`. See the doc comment on
+    /// `requestConnectionPriority(CONNECTION_PRIORITY_HIGH)` in `connect()`
+    /// -- HIGH is requested only to get the connect/auth bootstrap through a
     /// busy radio reliably, not held for a session's full lifetime. fini's
     /// sessions are long-lived, so leaving HIGH in effect permanently would
     /// mean a materially shorter connection interval -- more radio wakeups,
@@ -113,6 +113,17 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
     /// that needed it. Cleared alongside the other per-address state on
     /// disconnect (both sites below), so a reconnect to the same address
     /// re-triggers the bootstrap treatment instead of silently skipping it.
+    ///
+    /// Deliberately *not* also dropped on the first successful
+    /// `onCharacteristicWrite` (an earlier version of this fix did that): a
+    /// P1 review finding pointed out that the app-level bootstrap message
+    /// (the `Auth` frame) can itself be fragmented across several
+    /// characteristic writes when the negotiated MTU is small, and ending
+    /// the boost after just the first fragment would expose every remaining
+    /// fragment to the same contention this fix exists to survive. The
+    /// bounded timeout is the only revert path, sized with margin over the
+    /// write-retry budget precisely so it does not need write-level
+    /// granularity to know when bootstrap is "done".
     private val priorityLowered = ConcurrentHashMap.newKeySet<String>()
 
     /// Session id per central attached to our GATT server.
@@ -500,16 +511,6 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
                     nativeHandle, requestId, address, characteristic.uuid.toString(),
                     status == BluetoothGatt.GATT_SUCCESS
                 )
-                // First successful write since connect: the latency-sensitive
-                // bootstrap window CONNECTION_PRIORITY_HIGH exists to protect
-                // is over, so drop back to BALANCED rather than holding the
-                // shorter connection interval for this session's full,
-                // long-lived remainder. `priorityLowered.add` is the
-                // once-only gate (it returns false on every later write, once
-                // this address is already in the set).
-                if (status == BluetoothGatt.GATT_SUCCESS && priorityLowered.add(address)) {
-                    gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_BALANCED)
-                }
                 }
             }
 
@@ -568,11 +569,12 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
                     // PRIORITY_BOOTSTRAP_TIMEOUT_MS window starts now,
                     // comfortably covering that write's own up-to-~7s
                     // GATT_BUSY_MAX_RETRIES budget with margin rather than
-                    // racing it. Bounded fallback for connections that never
-                    // reach `onCharacteristicWrite` at all (idle/receive-only);
-                    // `priorityLowered.add` is the same once-only gate that
-                    // callback uses, so whichever happens first -- a write, or
-                    // this timeout -- makes the other a no-op.
+                    // racing it. This is the *only* revert path -- see
+                    // `priorityLowered`'s doc comment for why an earlier
+                    // per-write revert was removed (it ended the boost after
+                    // just the first fragment of a multi-write bootstrap
+                    // message). `priorityLowered.add` still guards against
+                    // scheduling more than one of these per connection.
                     retryHandler.postDelayed({
                         synchronized(gattLock) {
                             if (connectedGatts[address] === gatt && priorityLowered.add(address)) {

--- a/src-tauri/gen/android/app/src/main/kotlin/dev/blegatt/BleGattBridge.kt
+++ b/src-tauri/gen/android/app/src/main/kotlin/dev/blegatt/BleGattBridge.kt
@@ -101,30 +101,35 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
     /// is verified on *this* side instead, under the same lock that resolves
     /// the GATT, which makes validation and initiation one transition.
     private val gattSessions = ConcurrentHashMap<String, Long>()
-    /// Addresses whose connection priority has already been dropped back to
-    /// BALANCED by the bounded bootstrap-timeout fallback scheduled in
-    /// `onDescriptorWrite`. See the doc comment on
-    /// `requestConnectionPriority(CONNECTION_PRIORITY_HIGH)` in `connect()`
-    /// -- HIGH is requested only to get the connect/auth bootstrap through a
-    /// busy radio reliably, not held for a session's full lifetime. fini's
-    /// sessions are long-lived, so leaving HIGH in effect permanently would
-    /// mean a materially shorter connection interval -- more radio wakeups,
-    /// more battery drain -- for the entire session, not just the moment
-    /// that needed it. Cleared alongside the other per-address state on
-    /// disconnect (both sites below), so a reconnect to the same address
-    /// re-triggers the bootstrap treatment instead of silently skipping it.
-    ///
-    /// Deliberately *not* also dropped on the first successful
-    /// `onCharacteristicWrite` (an earlier version of this fix did that): a
-    /// P1 review finding pointed out that the app-level bootstrap message
-    /// (the `Auth` frame) can itself be fragmented across several
-    /// characteristic writes when the negotiated MTU is small, and ending
-    /// the boost after just the first fragment would expose every remaining
-    /// fragment to the same contention this fix exists to survive. The
-    /// bounded timeout is the only revert path, sized with margin over the
-    /// write-retry budget precisely so it does not need write-level
-    /// granularity to know when bootstrap is "done".
+    /// Addresses whose connection priority has been *finally* dropped back
+    /// to BALANCED by the bootstrap-priority fallback (see
+    /// `rearmPriorityFallback`) actually firing. Once an address is in this
+    /// set, bootstrap is considered over for good: later writes do not
+    /// re-arm the fallback or request HIGH again, since by then they are
+    /// ordinary long-lived-session traffic, not bootstrap. See the doc
+    /// comment on `requestConnectionPriority(CONNECTION_PRIORITY_HIGH)` in
+    /// `connect()` -- HIGH is requested only to get the connect/auth
+    /// bootstrap through a busy radio reliably, not held for a session's
+    /// full lifetime. fini's sessions are long-lived, so leaving HIGH in
+    /// effect permanently would mean a materially shorter connection
+    /// interval -- more radio wakeups, more battery drain -- for the entire
+    /// session, not just the moment that needed it. Cleared alongside the
+    /// other per-address state on disconnect (both sites below), so a
+    /// reconnect to the same address re-triggers the bootstrap treatment
+    /// instead of silently skipping it.
     private val priorityLowered = ConcurrentHashMap.newKeySet<String>()
+    /// The currently scheduled (not yet fired) bootstrap-priority fallback
+    /// per address, if any. See `rearmPriorityFallback`'s doc comment: a
+    /// P1 review finding on an earlier version of this fix pointed out that
+    /// a *fixed* one-shot deadline from subscribe time is not actually
+    /// bounded above a fragmented bootstrap message, since each fragment
+    /// gets its own up-to-~7s retry budget and fragments are sent
+    /// sequentially -- so the fixed deadline could fire mid-retry on a later
+    /// fragment. This tracks the one outstanding fallback so a new write can
+    /// cancel and replace it with a fresh one, turning it into an idle
+    /// timeout (fires `PRIORITY_BOOTSTRAP_TIMEOUT_MS` after the *last*
+    /// bootstrap write started, not a fixed point after subscribe).
+    private val priorityFallbacks = ConcurrentHashMap<String, Runnable>()
 
     /// Session id per central attached to our GATT server.
     ///
@@ -401,6 +406,7 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
                                 gattSessions.remove(address)
                                 pendingCharacteristics.remove(address)
                                 priorityLowered.remove(address)
+                                priorityFallbacks.remove(address)?.let { retryHandler.removeCallbacks(it) }
                                 clearPendingOperations(address)
                                 // Fires for unsolicited drops too (out of
                                 // range, peer powered off), which is the
@@ -454,6 +460,7 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
                             gattSessions.remove(address)
                             pendingCharacteristics.remove(address)
                             priorityLowered.remove(address)
+                            priorityFallbacks.remove(address)?.let { retryHandler.removeCallbacks(it) }
                             clearPendingOperations(address)
                             onDisconnected(nativeHandle, address, false)
                             false
@@ -565,23 +572,12 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
                     // callback's doc comment for the P1 this fixes. Subscribe
                     // just succeeded, which is exactly the moment before Rust
                     // attempts the first characteristic write this priority
-                    // bump exists to protect, so the full
-                    // PRIORITY_BOOTSTRAP_TIMEOUT_MS window starts now,
-                    // comfortably covering that write's own up-to-~7s
-                    // GATT_BUSY_MAX_RETRIES budget with margin rather than
-                    // racing it. This is the *only* revert path -- see
-                    // `priorityLowered`'s doc comment for why an earlier
-                    // per-write revert was removed (it ended the boost after
-                    // just the first fragment of a multi-write bootstrap
-                    // message). `priorityLowered.add` still guards against
-                    // scheduling more than one of these per connection.
-                    retryHandler.postDelayed({
-                        synchronized(gattLock) {
-                            if (connectedGatts[address] === gatt && priorityLowered.add(address)) {
-                                gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_BALANCED)
-                            }
-                        }
-                    }, PRIORITY_BOOTSTRAP_TIMEOUT_MS)
+                    // bump exists to protect, so the fallback's window starts
+                    // now. Re-armed again on every subsequent write in
+                    // `attemptWrite` -- see `rearmPriorityFallback`'s doc
+                    // comment for why a single fixed deadline from here isn't
+                    // enough on its own for a fragmented bootstrap message.
+                    rearmPriorityFallback(address, gatt)
                 }
                 }
             }
@@ -756,6 +752,13 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
             synchronized(queue) { queue.remove(requestId) }
             onCharacteristicWriteResult(nativeHandle, requestId, address, characteristicUuid, false)
             return
+        }
+        // Only for a genuinely new write (`attempt == 0`), not a GATT-busy
+        // retry of the same one -- see `rearmPriorityFallback`'s doc comment
+        // for why a fragmented bootstrap message needs the fallback pushed
+        // out on every new fragment, not just once at subscribe time.
+        if (attempt == 0) {
+            rearmPriorityFallback(address, gatt)
         }
         characteristic.writeType = if (withoutResponse) {
             BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
@@ -1345,6 +1348,41 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
         pendingReadIds.remove(address)
         pendingWriteIds.remove(address)
         pendingSubscribeIds.keys.removeAll { it.startsWith("$address/") }
+    }
+
+    /// (Re)arms the bounded bootstrap-priority fallback for `address`,
+    /// cancelling whichever one was previously scheduled first. Called once
+    /// on subscribe success and again on every new write thereafter
+    /// (`attempt == 0` in `attemptWrite`), which turns a single fixed
+    /// deadline into an idle timeout: it only actually fires
+    /// `PRIORITY_BOOTSTRAP_TIMEOUT_MS` after the *last* write was issued, not
+    /// a fixed point after subscribe. A P1 review finding on the earlier
+    /// fixed-deadline version: the app-level bootstrap message can be
+    /// fragmented across several characteristic writes under a small
+    /// negotiated MTU, each with its own up-to-~7s `GATT_BUSY_MAX_RETRIES`
+    /// budget, sent sequentially -- a fixed deadline measured from subscribe
+    /// time is not actually bounded above that whole sequence and could fire
+    /// mid-retry on a later fragment. Re-arming on every new write instead
+    /// keeps pushing the deadline out for as long as bootstrap keeps
+    /// actively sending, and only lets it fire once that stops.
+    ///
+    /// No-op once `priorityLowered` already holds `address`: that means an
+    /// earlier fallback already fired and bootstrap is considered over for
+    /// good, so a write after that point is ordinary session traffic and
+    /// must not re-request HIGH.
+    private fun rearmPriorityFallback(address: String, gatt: BluetoothGatt) {
+        if (priorityLowered.contains(address)) return
+        priorityFallbacks.remove(address)?.let { retryHandler.removeCallbacks(it) }
+        val fallback = Runnable {
+            synchronized(gattLock) {
+                priorityFallbacks.remove(address)
+                if (connectedGatts[address] === gatt && priorityLowered.add(address)) {
+                    gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_BALANCED)
+                }
+            }
+        }
+        priorityFallbacks[address] = fallback
+        retryHandler.postDelayed(fallback, PRIORITY_BOOTSTRAP_TIMEOUT_MS)
     }
 
     fun closeAll() {

--- a/src-tauri/gen/android/app/src/main/kotlin/dev/blegatt/BleGattBridge.kt
+++ b/src-tauri/gen/android/app/src/main/kotlin/dev/blegatt/BleGattBridge.kt
@@ -101,6 +101,19 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
     /// is verified on *this* side instead, under the same lock that resolves
     /// the GATT, which makes validation and initiation one transition.
     private val gattSessions = ConcurrentHashMap<String, Long>()
+    /// Addresses whose connection priority has already been dropped back to
+    /// BALANCED after their first successful post-connect write. See the doc
+    /// comment on `requestConnectionPriority(CONNECTION_PRIORITY_HIGH)` in
+    /// `connect()` -- HIGH is requested only to get the connect/auth
+    /// bootstrap (subscribe, then the first characteristic write) through a
+    /// busy radio reliably, not held for a session's full lifetime. fini's
+    /// sessions are long-lived, so leaving HIGH in effect permanently would
+    /// mean a materially shorter connection interval -- more radio wakeups,
+    /// more battery drain -- for the entire session, not just the moment
+    /// that needed it. Cleared alongside the other per-address state on
+    /// disconnect (both sites below), so a reconnect to the same address
+    /// re-triggers the bootstrap treatment instead of silently skipping it.
+    private val priorityLowered = ConcurrentHashMap.newKeySet<String>()
 
     /// Session id per central attached to our GATT server.
     ///
@@ -323,6 +336,10 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
                         // the shortest connection interval it can offer, so our own
                         // operations get serviced on the next event instead of
                         // losing the race to unrelated background BLE traffic.
+                        // Temporary, not permanent: `onCharacteristicWrite` drops
+                        // this back to BALANCED after the first successful write,
+                        // once the bootstrap this exists to protect is done -- see
+                        // `priorityLowered`'s doc comment.
                         gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_HIGH)
                         // Ask for the largest MTU the spec allows before
                         // discovering services. The peer decides the real
@@ -359,6 +376,7 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
                                 connectedGatts.remove(address)
                                 gattSessions.remove(address)
                                 pendingCharacteristics.remove(address)
+                                priorityLowered.remove(address)
                                 clearPendingOperations(address)
                                 // Fires for unsolicited drops too (out of
                                 // range, peer powered off), which is the
@@ -411,6 +429,7 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
                             connectedGatts.remove(address)
                             gattSessions.remove(address)
                             pendingCharacteristics.remove(address)
+                            priorityLowered.remove(address)
                             clearPendingOperations(address)
                             onDisconnected(nativeHandle, address, false)
                             false
@@ -468,6 +487,16 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
                     nativeHandle, requestId, address, characteristic.uuid.toString(),
                     status == BluetoothGatt.GATT_SUCCESS
                 )
+                // First successful write since connect: the latency-sensitive
+                // bootstrap window CONNECTION_PRIORITY_HIGH exists to protect
+                // is over, so drop back to BALANCED rather than holding the
+                // shorter connection interval for this session's full,
+                // long-lived remainder. `priorityLowered.add` is the
+                // once-only gate (it returns false on every later write, once
+                // this address is already in the set).
+                if (status == BluetoothGatt.GATT_SUCCESS && priorityLowered.add(address)) {
+                    gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_BALANCED)
+                }
                 }
             }
 

--- a/src-tauri/gen/android/app/src/main/kotlin/dev/blegatt/BleGattBridge.kt
+++ b/src-tauri/gen/android/app/src/main/kotlin/dev/blegatt/BleGattBridge.kt
@@ -1373,8 +1373,25 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
     private fun rearmPriorityFallback(address: String, gatt: BluetoothGatt) {
         if (priorityLowered.contains(address)) return
         priorityFallbacks.remove(address)?.let { retryHandler.removeCallbacks(it) }
-        val fallback = Runnable {
+        // A P1 review finding on the first version of this re-arming scheme:
+        // `Handler.removeCallbacks` above only stops a callback still
+        // *waiting* to run -- if the previous fallback had already been
+        // dispatched and was merely blocked on `gattLock` (e.g. by this very
+        // call, made from inside a `synchronized(gattLock)` block elsewhere),
+        // removing it here does nothing, and it can still acquire the lock
+        // *after* this new one is installed below, unconditionally remove
+        // the replacement it knows nothing about, and revert priority mid-
+        // retry on the new fragment. `lateinit` lets the runnable capture its
+        // own identity so it can check, first thing under the lock, whether
+        // it is still the map's current entry for this address -- the same
+        // compare-and-act discipline `cancelPendingOperation`'s doc comment
+        // (finding 3) already established for the identical race on
+        // `pendingRetries`. Only the runnable that wins that comparison acts;
+        // a superseded one is a no-op.
+        lateinit var fallback: Runnable
+        fallback = Runnable {
             synchronized(gattLock) {
+                if (priorityFallbacks[address] !== fallback) return@Runnable
                 priorityFallbacks.remove(address)
                 if (connectedGatts[address] === gatt && priorityLowered.add(address)) {
                     gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_BALANCED)

--- a/src-tauri/gen/android/app/src/main/kotlin/dev/blegatt/BleGattBridge.kt
+++ b/src-tauri/gen/android/app/src/main/kotlin/dev/blegatt/BleGattBridge.kt
@@ -341,6 +341,26 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
                         // once the bootstrap this exists to protect is done -- see
                         // `priorityLowered`'s doc comment.
                         gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_HIGH)
+                        // Bounded fallback for the P1 above `onCharacteristicWrite`
+                        // is meant to close: a receive-only or otherwise
+                        // write-less connection never reaches that callback, so
+                        // without this HIGH would hold for the connection's
+                        // entire lifetime. Guarantees BALANCED resumes within
+                        // PRIORITY_BOOTSTRAP_TIMEOUT_MS regardless of whether a
+                        // write ever happens. `priorityLowered.add` is the same
+                        // once-only gate `onCharacteristicWrite` uses, so
+                        // whichever path -- a write, or this timeout -- gets
+                        // there first makes the other a no-op; the `gattLock`
+                        // ownership check matters because 10s is easily long
+                        // enough for this connection to have been superseded or
+                        // torn down by the time this fires.
+                        retryHandler.postDelayed({
+                            synchronized(gattLock) {
+                                if (connectedGatts[address] === gatt && priorityLowered.add(address)) {
+                                    gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_BALANCED)
+                                }
+                            }
+                        }, PRIORITY_BOOTSTRAP_TIMEOUT_MS)
                         // Ask for the largest MTU the spec allows before
                         // discovering services. The peer decides the real
                         // value and reports it via onMtuChanged; until then
@@ -1570,6 +1590,21 @@ class BleGattBridge(private val context: Context, private val nativeHandle: Long
         private const val GATT_BUSY_MAX_RETRIES = 6
         private const val GATT_BUSY_RETRY_BASE_DELAY_MS = 200L
         private const val GATT_BUSY_RETRY_MAX_DELAY_MS = 2000L
+
+        /// A P1 review finding on the original CONNECTION_PRIORITY_HIGH fix:
+        /// dropping back to BALANCED only from `onCharacteristicWrite` never
+        /// fires for a connection that stays idle or only receives
+        /// notifications -- `datagram::connect` subscribes but does not
+        /// guarantee a bootstrap write, so a receive-only or delayed-first-
+        /// send session would hold HIGH's shorter connection interval (more
+        /// radio wakeups, more battery drain) for its entire lifetime with no
+        /// write ever arriving to end it. This bounds that exposure
+        /// regardless of whether a write happens at all. 10s, not the 7s
+        /// `GATT_BUSY_MAX_RETRIES` write-retry budget itself: connect + MTU +
+        /// service discovery + subscribe all happen *before* that budget's
+        /// clock even starts, so the timeout needs headroom above it, not to
+        /// equal it.
+        private const val PRIORITY_BOOTSTRAP_TIMEOUT_MS = 10_000L
 
         /// `attempt` is the *upcoming* attempt number (1-indexed: the first
         /// retry is 1, matching `attempt + 1` at each call site) -- delay


### PR DESCRIPTION
## Summary

Bumps the `ble-gatt` pin to `d8de96a` ([VRuzhentsov/ble-gatt#5](https://github.com/VRuzhentsov/ble-gatt/pull/5), merged), which requests `CONNECTION_PRIORITY_HIGH` on Android central connect.

## Root cause this fixes

Live production capture (Pixel 6 Pro, 2026-08-23) diagnosing a "Still connecting…" BLE report: connect → MTU → discover → subscribe all completed cleanly in ~33ms, then the very first characteristic write (the app-level `Auth` frame) was rejected locally by the Android BLE stack for the *entire* existing 7s retry budget (from #155), on every single connection attempt — the UI state never resolving.

`dumpsys bluetooth_manager` on the phone during the failure window showed a concurrent system GATT server (`com.google.uid.shared`, tag=`nearby_presence` — Android's own Nearby/Fast Pair background service) registered on the same adapter. `BleGattBridge.kt` never requested a connection priority, so new connections defaulted to `CONNECTION_PRIORITY_BALANCED` — a longer connection interval that gives Android's scheduler room to service that background traffic ahead of this link's own operations.

Full root-cause writeup and evidence: ble-gatt#5.

## Changes

- `Cargo.toml` / `Cargo.lock`: `ble-gatt` rev bumped to `d8de96abc582b47f388d1e4713578217636a7355`.
- `gen/android/app/src/main/kotlin/dev/blegatt/BleGattBridge.kt`: re-synced vendored copy, matching the same rev (same pattern as #155's own sync).

## Test plan

- [x] `cargo update -p ble-gatt --precise d8de96a...` resolved cleanly.
- [x] `cargo check` passes clean (same pre-existing warning count as before).
- [ ] Rebuild the Android app and re-verify against the same Pixel 6 Pro that reproduced the original failure.
